### PR TITLE
Fixed test.

### DIFF
--- a/src/test/java/org/asteriskjava/manager/event/CdrEventTest.java
+++ b/src/test/java/org/asteriskjava/manager/event/CdrEventTest.java
@@ -3,6 +3,7 @@ package org.asteriskjava.manager.event;
 import static org.junit.Assert.assertEquals;
 
 import java.util.TimeZone;
+import org.junit.After;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -21,7 +22,7 @@ public class CdrEventTest
         TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
     }
 
-    @Before
+    @After
     public void tearDown()
     {
         TimeZone.setDefault(defaultTimeZone);


### PR DESCRIPTION
The tearDown method was called before tests were executed instead of after.
