### PR TITLE
Changed precedence and channel status verification to correctly report ca

### DIFF
--- a/src/main/java/org/asteriskjava/live/internal/AsteriskServerImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskServerImpl.java
@@ -1128,12 +1128,6 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
                 return;
             }
 
-            if (channel.wasInState(ChannelState.UP))
-            {
-                cb.onSuccess(channel);
-                return;
-            }
-
             if (channel.wasBusy())
             {
                 cb.onBusy(channel);
@@ -1169,9 +1163,15 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
                     return;
                 }
             }
+            
+            if (channel.wasInState(ChannelState.DOWN))
+            {
+                cb.onNoAnswer(channel);
+                return;
+            }
 
-            // if nothing else matched we asume no answer
-            cb.onNoAnswer(channel);
+            // if nothing else matched we asume success
+            cb.onSuccess(channel);
         }
         catch (Throwable t)
         {


### PR DESCRIPTION
Changed precedence and channel status verification to correctly report callback listeners.

Problem description on https://secure.reucon.net/issues/browse/AJ-290
