### PR TITLE
Remove System.out.print from AgentManager

### DIFF
--- a/src/main/java/org/asteriskjava/live/internal/AgentManager.java
+++ b/src/main/java/org/asteriskjava/live/internal/AgentManager.java
@@ -90,7 +90,7 @@ public class AgentManager
         {
             if (event instanceof AgentsEvent)
             {
-                System.out.println(event);
+                logger.info( event );
                 handleAgentsEvent((AgentsEvent) event);
             }
         }


### PR DESCRIPTION
It should use a logger.info, and not a System.out.print, with that the user will be able to disable the output of this information
