### PR TITLE
Fixed broken RtcpReceivedEvent unit test.

### DIFF
--- a/src/test/java/org/asteriskjava/manager/event/RtcpReceivedEventTest.java
+++ b/src/test/java/org/asteriskjava/manager/event/RtcpReceivedEventTest.java
@@ -49,6 +49,6 @@ public class RtcpReceivedEventTest
     public void testRtt()
     {
         rtcpReceivedEvent.setRtt("12345(sec)");
-        assertEquals(new Long(12345), rtcpReceivedEvent.getRtt());
+        assertEquals(new Double(12345), rtcpReceivedEvent.getRtt());
     }
 }


### PR DESCRIPTION
The changes in d734ea6, to resolve #45, broke the RtcpReceivedEventTest.testRtt unit test, since it expects the Rtt field to be a Long. This PR updates the test to expect the Rtt field as a Double. 