### PR TITLE
I fixed a build problem that could be traced to the class AsteriskChanne...

### DIFF
--- a/src/main/java/org/asteriskjava/live/AsteriskChannel.java
+++ b/src/main/java/org/asteriskjava/live/AsteriskChannel.java
@@ -612,7 +612,7 @@ public interface AsteriskChannel extends LiveObject
      * @see #unPauseMixMonitor()()
      * @since 1.0.0
      */
-    void pauseMixMonitor(MixMonitorDirection direction) throws ManagerCommunicationException, NoSuchChannelException;
+    void muteMixMonitor(MixMonitorDirection direction) throws ManagerCommunicationException, NoSuchChannelException;
     
     
     /**
@@ -630,6 +630,6 @@ public interface AsteriskChannel extends LiveObject
      * @see #pauseMixMonitor()
      * @since 1.0.0
      */
-    void unPauseMixMonitor(MixMonitorDirection direction) throws ManagerCommunicationException, NoSuchChannelException;
+    void unMuteMixMonitor(MixMonitorDirection direction) throws ManagerCommunicationException, NoSuchChannelException;
     
 }

--- a/src/main/java/org/asteriskjava/live/internal/AsteriskChannelImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskChannelImpl.java
@@ -35,8 +35,8 @@ import org.asteriskjava.manager.action.AbsoluteTimeoutAction;
 import org.asteriskjava.manager.action.ChangeMonitorAction;
 import org.asteriskjava.manager.action.GetVarAction;
 import org.asteriskjava.manager.action.HangupAction;
+import org.asteriskjava.manager.action.MixMonitorMuteAction;
 import org.asteriskjava.manager.action.MonitorAction;
-import org.asteriskjava.manager.action.PauseMixMonitorAction;
 import org.asteriskjava.manager.action.PauseMonitorAction;
 import org.asteriskjava.manager.action.PlayDtmfAction;
 import org.asteriskjava.manager.action.RedirectAction;
@@ -802,20 +802,20 @@ class AsteriskChannelImpl extends AbstractLiveObject implements AsteriskChannel
     }
 
     
-    public void pauseMixMonitor(MixMonitorDirection direction) throws ManagerCommunicationException, NoSuchChannelException
+    public void muteMixMonitor(MixMonitorDirection direction) throws ManagerCommunicationException, NoSuchChannelException
     {
         ManagerResponse response;
-        response = server.sendAction(new PauseMixMonitorAction(this.name,1,direction.getStateName()));
+        response = server.sendAction(new MixMonitorMuteAction(this.name,direction.getStateName(),1));
         if (response instanceof ManagerError) {
             throw new NoSuchChannelException("Channel '" + name + "' is not available: " + response.getMessage());
         }
     }
 
     
-    public void unPauseMixMonitor(MixMonitorDirection direction) throws ManagerCommunicationException, NoSuchChannelException
+    public void unMuteMixMonitor(MixMonitorDirection direction) throws ManagerCommunicationException, NoSuchChannelException
     {
         ManagerResponse response;
-        response = server.sendAction(new PauseMixMonitorAction(this.name,0,direction.getStateName()));        
+        response = server.sendAction(new MixMonitorMuteAction(this.name,direction.getStateName(),0));        
         if (response instanceof ManagerError) {
             throw new NoSuchChannelException("Channel '" + name + "' is not available: " + response.getMessage());
         }

--- a/src/main/java/org/asteriskjava/manager/AsteriskMapping.java
+++ b/src/main/java/org/asteriskjava/manager/AsteriskMapping.java
@@ -8,7 +8,7 @@ import java.lang.annotation.Target;
 
 /**
  * Customized the mapping to Asterisk. In general the mapping is done implicitly based
- * on reflection but there are certain action that are using headers with specical
+ * on reflection but there are certain action that are using headers with special
  * characters that can not be represented in Java. In those cases you can annotate
  * the property (getter, setter or field) and provide the header name that Asterisk expects.
  *


### PR DESCRIPTION
...lImpl. The problem was that the method pauseMixMonitor() required an inexistent class PauseMixMonitorAction (maybe someone forgot to check it in?).

I replaced this method with muteMixMonitor() and unMuteMixMonitor() that uses MixMonitorMuteAction class (assuming this was the original developer's intention)