### PR TITLE
Asterisk 13 relevant changes and things already merged to 1.1 branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ target
 .idea
 .gradle
 classes
+/bin

--- a/src/main/java/org/asteriskjava/live/AsteriskServer.java
+++ b/src/main/java/org/asteriskjava/live/AsteriskServer.java
@@ -479,6 +479,14 @@ public interface AsteriskServer
      */
     void removeAsteriskServerListener(AsteriskServerListener listener);
 
+	/**
+	* Checks whether the listener is already registered with this Asterisk server
+	*
+	* @param listener the listener to check
+	* @return true, if the listener is already registered.
+	*/
+	boolean isAsteriskServerListening(AsteriskServerListener listener);
+    
     /**
 	 * The chainListener allows a listener to receive manager events after they
 	 * have been processed by the AsteriskServer. If the AsteriskServer is

--- a/src/main/java/org/asteriskjava/live/AsteriskServer.java
+++ b/src/main/java/org/asteriskjava/live/AsteriskServer.java
@@ -29,11 +29,12 @@ import org.asteriskjava.config.ConfigFile;
 /**
  * The AsteriskServer is built on top of the
  * {@link org.asteriskjava.manager.ManagerConnection} and is an attempt to
- * simplify interaction with Asterisk by abstracting the interface. <br> You
- * will certainly have less freedom using AsteriskServer but it will make life
- * easier for easy things (like originating a call or getting a list of open
- * channels). <br> AsteriskServer is still in an early state of development. So,
- * when using AsteriskServer be aware that it might change in the future.
+ * simplify interaction with Asterisk by abstracting the interface. <br>
+ * You will certainly have less freedom using AsteriskServer but it will make
+ * life easier for easy things (like originating a call or getting a list of
+ * open channels). <br>
+ * AsteriskServer is still in an early state of development. So, when using
+ * AsteriskServer be aware that it might change in the future.
  * 
  * @author srt
  * @version $Id$
@@ -41,12 +42,14 @@ import org.asteriskjava.config.ConfigFile;
 public interface AsteriskServer
 {
     /**
-     * Returns the underlying ManagerConnection.<p>
-     * Unlike the methods operating on the manager connection this method does not implicitly initialize the
-     * connection. Thus you can use this method to add custom
-     * {@linkplain org.asteriskjava.manager.ManagerEventListener ManagerEventListeners} before the connection
-     * to the Asterisk server is established. If you want to ensure that the connection is established call
-     * {@link #initialize()}.
+     * Returns the underlying ManagerConnection.
+     * <p>
+     * Unlike the methods operating on the manager connection this method does
+     * not implicitly initialize the connection. Thus you can use this method to
+     * add custom {@linkplain org.asteriskjava.manager.ManagerEventListener
+     * ManagerEventListeners} before the connection to the Asterisk server is
+     * established. If you want to ensure that the connection is established
+     * call {@link #initialize()}.
      * 
      * @return the underlying ManagerConnection.
      */
@@ -54,26 +57,32 @@ public interface AsteriskServer
 
     /**
      * Generates an outgoing channel.
-     * @param originateAction the action that contains parameters for the originate
+     * 
+     * @param originateAction the action that contains parameters for the
+     *            originate
      * @return the generated channel
      * @throws NoSuchChannelException if the channel is not available on the
-     *         Asterisk server, for example because you used "SIP/1310" and 1310
-     *         is not a valid SIP user, the SIP channel module hasn't been
-     *         loaded or the SIP or IAX peer is not registered currently.
+     *             Asterisk server, for example because you used "SIP/1310" and
+     *             1310 is not a valid SIP user, the SIP channel module hasn't
+     *             been loaded or the SIP or IAX peer is not registered
+     *             currently.
      * @throws ManagerCommunicationException if the originate action cannot be
-     *         sent to Asterisk
+     *             sent to Asterisk
      */
-    public AsteriskChannel originate(OriginateAction originateAction) throws ManagerCommunicationException, NoSuchChannelException;
-    
+    public AsteriskChannel originate(OriginateAction originateAction) throws ManagerCommunicationException,
+            NoSuchChannelException;
+
     /**
      * Asynchronously generates an outgoing channel.
-     * @param originateAction the action that contains parameters for the originate
+     * 
+     * @param originateAction the action that contains parameters for the
+     *            originate
      * @param cb callback to inform about the result
      * @throws ManagerCommunicationException if the originate action cannot be
-     *         sent to Asterisk
+     *             sent to Asterisk
      */
     public void originateAsync(OriginateAction originateAction, OriginateCallback cb) throws ManagerCommunicationException;
-    
+
     /**
      * Generates an outgoing channel to a dialplan entry (extension, context,
      * priority).
@@ -83,18 +92,18 @@ public interface AsteriskServer
      * @param exten extension to connect to
      * @param priority priority to connect to
      * @param timeout how long to wait for the channel to be answered before its
-     *        considered to have failed (in ms)
+     *            considered to have failed (in ms)
      * @return the generated channel
      * @throws NoSuchChannelException if the channel is not available on the
-     *         Asterisk server, for example because you used "SIP/1310" and 1310
-     *         is not a valid SIP user, the SIP channel module hasn't been
-     *         loaded or the SIP or IAX peer is not registered currently.
+     *             Asterisk server, for example because you used "SIP/1310" and
+     *             1310 is not a valid SIP user, the SIP channel module hasn't
+     *             been loaded or the SIP or IAX peer is not registered
+     *             currently.
      * @throws ManagerCommunicationException if the originate action cannot be
-     *         sent to Asterisk
+     *             sent to Asterisk
      */
-    AsteriskChannel originateToExtension(String channel, String context,
-	    String exten, int priority, long timeout)
-	    throws ManagerCommunicationException, NoSuchChannelException;
+    AsteriskChannel originateToExtension(String channel, String context, String exten, int priority, long timeout)
+            throws ManagerCommunicationException, NoSuchChannelException;
 
     /**
      * Generates an outgoing channel to a dialplan entry (extension, context,
@@ -105,22 +114,21 @@ public interface AsteriskServer
      * @param exten extension to connect to
      * @param priority priority to connect to
      * @param timeout how long to wait for the channel to be answered before its
-     *        considered to have failed (in ms)
+     *            considered to have failed (in ms)
      * @param callerId callerId to use for the outgoing channel, may be
-     *        <code>null</code>.
+     *            <code>null</code>.
      * @param variables channel variables to set, may be <code>null</code>.
      * @return the generated channel
      * @throws NoSuchChannelException if the channel is not available on the
-     *         Asterisk server, for example because you used "SIP/1310" and 1310
-     *         is not a valid SIP user, the SIP channel module hasn't been
-     *         loaded or the SIP or IAX peer is not registered currently.
+     *             Asterisk server, for example because you used "SIP/1310" and
+     *             1310 is not a valid SIP user, the SIP channel module hasn't
+     *             been loaded or the SIP or IAX peer is not registered
+     *             currently.
      * @throws ManagerCommunicationException if the originate action cannot be
-     *         sent to Asterisk
+     *             sent to Asterisk
      */
-    AsteriskChannel originateToExtension(String channel, String context,
-	    String exten, int priority, long timeout, CallerId callerId,
-	    Map<String, String> variables)
-	    throws ManagerCommunicationException, NoSuchChannelException;
+    AsteriskChannel originateToExtension(String channel, String context, String exten, int priority, long timeout,
+            CallerId callerId, Map<String, String> variables) throws ManagerCommunicationException, NoSuchChannelException;
 
     /**
      * Generates an outgoing channel to an application.
@@ -128,20 +136,20 @@ public interface AsteriskServer
      * @param channel channel name to call, for example "SIP/1310".
      * @param application application to connect to, for example "MeetMe"
      * @param data data to pass to the application, for example "1000|d", may be
-     *        <code>null</code>.
+     *            <code>null</code>.
      * @param timeout how long to wait for the channel to be answered before its
-     *        considered to have failed (in ms)
+     *            considered to have failed (in ms)
      * @return the generated channel
      * @throws NoSuchChannelException if the channel is not available on the
-     *         Asterisk server, for example because you used "SIP/1310" and 1310
-     *         is not a valid SIP user, the SIP channel module hasn't been
-     *         loaded or the SIP or IAX peer is not registered currently.
+     *             Asterisk server, for example because you used "SIP/1310" and
+     *             1310 is not a valid SIP user, the SIP channel module hasn't
+     *             been loaded or the SIP or IAX peer is not registered
+     *             currently.
      * @throws ManagerCommunicationException if the originate action cannot be
-     *         sent to Asterisk
+     *             sent to Asterisk
      */
-    AsteriskChannel originateToApplication(String channel, String application,
-	    String data, long timeout) throws ManagerCommunicationException,
-	    NoSuchChannelException;
+    AsteriskChannel originateToApplication(String channel, String application, String data, long timeout)
+            throws ManagerCommunicationException, NoSuchChannelException;
 
     /**
      * Generates an outgoing channel to an application and sets an optional map
@@ -150,24 +158,23 @@ public interface AsteriskServer
      * @param channel channel name to call, for example "SIP/1310".
      * @param application application to connect to, for example "MeetMe"
      * @param data data to pass to the application, for example "1000|d", may be
-     *        <code>null</code>.
+     *            <code>null</code>.
      * @param timeout how long to wait for the channel to be answered before its
-     *        considered to have failed (in ms)
+     *            considered to have failed (in ms)
      * @param callerId callerId to use for the outgoing channel, may be
-     *        <code>null</code>.
+     *            <code>null</code>.
      * @param variables channel variables to set, may be <code>null</code>.
      * @return the generated channel
      * @throws NoSuchChannelException if the channel is not available on the
-     *         Asterisk server, for example because you used "SIP/1310" and 1310
-     *         is not a valid SIP user, the SIP channel module hasn't been
-     *         loaded or the SIP or IAX peer is not registered currently.
+     *             Asterisk server, for example because you used "SIP/1310" and
+     *             1310 is not a valid SIP user, the SIP channel module hasn't
+     *             been loaded or the SIP or IAX peer is not registered
+     *             currently.
      * @throws ManagerCommunicationException if the originate action cannot be
-     *         sent to Asterisk
+     *             sent to Asterisk
      */
-    AsteriskChannel originateToApplication(String channel, String application,
-	    String data, long timeout, CallerId callerId,
-	    Map<String, String> variables)
-	    throws ManagerCommunicationException, NoSuchChannelException;
+    AsteriskChannel originateToApplication(String channel, String application, String data, long timeout, CallerId callerId,
+            Map<String, String> variables) throws ManagerCommunicationException, NoSuchChannelException;
 
     /**
      * Asynchronously generates an outgoing channel to a dialplan entry
@@ -178,14 +185,13 @@ public interface AsteriskServer
      * @param exten extension to connect to
      * @param priority priority to connect to
      * @param timeout how long to wait for the channel to be answered before its
-     *        considered to have failed (in ms)
+     *            considered to have failed (in ms)
      * @param callback callback to inform about the result
      * @throws ManagerCommunicationException if the originate action cannot be
-     *         sent to Asterisk
+     *             sent to Asterisk
      */
-    void originateToExtensionAsync(String channel, String context,
-	    String exten, int priority, long timeout, OriginateCallback callback)
-	    throws ManagerCommunicationException;
+    void originateToExtensionAsync(String channel, String context, String exten, int priority, long timeout,
+            OriginateCallback callback) throws ManagerCommunicationException;
 
     /**
      * Asynchronously generates an outgoing channel to a dialplan entry
@@ -197,18 +203,17 @@ public interface AsteriskServer
      * @param exten extension to connect to
      * @param priority priority to connect to
      * @param timeout how long to wait for the channel to be answered before its
-     *        considered to have failed (in ms)
+     *            considered to have failed (in ms)
      * @param callerId callerId to use for the outgoing channel, may be
-     *        <code>null</code>.
+     *            <code>null</code>.
      * @param variables channel variables to set, may be <code>null</code>.
      * @param callback callback to inform about the result
      * @throws ManagerCommunicationException if the originate action cannot be
-     *         sent to Asterisk
+     *             sent to Asterisk
      */
-    void originateToExtensionAsync(String channel, String context,
-	    String exten, int priority, long timeout, CallerId callerId,
-	    Map<String, String> variables, OriginateCallback callback)
-	    throws ManagerCommunicationException;
+    void originateToExtensionAsync(String channel, String context, String exten, int priority, long timeout,
+            CallerId callerId, Map<String, String> variables, OriginateCallback callback)
+            throws ManagerCommunicationException;
 
     /**
      * Asynchronously generates an outgoing channel to an application.
@@ -216,16 +221,15 @@ public interface AsteriskServer
      * @param channel channel name to call, for example "SIP/1310".
      * @param application application to connect to, for example "MeetMe"
      * @param data data to pass to the application, for example "1000|d", may be
-     *        <code>null</code>.
+     *            <code>null</code>.
      * @param timeout how long to wait for the channel to be answered before its
-     *        considered to have failed (in ms)
+     *            considered to have failed (in ms)
      * @param callback callback to inform about the result
      * @throws ManagerCommunicationException if the originate action cannot be
-     *         sent to Asterisk
+     *             sent to Asterisk
      */
-    void originateToApplicationAsync(String channel, String application,
-	    String data, long timeout, OriginateCallback callback)
-	    throws ManagerCommunicationException;
+    void originateToApplicationAsync(String channel, String application, String data, long timeout,
+            OriginateCallback callback) throws ManagerCommunicationException;
 
     /**
      * Asynchronously generates an outgoing channel to an application and sets
@@ -234,42 +238,38 @@ public interface AsteriskServer
      * @param channel channel name to call, for example "SIP/1310".
      * @param application application to connect to, for example "MeetMe"
      * @param data data to pass to the application, for example "1000|d", may be
-     *        <code>null</code>.
+     *            <code>null</code>.
      * @param timeout how long to wait for the channel to be answered before its
-     *        considered to have failed (in ms)
+     *            considered to have failed (in ms)
      * @param callerId callerId to use for the outgoing channel, may be
-     *        <code>null</code>.
+     *            <code>null</code>.
      * @param variables channel variables to set, may be <code>null</code>.
      * @param callback callback to inform about the result
      * @throws ManagerCommunicationException if the originate action cannot be
-     *         sent to Asterisk
+     *             sent to Asterisk
      */
-    void originateToApplicationAsync(String channel, String application,
-	    String data, long timeout, CallerId callerId,
-	    Map<String, String> variables, OriginateCallback callback)
-	    throws ManagerCommunicationException;
+    void originateToApplicationAsync(String channel, String application, String data, long timeout, CallerId callerId,
+            Map<String, String> variables, OriginateCallback callback) throws ManagerCommunicationException;
 
     /**
      * Returns the active channels of the Asterisk server.
      * 
      * @return a Collection of active channels.
      * @throws ManagerCommunicationException if there is a problem communication
-     *         with Asterisk
+     *             with Asterisk
      */
-    Collection<AsteriskChannel> getChannels()
-	    throws ManagerCommunicationException;
+    Collection<AsteriskChannel> getChannels() throws ManagerCommunicationException;
 
     /**
      * Returns a channel by its name.
      * 
      * @param name name of the channel to return
-     * @return the channel with the given name or <code>null</code> if there
-     *         is no such channel.
+     * @return the channel with the given name or <code>null</code> if there is
+     *         no such channel.
      * @throws ManagerCommunicationException if there is a problem communication
-     *         with Asterisk
+     *             with Asterisk
      */
-    AsteriskChannel getChannelByName(String name)
-	    throws ManagerCommunicationException;
+    AsteriskChannel getChannelByName(String name) throws ManagerCommunicationException;
 
     /**
      * Returns a channel by its unique id.
@@ -278,20 +278,18 @@ public interface AsteriskServer
      * @return the channel with the given unique id or <code>null</code> if
      *         there is no such channel.
      * @throws ManagerCommunicationException if there is a problem communication
-     *         with Asterisk
+     *             with Asterisk
      */
-    AsteriskChannel getChannelById(String id)
-	    throws ManagerCommunicationException;
+    AsteriskChannel getChannelById(String id) throws ManagerCommunicationException;
 
     /**
      * Returns the acitve MeetMe rooms on the Asterisk server.
      * 
      * @return a Collection of MeetMeRooms
      * @throws ManagerCommunicationException if there is a problem communication
-     *         with Asterisk
+     *             with Asterisk
      */
-    Collection<MeetMeRoom> getMeetMeRooms()
-	    throws ManagerCommunicationException;
+    Collection<MeetMeRoom> getMeetMeRooms() throws ManagerCommunicationException;
 
     /**
      * Returns the MeetMe room with the given number, if the room does not yet
@@ -300,17 +298,16 @@ public interface AsteriskServer
      * @param roomNumber the number of the room to return
      * @return the MeetMe room with the given number.
      * @throws ManagerCommunicationException if there is a problem communication
-     *         with Asterisk
+     *             with Asterisk
      */
-    MeetMeRoom getMeetMeRoom(String roomNumber)
-	    throws ManagerCommunicationException;
+    MeetMeRoom getMeetMeRoom(String roomNumber) throws ManagerCommunicationException;
 
     /**
      * Returns the queues served by the Asterisk server.
      * 
      * @return a Collection of queues.
      * @throws ManagerCommunicationException if there is a problem communication
-     *         with Asterisk
+     *             with Asterisk
      */
     Collection<AsteriskQueue> getQueues() throws ManagerCommunicationException;
 
@@ -320,29 +317,30 @@ public interface AsteriskServer
      * 
      * @return a Collection of agents
      * @throws ManagerCommunicationException if there is a problem communication
-     *         with Asterisk
+     *             with Asterisk
      */
     Collection<AsteriskAgent> getAgents() throws ManagerCommunicationException;
 
     /**
-     * Returns the exact version string of this Asterisk server. <br> This
-     * typically looks like "Asterisk 1.2.9.1-BRIstuffed-0.3.0-PRE-1q built by
-     * root @ pbx0 on a i686 running Linux on 2006-06-20 20:21:30 UTC".
+     * Returns the exact version string of this Asterisk server. <br>
+     * This typically looks like "Asterisk 1.2.9.1-BRIstuffed-0.3.0-PRE-1q built
+     * by root @ pbx0 on a i686 running Linux on 2006-06-20 20:21:30 UTC".
      * 
      * @return the version of this Asterisk server
      * @throws ManagerCommunicationException if the version cannot be retrieved
-     *         from Asterisk
+     *             from Asterisk
      * @since 0.2
      */
     String getVersion() throws ManagerCommunicationException;
 
     /**
-     * Returns the CVS revision of a given source file of this Asterisk server.
-     * <br> For example getVersion("app_meetme.c") may return {1, 102} for CVS
-     * revision "1.102". <br> Note that this feature is not available with
-     * Asterisk 1.0.x. <br> You can use this feature if you need to write
-     * applications that behave different depending on specific modules being
-     * available in a specific version or not.
+     * Returns the CVS revision of a given source file of this Asterisk server. <br>
+     * For example getVersion("app_meetme.c") may return {1, 102} for CVS
+     * revision "1.102". <br>
+     * Note that this feature is not available with Asterisk 1.0.x. <br>
+     * You can use this feature if you need to write applications that behave
+     * different depending on specific modules being available in a specific
+     * version or not.
      * 
      * @param file the file for which to get the version like "app_meetme.c"
      * @return the CVS revision of the file, or <code>null</code> if that file
@@ -350,7 +348,7 @@ public interface AsteriskServer
      *         due to a module that provides it has not been loaded) or if you
      *         are connected to an Astersion 1.0.x
      * @throws ManagerCommunicationException if the version cannot be retrieved
-     *         from Asterisk
+     *             from Asterisk
      * @since 0.2
      */
     int[] getVersion(String file) throws ManagerCommunicationException;
@@ -362,11 +360,10 @@ public interface AsteriskServer
      * @return the value of the global variable or <code>null</code> if it is
      *         not set.
      * @throws ManagerCommunicationException if the get variable action cannot
-     *         be sent to Asterisk.
+     *             be sent to Asterisk.
      * @since 0.3
      */
-    String getGlobalVariable(String variable)
-	    throws ManagerCommunicationException;
+    String getGlobalVariable(String variable) throws ManagerCommunicationException;
 
     /**
      * Sets the value of the given global variable.
@@ -374,11 +371,10 @@ public interface AsteriskServer
      * @param variable the name of the global variable to set.
      * @param value the value of the global variable to set.
      * @throws ManagerCommunicationException if the set variable action cannot
-     *         be sent to Asterisk.
+     *             be sent to Asterisk.
      * @since 0.3
      */
-    void setGlobalVariable(String variable, String value)
-	    throws ManagerCommunicationException;
+    void setGlobalVariable(String variable, String value) throws ManagerCommunicationException;
 
     /**
      * Returns a collection of all voicemailboxes configured for this Asterisk
@@ -387,7 +383,7 @@ public interface AsteriskServer
      * @return a collection of all voicemailboxes configured for this Asterisk
      *         server
      * @throws ManagerCommunicationException if the voicemailboxes can't be
-     *         retrieved.
+     *             retrieved.
      * @since 0.3
      */
     Collection<Voicemailbox> getVoicemailboxes() throws ManagerCommunicationException;
@@ -405,47 +401,57 @@ public interface AsteriskServer
     List<String> executeCliCommand(String command) throws ManagerCommunicationException;
 
     /**
-     * Checks whether a module is currently loaded.<p>
+     * Checks whether a module is currently loaded.
+     * <p>
      * Available since Asterisk 1.6
      *
-     * @param module name of the module to load (with out without the ".so" extension).
-     * @return <code>true</code> if the module is currently loaded, <code>false</code> otherwise.
+     * @param module name of the module to load (with out without the ".so"
+     *            extension).
+     * @return <code>true</code> if the module is currently loaded,
+     *         <code>false</code> otherwise.
      * @throws ManagerCommunicationException if the module can't be checked.
      */
     boolean isModuleLoaded(String module) throws ManagerCommunicationException;
 
     /**
-     * Loads a module or subsystem<p>
+     * Loads a module or subsystem
+     * <p>
      * Available since Asterisk 1.6
      *
-     * @param module name of the module to load (including ".so" extension) or subsystem name.
+     * @param module name of the module to load (including ".so" extension) or
+     *            subsystem name.
      * @throws ManagerCommunicationException if the module cannot be loaded.
      * @since 1.0.0
      */
     void loadModule(String module) throws ManagerCommunicationException;
 
     /**
-     * Unloads a module or subsystem.<p>
+     * Unloads a module or subsystem.
+     * <p>
      * Available since Asterisk 1.6
      *
-     * @param module name of the module to unload (including ".so" extension) or subsystem name.
+     * @param module name of the module to unload (including ".so" extension) or
+     *            subsystem name.
      * @throws ManagerCommunicationException if the module cannot be unloaded.
      * @since 1.0.0
      */
     void unloadModule(String module) throws ManagerCommunicationException;
 
     /**
-     * Reloads a module or subsystem.<p>
+     * Reloads a module or subsystem.
+     * <p>
      * Available since Asterisk 1.6
      *
-     * @param module name of the module to reload (including ".so" extension) or subsystem name.
+     * @param module name of the module to reload (including ".so" extension) or
+     *            subsystem name.
      * @throws ManagerCommunicationException if the module cannot be reloaded.
      * @since 1.0.0
      */
     void reloadModule(String module) throws ManagerCommunicationException;
 
     /**
-     * Reloads all currently loaded modules.<p>
+     * Reloads all currently loaded modules.
+     * <p>
      * Available since Asterisk 1.6
      *
      * @throws ManagerCommunicationException if the modules cannot be reloaded.
@@ -468,7 +474,7 @@ public interface AsteriskServer
      * 
      * @param listener the listener to add.
      * @throws ManagerCommunicationException if the server is not yet connected
-     *         and the connection or initialization fails.
+     *             and the connection or initialization fails.
      */
     void addAsteriskServerListener(AsteriskServerListener listener) throws ManagerCommunicationException;
 
@@ -479,79 +485,83 @@ public interface AsteriskServer
      */
     void removeAsteriskServerListener(AsteriskServerListener listener);
 
-	/**
-	* Checks whether the listener is already registered with this Asterisk server
-	*
-	* @param listener the listener to check
-	* @return true, if the listener is already registered.
-	*/
-	boolean isAsteriskServerListening(AsteriskServerListener listener);
-    
     /**
-	 * The chainListener allows a listener to receive manager events after they
-	 * have been processed by the AsteriskServer. If the AsteriskServer is
-	 * handling messages using the asyncEventHandling then these messages will
-	 * also be async. You would use the chainListener if you are processing raw
-	 * events and using the AJ live ChannelManager. If you don't use the chain
-	 * listener then you can't be certain that a channel name passed in a raw
-	 * event will match the channel name held by the live Channel Manager. By
-	 * chaining events you can be certain that events such as channel Rename
-	 * events have been processed by the live ChannelManager before you receive
-	 * an event and as such the names will always match.
-	 * 
-	 * Whilst name matching is not always critical (as you should be matching by the
-	 * channels unique id) the channel name does also contain state information (Zombie, Masq)
-	 * in these cases it can be critical that you have the same name otherwise your 
-	 * state information will be out of date.
-	 * 
-	 */
+     * Checks whether the listener is already registered with this Asterisk
+     * server
+     *
+     * @param listener the listener to check
+     * @return true, if the listener is already registered.
+     */
+    boolean isAsteriskServerListening(AsteriskServerListener listener);
+
+    /**
+     * The chainListener allows a listener to receive manager events after they
+     * have been processed by the AsteriskServer. If the AsteriskServer is
+     * handling messages using the asyncEventHandling then these messages will
+     * also be async. You would use the chainListener if you are processing raw
+     * events and using the AJ live ChannelManager. If you don't use the chain
+     * listener then you can't be certain that a channel name passed in a raw
+     * event will match the channel name held by the live Channel Manager. By
+     * chaining events you can be certain that events such as channel Rename
+     * events have been processed by the live ChannelManager before you receive
+     * an event and as such the names will always match. Whilst name matching is
+     * not always critical (as you should be matching by the channels unique id)
+     * the channel name does also contain state information (Zombie, Masq) in
+     * these cases it can be critical that you have the same name otherwise your
+     * state information will be out of date.
+     */
     public void addChainListener(ManagerEventListener chainListener);
 
-    /** 
+    /**
      * remove the chain listener.
+     * 
      * @param chainListener
      */
-	public void removeChainListener(ManagerEventListener chainListener);
+    public void removeChainListener(ManagerEventListener chainListener);
 
     /**
      * Closes the connection to this server.
      */
     void shutdown();
 
-	/**
-	 * Opens the connection to this server.
+    /**
+     * Opens the connection to this server.
      * 
-	 * @throws ManagerCommunicationException if login fails
-	 */
-	void initialize() throws ManagerCommunicationException;
+     * @throws ManagerCommunicationException if login fails
+     */
+    void initialize() throws ManagerCommunicationException;
 
     /**
      * get Asterisk Queue by name
+     * 
      * @author itaqua
      * @param queueName Name of the queue to retrieve
      * @return
      */
-	public AsteriskQueue getQueueByName(String queueName);
+    public AsteriskQueue getQueueByName(String queueName);
 
     /**
      * List of Queues Objects updated after certain date
+     * 
      * @author itaqua
      * @param date
      * @return
      */
-	public List<AsteriskQueue> getQueuesUpdatedAfter(Date date);
+    public List<AsteriskQueue> getQueuesUpdatedAfter(Date date);
 
-	/**
-     * every time we get an event of a queue we reload the information about it from
-	 * the Asterisk Server
+    /**
+     * every time we get an event of a queue we reload the information about it
+     * from the Asterisk Server
+     * 
      * @author itaqua
-	 */
-	public void forceQueuesMonitor(boolean force);
+     */
+    public void forceQueuesMonitor(boolean force);
 
     /**
      * Check if the Queue Information is forced
+     * 
      * @author itaqua
      * @return
      */
-	public boolean isQueuesMonitorForced();
+    public boolean isQueuesMonitorForced();
 }

--- a/src/main/java/org/asteriskjava/live/DefaultAsteriskServer.java
+++ b/src/main/java/org/asteriskjava/live/DefaultAsteriskServer.java
@@ -37,323 +37,309 @@ import org.asteriskjava.manager.action.OriginateAction;
  */
 public class DefaultAsteriskServer implements AsteriskServer
 {
-	private final AsteriskServerImpl impl;
+    private final AsteriskServerImpl impl;
 
-	/**
-	 * Creates a new instance without a {@link ManagerConnection}. The
-	 * ManagerConnection must be set using
-	 * {@link #setManagerConnection(ManagerConnection)} before you can use this
-	 * AsteriskServer.
-	 */
-	public DefaultAsteriskServer()
-	{
-		this.impl = new AsteriskServerImpl();
-	}
-
-	/**
-	 * Creates a new instance and a new {@link ManagerConnection} with the given
-	 * connection data.
-	 *
-	 * @param hostname
-	 *            the hostname of the Asterisk server to connect to.
-	 * @param username
-	 *            the username to use for login
-	 * @param password
-	 *            the password to use for login
-	 */
-	public DefaultAsteriskServer(String hostname, String username, String password)
-	{
-		final ManagerConnection connection;
-		connection = createManagerConnection(hostname, 0, username, password);
-		this.impl = new AsteriskServerImpl(connection);
-	}
-
-	/**
-	 * Creates a new instance and a new {@link ManagerConnection} with the given
-	 * connection data.
-	 *
-	 * @param hostname
-	 *            the hostname of the Asterisk server to connect to.
-	 * @param port
-	 *            the port where Asterisk listens for incoming Manager API
-	 *            connections, usually 5038.
-	 * @param username
-	 *            the username to use for login
-	 * @param password
-	 *            the password to use for login
-	 */
-	public DefaultAsteriskServer(String hostname, int port, String username, String password)
-	{
-		final ManagerConnection connection;
-		connection = createManagerConnection(hostname, port, username, password);
-		this.impl = new AsteriskServerImpl(connection);
-	}
-
-	protected DefaultManagerConnection createManagerConnection(String hostname, int port, String username,
-			String password)
-	{
-		DefaultManagerConnection dmc;
-		dmc = new DefaultManagerConnection(hostname, port, username, password);
-		return dmc;
-	}
-
-	/**
-	 * Creates a new instance that uses the given {@link ManagerConnection}.
-	 *
-	 * @param eventConnection
-	 *            the ManagerConnection to use for receiving events from
-	 *            Asterisk.
-	 */
-	public DefaultAsteriskServer(ManagerConnection eventConnection)
-	{
-		this.impl = new AsteriskServerImpl(eventConnection);
-	}
-
-	/**
-	 * Determines if queue status is retrieved at startup. If you don't need
-	 * queue information and still run Asterisk 1.0.x you can set this to
-	 * <code>true</code> to circumvent the startup delay caused by the missing
-	 * QueueStatusComplete event. <br>
-	 * Default is <code>false</code>.
-	 *
-	 * @param skipQueues
-	 *            <code>true</code> to skip queue initialization,
-	 *            <code>false</code> to not skip.
-	 * @since 0.2
-	 */
-	public void setSkipQueues(boolean skipQueues)
-	{
-		this.impl.setSkipQueues(skipQueues);
-	}
-
-	public void setManagerConnection(ManagerConnection eventConnection)
-	{
-		this.impl.setManagerConnection(eventConnection);
-	}
-
-	public void initialize() throws ManagerCommunicationException
-	{
-		this.impl.initialize();
-	}
-
-	/* Implementation of the AsteriskServer interface */
-
-	public ManagerConnection getManagerConnection()
-	{
-		return this.impl.getManagerConnection();
-	}
-
-	public AsteriskChannel originate(OriginateAction originateAction) throws ManagerCommunicationException,
-			NoSuchChannelException
-	{
-		return this.impl.originate(originateAction);
-	}
-
-	public AsteriskChannel originateToExtension(String channel, String context, String exten, int priority, long timeout)
-			throws ManagerCommunicationException, NoSuchChannelException
-	{
-		return this.impl.originateToExtension(channel, context, exten, priority, timeout);
-	}
-
-	public AsteriskChannel originateToExtension(String channel, String context, String exten, int priority,
-			long timeout, CallerId callerId, Map<String, String> variables) throws ManagerCommunicationException,
-			NoSuchChannelException
-	{
-		return this.impl.originateToExtension(channel, context, exten, priority, timeout, callerId, variables);
-	}
-
-	public AsteriskChannel originateToApplication(String channel, String application, String data, long timeout)
-			throws ManagerCommunicationException, NoSuchChannelException
-	{
-		return this.impl.originateToApplication(channel, application, data, timeout);
-	}
-
-	public AsteriskChannel originateToApplication(String channel, String application, String data, long timeout,
-			CallerId callerId, Map<String, String> variables) throws ManagerCommunicationException,
-			NoSuchChannelException
-	{
-		return this.impl.originateToApplication(channel, application, data, timeout, callerId, variables);
-	}
-
-	public void originateAsync(OriginateAction originateAction, OriginateCallback cb)
-			throws ManagerCommunicationException
-	{
-		this.impl.originateAsync(originateAction, cb);
-	}
-
-	public void originateToApplicationAsync(String channel, String application, String data, long timeout,
-			CallerId callerId, Map<String, String> variables, OriginateCallback cb)
-			throws ManagerCommunicationException
-	{
-		this.impl.originateToApplicationAsync(channel, application, data, timeout, callerId, variables, cb);
-	}
-
-	public void originateToApplicationAsync(String channel, String application, String data, long timeout,
-			OriginateCallback cb) throws ManagerCommunicationException
-	{
-		this.impl.originateToApplicationAsync(channel, application, data, timeout, cb);
-	}
-
-	public void originateToExtensionAsync(String channel, String context, String exten, int priority, long timeout,
-			CallerId callerId, Map<String, String> variables, OriginateCallback cb)
-			throws ManagerCommunicationException
-	{
-		this.impl.originateToExtensionAsync(channel, context, exten, priority, timeout, callerId, variables, cb);
-	}
-
-	public void originateToExtensionAsync(String channel, String context, String exten, int priority, long timeout,
-			OriginateCallback cb) throws ManagerCommunicationException
-	{
-		this.impl.originateToExtensionAsync(channel, context, exten, priority, timeout, cb);
-	}
-
-	public Collection<AsteriskChannel> getChannels() throws ManagerCommunicationException
-	{
-		return this.impl.getChannels();
-	}
-
-	public AsteriskChannel getChannelByName(String name) throws ManagerCommunicationException
-	{
-		return this.impl.getChannelByName(name);
-	}
-
-	public AsteriskChannel getChannelById(String id) throws ManagerCommunicationException
-	{
-		return this.impl.getChannelById(id);
-	}
-
-	public Collection<MeetMeRoom> getMeetMeRooms() throws ManagerCommunicationException
-	{
-		return this.impl.getMeetMeRooms();
-	}
-
-	public MeetMeRoom getMeetMeRoom(String name) throws ManagerCommunicationException
-	{
-		return this.impl.getMeetMeRoom(name);
-	}
-
-	public Collection<AsteriskQueue> getQueues() throws ManagerCommunicationException
-	{
-		return this.impl.getQueues();
-	}
-
-	public String getVersion() throws ManagerCommunicationException
-	{
-		return this.impl.getVersion();
-	}
-
-	public int[] getVersion(String file) throws ManagerCommunicationException
-	{
-		return this.impl.getVersion(file);
-	}
-
-	public String getGlobalVariable(String variable) throws ManagerCommunicationException
-	{
-		return this.impl.getGlobalVariable(variable);
-	}
-
-	public void setGlobalVariable(String variable, String value) throws ManagerCommunicationException
-	{
-		this.impl.setGlobalVariable(variable, value);
-	}
-
-	public Collection<Voicemailbox> getVoicemailboxes() throws ManagerCommunicationException
-	{
-		return this.impl.getVoicemailboxes();
-	}
-
-	public List<String> executeCliCommand(String command) throws ManagerCommunicationException
-	{
-		return this.impl.executeCliCommand(command);
-	}
-
-	public boolean isModuleLoaded(String module) throws ManagerCommunicationException
-	{
-		return this.impl.isModuleLoaded(module);
-	}
-
-	public ConfigFile getConfig(String filename) throws ManagerCommunicationException
-	{
-		return this.impl.getConfig(filename);
-	}
-
-	public void reloadAllModules() throws ManagerCommunicationException
-	{
-		this.impl.reloadAllModules();
-	}
-
-	public void reloadModule(String module) throws ManagerCommunicationException
-	{
-		this.impl.reloadModule(module);
-	}
-
-	public void unloadModule(String module) throws ManagerCommunicationException
-	{
-		this.impl.unloadModule(module);
-	}
-
-	public void loadModule(String module) throws ManagerCommunicationException
-	{
-		this.impl.loadModule(module);
-	}
-
-	public void addAsteriskServerListener(AsteriskServerListener listener) throws ManagerCommunicationException
-	{
-		this.impl.addAsteriskServerListener(listener);
-	}
-
-	public void removeAsteriskServerListener(AsteriskServerListener listener)
-	{
-		this.impl.removeAsteriskServerListener(listener);
+    /**
+     * Creates a new instance without a {@link ManagerConnection}. The
+     * ManagerConnection must be set using
+     * {@link #setManagerConnection(ManagerConnection)} before you can use this
+     * AsteriskServer.
+     */
+    public DefaultAsteriskServer()
+    {
+        this.impl = new AsteriskServerImpl();
     }
-    
-    public boolean isAsteriskServerListening(AsteriskServerListener listener){
-    	return this.impl.isAsteriskServerListening(listener);
-	}
 
-	public void shutdown()
-	{
-		this.impl.shutdown();
-	}
+    /**
+     * Creates a new instance and a new {@link ManagerConnection} with the given
+     * connection data.
+     *
+     * @param hostname the hostname of the Asterisk server to connect to.
+     * @param username the username to use for login
+     * @param password the password to use for login
+     */
+    public DefaultAsteriskServer(String hostname, String username, String password)
+    {
+        final ManagerConnection connection;
+        connection = createManagerConnection(hostname, 0, username, password);
+        this.impl = new AsteriskServerImpl(connection);
+    }
 
-	public Collection<AsteriskAgent> getAgents() throws ManagerCommunicationException
-	{
-		return this.impl.getAgents();
-	}
+    /**
+     * Creates a new instance and a new {@link ManagerConnection} with the given
+     * connection data.
+     *
+     * @param hostname the hostname of the Asterisk server to connect to.
+     * @param port the port where Asterisk listens for incoming Manager API
+     *            connections, usually 5038.
+     * @param username the username to use for login
+     * @param password the password to use for login
+     */
+    public DefaultAsteriskServer(String hostname, int port, String username, String password)
+    {
+        final ManagerConnection connection;
+        connection = createManagerConnection(hostname, port, username, password);
+        this.impl = new AsteriskServerImpl(connection);
+    }
 
-	public AsteriskQueue getQueueByName(String queueName)
-	{
-		return impl.getQueueByName(queueName);
-	}
+    protected DefaultManagerConnection createManagerConnection(String hostname, int port, String username, String password)
+    {
+        DefaultManagerConnection dmc;
+        dmc = new DefaultManagerConnection(hostname, port, username, password);
+        return dmc;
+    }
 
-	@Override
-	public List<AsteriskQueue> getQueuesUpdatedAfter(Date date)
-	{
-		return impl.getQueuesUpdatedAfter(date);
-	}
+    /**
+     * Creates a new instance that uses the given {@link ManagerConnection}.
+     *
+     * @param eventConnection the ManagerConnection to use for receiving events
+     *            from Asterisk.
+     */
+    public DefaultAsteriskServer(ManagerConnection eventConnection)
+    {
+        this.impl = new AsteriskServerImpl(eventConnection);
+    }
 
-	@Override
-	public void forceQueuesMonitor(boolean force)
-	{
-		impl.forceQueuesMonitor(force);
-	}
+    /**
+     * Determines if queue status is retrieved at startup. If you don't need
+     * queue information and still run Asterisk 1.0.x you can set this to
+     * <code>true</code> to circumvent the startup delay caused by the missing
+     * QueueStatusComplete event. <br>
+     * Default is <code>false</code>.
+     *
+     * @param skipQueues <code>true</code> to skip queue initialization,
+     *            <code>false</code> to not skip.
+     * @since 0.2
+     */
+    public void setSkipQueues(boolean skipQueues)
+    {
+        this.impl.setSkipQueues(skipQueues);
+    }
 
-	@Override
-	public boolean isQueuesMonitorForced()
-	{
-		return impl.isQueuesMonitorForced();
-	}
+    public void setManagerConnection(ManagerConnection eventConnection)
+    {
+        this.impl.setManagerConnection(eventConnection);
+    }
 
-	@Override
-	public void addChainListener(ManagerEventListener chainListener)
-	{
-		this.impl.addChainListener(chainListener);
-	}
+    public void initialize() throws ManagerCommunicationException
+    {
+        this.impl.initialize();
+    }
 
-	@Override
-	public void removeChainListener(ManagerEventListener chainListener)
-	{
-		this.impl.removeChainListener(chainListener);
+    /* Implementation of the AsteriskServer interface */
 
-	}
+    public ManagerConnection getManagerConnection()
+    {
+        return this.impl.getManagerConnection();
+    }
+
+    public AsteriskChannel originate(OriginateAction originateAction) throws ManagerCommunicationException,
+            NoSuchChannelException
+    {
+        return this.impl.originate(originateAction);
+    }
+
+    public AsteriskChannel originateToExtension(String channel, String context, String exten, int priority, long timeout)
+            throws ManagerCommunicationException, NoSuchChannelException
+    {
+        return this.impl.originateToExtension(channel, context, exten, priority, timeout);
+    }
+
+    public AsteriskChannel originateToExtension(String channel, String context, String exten, int priority, long timeout,
+            CallerId callerId, Map<String, String> variables) throws ManagerCommunicationException, NoSuchChannelException
+    {
+        return this.impl.originateToExtension(channel, context, exten, priority, timeout, callerId, variables);
+    }
+
+    public AsteriskChannel originateToApplication(String channel, String application, String data, long timeout)
+            throws ManagerCommunicationException, NoSuchChannelException
+    {
+        return this.impl.originateToApplication(channel, application, data, timeout);
+    }
+
+    public AsteriskChannel originateToApplication(String channel, String application, String data, long timeout,
+            CallerId callerId, Map<String, String> variables) throws ManagerCommunicationException, NoSuchChannelException
+    {
+        return this.impl.originateToApplication(channel, application, data, timeout, callerId, variables);
+    }
+
+    public void originateAsync(OriginateAction originateAction, OriginateCallback cb) throws ManagerCommunicationException
+    {
+        this.impl.originateAsync(originateAction, cb);
+    }
+
+    public void originateToApplicationAsync(String channel, String application, String data, long timeout,
+            CallerId callerId, Map<String, String> variables, OriginateCallback cb) throws ManagerCommunicationException
+    {
+        this.impl.originateToApplicationAsync(channel, application, data, timeout, callerId, variables, cb);
+    }
+
+    public void originateToApplicationAsync(String channel, String application, String data, long timeout,
+            OriginateCallback cb) throws ManagerCommunicationException
+    {
+        this.impl.originateToApplicationAsync(channel, application, data, timeout, cb);
+    }
+
+    public void originateToExtensionAsync(String channel, String context, String exten, int priority, long timeout,
+            CallerId callerId, Map<String, String> variables, OriginateCallback cb) throws ManagerCommunicationException
+    {
+        this.impl.originateToExtensionAsync(channel, context, exten, priority, timeout, callerId, variables, cb);
+    }
+
+    public void originateToExtensionAsync(String channel, String context, String exten, int priority, long timeout,
+            OriginateCallback cb) throws ManagerCommunicationException
+    {
+        this.impl.originateToExtensionAsync(channel, context, exten, priority, timeout, cb);
+    }
+
+    public Collection<AsteriskChannel> getChannels() throws ManagerCommunicationException
+    {
+        return this.impl.getChannels();
+    }
+
+    public AsteriskChannel getChannelByName(String name) throws ManagerCommunicationException
+    {
+        return this.impl.getChannelByName(name);
+    }
+
+    public AsteriskChannel getChannelById(String id) throws ManagerCommunicationException
+    {
+        return this.impl.getChannelById(id);
+    }
+
+    public Collection<MeetMeRoom> getMeetMeRooms() throws ManagerCommunicationException
+    {
+        return this.impl.getMeetMeRooms();
+    }
+
+    public MeetMeRoom getMeetMeRoom(String name) throws ManagerCommunicationException
+    {
+        return this.impl.getMeetMeRoom(name);
+    }
+
+    public Collection<AsteriskQueue> getQueues() throws ManagerCommunicationException
+    {
+        return this.impl.getQueues();
+    }
+
+    public String getVersion() throws ManagerCommunicationException
+    {
+        return this.impl.getVersion();
+    }
+
+    public int[] getVersion(String file) throws ManagerCommunicationException
+    {
+        return this.impl.getVersion(file);
+    }
+
+    public String getGlobalVariable(String variable) throws ManagerCommunicationException
+    {
+        return this.impl.getGlobalVariable(variable);
+    }
+
+    public void setGlobalVariable(String variable, String value) throws ManagerCommunicationException
+    {
+        this.impl.setGlobalVariable(variable, value);
+    }
+
+    public Collection<Voicemailbox> getVoicemailboxes() throws ManagerCommunicationException
+    {
+        return this.impl.getVoicemailboxes();
+    }
+
+    public List<String> executeCliCommand(String command) throws ManagerCommunicationException
+    {
+        return this.impl.executeCliCommand(command);
+    }
+
+    public boolean isModuleLoaded(String module) throws ManagerCommunicationException
+    {
+        return this.impl.isModuleLoaded(module);
+    }
+
+    public ConfigFile getConfig(String filename) throws ManagerCommunicationException
+    {
+        return this.impl.getConfig(filename);
+    }
+
+    public void reloadAllModules() throws ManagerCommunicationException
+    {
+        this.impl.reloadAllModules();
+    }
+
+    public void reloadModule(String module) throws ManagerCommunicationException
+    {
+        this.impl.reloadModule(module);
+    }
+
+    public void unloadModule(String module) throws ManagerCommunicationException
+    {
+        this.impl.unloadModule(module);
+    }
+
+    public void loadModule(String module) throws ManagerCommunicationException
+    {
+        this.impl.loadModule(module);
+    }
+
+    public void addAsteriskServerListener(AsteriskServerListener listener) throws ManagerCommunicationException
+    {
+        this.impl.addAsteriskServerListener(listener);
+    }
+
+    public void removeAsteriskServerListener(AsteriskServerListener listener)
+    {
+        this.impl.removeAsteriskServerListener(listener);
+    }
+
+    public boolean isAsteriskServerListening(AsteriskServerListener listener)
+    {
+        return this.impl.isAsteriskServerListening(listener);
+    }
+
+    public void shutdown()
+    {
+        this.impl.shutdown();
+    }
+
+    public Collection<AsteriskAgent> getAgents() throws ManagerCommunicationException
+    {
+        return this.impl.getAgents();
+    }
+
+    public AsteriskQueue getQueueByName(String queueName)
+    {
+        return impl.getQueueByName(queueName);
+    }
+
+    @Override
+    public List<AsteriskQueue> getQueuesUpdatedAfter(Date date)
+    {
+        return impl.getQueuesUpdatedAfter(date);
+    }
+
+    @Override
+    public void forceQueuesMonitor(boolean force)
+    {
+        impl.forceQueuesMonitor(force);
+    }
+
+    @Override
+    public boolean isQueuesMonitorForced()
+    {
+        return impl.isQueuesMonitorForced();
+    }
+
+    @Override
+    public void addChainListener(ManagerEventListener chainListener)
+    {
+        this.impl.addChainListener(chainListener);
+    }
+
+    @Override
+    public void removeChainListener(ManagerEventListener chainListener)
+    {
+        this.impl.removeChainListener(chainListener);
+
+    }
 }

--- a/src/main/java/org/asteriskjava/live/DefaultAsteriskServer.java
+++ b/src/main/java/org/asteriskjava/live/DefaultAsteriskServer.java
@@ -305,6 +305,10 @@ public class DefaultAsteriskServer implements AsteriskServer
 	public void removeAsteriskServerListener(AsteriskServerListener listener)
 	{
 		this.impl.removeAsteriskServerListener(listener);
+    }
+    
+    public boolean isAsteriskServerListening(AsteriskServerListener listener){
+    	return this.impl.isAsteriskServerListening(listener);
 	}
 
 	public void shutdown()

--- a/src/main/java/org/asteriskjava/live/internal/AbstractLiveObject.java
+++ b/src/main/java/org/asteriskjava/live/internal/AbstractLiveObject.java
@@ -58,7 +58,16 @@ abstract class AbstractLiveObject implements LiveObject
 
     public void addPropertyChangeListener(String propertyName, PropertyChangeListener listener)
     {
-        changes.addPropertyChangeListener(propertyName, listener);
+    	boolean haveToAdd = true;
+    	for(PropertyChangeListener l : changes.getPropertyChangeListeners()){
+    		if(l == listener){
+    			haveToAdd = false;
+    			break;
+    		}
+    	}
+    	if(haveToAdd){
+	        changes.addPropertyChangeListener(propertyName, listener);
+	    }
     }
 
     public void removePropertyChangeListener(PropertyChangeListener listener)

--- a/src/main/java/org/asteriskjava/live/internal/AbstractLiveObject.java
+++ b/src/main/java/org/asteriskjava/live/internal/AbstractLiveObject.java
@@ -36,7 +36,7 @@ abstract class AbstractLiveObject implements LiveObject
     private final PropertyChangeSupport changes;
     protected final AsteriskServerImpl server;
 
-  //last time this object was updated
+    // last time this object was updated
     private long lastUpdate;
 
     AbstractLiveObject(AsteriskServerImpl server)
@@ -58,16 +58,19 @@ abstract class AbstractLiveObject implements LiveObject
 
     public void addPropertyChangeListener(String propertyName, PropertyChangeListener listener)
     {
-    	boolean haveToAdd = true;
-    	for(PropertyChangeListener l : changes.getPropertyChangeListeners()){
-    		if(l == listener){
-    			haveToAdd = false;
-    			break;
-    		}
-    	}
-    	if(haveToAdd){
-	        changes.addPropertyChangeListener(propertyName, listener);
-	    }
+        boolean haveToAdd = true;
+        for (PropertyChangeListener l : changes.getPropertyChangeListeners())
+        {
+            if (l == listener)
+            {
+                haveToAdd = false;
+                break;
+            }
+        }
+        if (haveToAdd)
+        {
+            changes.addPropertyChangeListener(propertyName, listener);
+        }
     }
 
     public void removePropertyChangeListener(PropertyChangeListener listener)
@@ -79,12 +82,12 @@ abstract class AbstractLiveObject implements LiveObject
     {
         changes.removePropertyChangeListener(propertyName, listener);
     }
-    
+
     protected void firePropertyChange(String propertyName, Object oldValue, Object newValue)
     {
         if (oldValue != null || newValue != null)
         {
-        	stampLastUpdate();
+            stampLastUpdate();
             try
             {
                 changes.firePropertyChange(propertyName, oldValue, newValue);
@@ -97,11 +100,13 @@ abstract class AbstractLiveObject implements LiveObject
     }
 
     @Override
-    public long getLastUpdateMillis() {
-    	return lastUpdate;
+    public long getLastUpdateMillis()
+    {
+        return lastUpdate;
     }
 
-    public void stampLastUpdate(){
-    	lastUpdate = System.currentTimeMillis();
+    public void stampLastUpdate()
+    {
+        lastUpdate = System.currentTimeMillis();
     }
 }

--- a/src/main/java/org/asteriskjava/live/internal/AsteriskServerImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskServerImpl.java
@@ -141,9 +141,10 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
      */
     private ManagerConnection eventConnection;
     private ManagerEventListener eventListener = null;
-    ManagerEventListenerProxy managerEventListenerProxy;
+    private ManagerEventListenerProxy managerEventListenerProxy;
 
-    boolean initialized = false;
+    private boolean initialized = false;
+    private boolean initializing = false;
 
     final Set<AsteriskServerListener> listeners;
 
@@ -273,7 +274,7 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
 
     private synchronized void initializeIfNeeded() throws ManagerCommunicationException
     {
-        if (initialized)
+        if (initialized || initializing)
         {
             return;
         }
@@ -287,6 +288,9 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
             eventListener = this;
             eventConnection.addEventListener(eventListener);
         }
+
+        initializing = true;
+        
         if (eventConnection.getState() == ManagerConnectionState.INITIAL
                 || eventConnection.getState() == ManagerConnectionState.DISCONNECTED)
         {
@@ -1209,6 +1213,7 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
         meetMeManager.disconnected();
         queueManager.disconnected();
         initialized = false;
+        initializing = false;
     }
 
     /*
@@ -1232,6 +1237,7 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
 
             logger.info("Initializing done");
             initialized = true;
+            initializing = false;
         }
         catch (Exception e)
         {
@@ -1355,16 +1361,16 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
             managerEventListenerProxy.shutdown();
         }
 
-		    if (eventConnection != null && eventListener != null) {
-			    eventConnection.removeEventListener(eventListener);
-	      }
+		if (eventConnection != null && eventListener != null) {
+		    	eventConnection.removeEventListener(eventListener);
+	    }
 
-		    managerEventListenerProxy = null;
+		managerEventListenerProxy = null;
         eventListener = null;
 
-	      if (initialized) {//incredible, but it happened
-		      handleDisconnectEvent(null);
-	      }//i
+	    if (initialized) {//incredible, but it happened
+	    	handleDisconnectEvent(null);
+	    }//i
     }//shutdown
 
     public List<PeerEntryEvent> getPeerEntries() throws ManagerCommunicationException

--- a/src/main/java/org/asteriskjava/live/internal/AsteriskServerImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskServerImpl.java
@@ -871,16 +871,21 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
         return new ConfigFileImpl(filename, categories);
     }
 
-    public void addAsteriskServerListener(AsteriskServerListener listener) throws ManagerCommunicationException
+    @Override
+	public void addAsteriskServerListener(AsteriskServerListener listener) throws ManagerCommunicationException
     {
         initializeIfNeeded();
         synchronized (listeners)
         {
-            listeners.add(listener);
+        	if(!listeners.contains(listener))
+        	{
+        		listeners.add(listener);
+        	}
         }
     }
 
-    public void removeAsteriskServerListener(AsteriskServerListener listener)
+    @Override
+	public void removeAsteriskServerListener(AsteriskServerListener listener)
     {
         synchronized (listeners)
         {
@@ -888,6 +893,12 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
         }
     }
 
+    @Override
+	public boolean isAsteriskServerListening(AsteriskServerListener listener)
+    {
+    	return listeners.contains(listener);
+    }
+    
 	public void addChainListener(ManagerEventListener chainListener)
 	{
 		synchronized (this.chainListeners)

--- a/src/main/java/org/asteriskjava/live/internal/AsteriskServerImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskServerImpl.java
@@ -155,17 +155,17 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
 
     /**
      * The exact version string of the Asterisk server we are connected to.
-	 * <p/>
+     * <p/>
      * Contains <code>null</code> until lazily initialized.
      */
     private String version;
 
     /**
      * Holds the version of Asterisk's source files.
-	 * <p/>
+     * <p/>
      * That corresponds to the output of the CLI command
      * <code>show version files</code>.
-	 * <p/>
+     * <p/>
      * Contains <code>null</code> until lazily initialized.
      */
     private Map<String, String> versions;
@@ -186,27 +186,26 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
     private boolean skipQueues;
 
     /**
-	 * Set to <code>true</code> to not handle ManagerEvents in the reader tread
-	 * but process them asynchronously. This is a good idea :)
+     * Set to <code>true</code> to not handle ManagerEvents in the reader tread
+     * but process them asynchronously. This is a good idea :)
      */
     private boolean asyncEventHandling = true;
 
     /**
-	 * The chainListener allows a listener to receive manager events after they
-	 * have been processed by the AsteriskServer. If the AsteriskServer is
-	 * handling messages using the asyncEventHandling then these messages will
-	 * also be async. You would use the chainListener if you are processing raw
-	 * events and using the AJ live ChannelManager. If you don't use the chain
-	 * listener then you can't be certain that a channel name passed in a raw
-	 * event will match the channel name held by the Channel Manager. By
-	 * chaining events you can be certain that events such as channel Rename
-	 * events have been processed by the live ChannelManager before you receive
-	 * an event and as such the names will always match.
-	 * 
-	 */
-	private List<ManagerEventListener> chainListeners = new ArrayList<ManagerEventListener>();
+     * The chainListener allows a listener to receive manager events after they
+     * have been processed by the AsteriskServer. If the AsteriskServer is
+     * handling messages using the asyncEventHandling then these messages will
+     * also be async. You would use the chainListener if you are processing raw
+     * events and using the AJ live ChannelManager. If you don't use the chain
+     * listener then you can't be certain that a channel name passed in a raw
+     * event will match the channel name held by the Channel Manager. By
+     * chaining events you can be certain that events such as channel Rename
+     * events have been processed by the live ChannelManager before you receive
+     * an event and as such the names will always match.
+     */
+    private List<ManagerEventListener> chainListeners = new ArrayList<ManagerEventListener>();
 
-	/**
+    /**
      * Creates a new instance.
      */
     public AsteriskServerImpl()
@@ -223,28 +222,26 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
     /**
      * Creates a new instance.
      *
-	 * @param eventConnection
-	 *            the ManagerConnection to use for receiving events from
-	 *            Asterisk.
+     * @param eventConnection the ManagerConnection to use for receiving events
+     *            from Asterisk.
      */
     public AsteriskServerImpl(ManagerConnection eventConnection)
     {
         this();
-		setManagerConnection(eventConnection); // todo: !!! Possible bug !!!:
-												// call to overridable method
-												// over object construction
+        setManagerConnection(eventConnection); // todo: !!! Possible bug !!!:
+                                               // call to overridable method
+                                               // over object construction
     }
 
     /**
      * Determines if queue status is retrieved at startup. If you don't need
      * queue information and still run Asterisk 1.0.x you can set this to
      * <code>true</code> to circumvent the startup delay caused by the missing
-     * QueueStatusComplete event.
-     * <br>
+     * QueueStatusComplete event. <br>
      * Default is <code>false</code>.
      *
      * @param skipQueues <code>true</code> to skip queue initialization,
-     *                   <code>false</code> to not skip.
+     *            <code>false</code> to not skip.
      * @since 0.2
      */
     public void setSkipQueues(boolean skipQueues)
@@ -290,7 +287,7 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
         }
 
         initializing = true;
-        
+
         if (eventConnection.getState() == ManagerConnectionState.INITIAL
                 || eventConnection.getState() == ManagerConnectionState.DISCONNECTED)
         {
@@ -308,17 +305,14 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
 
     /* Implementation of the AsteriskServer interface */
 
-    public AsteriskChannel originateToExtension(String channel, String context,
-                                                String exten, int priority, long timeout)
+    public AsteriskChannel originateToExtension(String channel, String context, String exten, int priority, long timeout)
             throws ManagerCommunicationException, NoSuchChannelException
     {
         return originateToExtension(channel, context, exten, priority, timeout, null, null);
     }
 
-    public AsteriskChannel originateToExtension(String channel, String context,
-                                                String exten, int priority, long timeout, CallerId callerId,
-                                                Map<String, String> variables)
-            throws ManagerCommunicationException, NoSuchChannelException
+    public AsteriskChannel originateToExtension(String channel, String context, String exten, int priority, long timeout,
+            CallerId callerId, Map<String, String> variables) throws ManagerCommunicationException, NoSuchChannelException
     {
         final OriginateAction originateAction;
 
@@ -337,17 +331,14 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
         return originate(originateAction);
     }
 
-    public AsteriskChannel originateToApplication(String channel,
-                                                  String application, String data, long timeout)
+    public AsteriskChannel originateToApplication(String channel, String application, String data, long timeout)
             throws ManagerCommunicationException, NoSuchChannelException
     {
         return originateToApplication(channel, application, data, timeout, null, null);
     }
 
-    public AsteriskChannel originateToApplication(String channel,
-                                                  String application, String data, long timeout, CallerId callerId,
-                                                  Map<String, String> variables)
-            throws ManagerCommunicationException, NoSuchChannelException
+    public AsteriskChannel originateToApplication(String channel, String application, String data, long timeout,
+            CallerId callerId, Map<String, String> variables) throws ManagerCommunicationException, NoSuchChannelException
     {
         final OriginateAction originateAction;
 
@@ -365,7 +356,8 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
         return originate(originateAction);
     }
 
-    public AsteriskChannel originate(OriginateAction originateAction) throws ManagerCommunicationException, NoSuchChannelException
+    public AsteriskChannel originate(OriginateAction originateAction) throws ManagerCommunicationException,
+            NoSuchChannelException
     {
         final ResponseEvents responseEvents;
         final Iterator<ResponseEvent> responseEventIterator;
@@ -402,17 +394,14 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
         return channel;
     }
 
-    public void originateToExtensionAsync(String channel, String context,
-                                          String exten, int priority, long timeout, OriginateCallback cb)
-            throws ManagerCommunicationException
+    public void originateToExtensionAsync(String channel, String context, String exten, int priority, long timeout,
+            OriginateCallback cb) throws ManagerCommunicationException
     {
         originateToExtensionAsync(channel, context, exten, priority, timeout, null, null, cb);
     }
 
-    public void originateToExtensionAsync(String channel, String context,
-                                          String exten, int priority, long timeout, CallerId callerId,
-                                          Map<String, String> variables, OriginateCallback cb)
-            throws ManagerCommunicationException
+    public void originateToExtensionAsync(String channel, String context, String exten, int priority, long timeout,
+            CallerId callerId, Map<String, String> variables, OriginateCallback cb) throws ManagerCommunicationException
     {
         final OriginateAction originateAction;
 
@@ -431,17 +420,14 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
         originateAsync(originateAction, cb);
     }
 
-    public void originateToApplicationAsync(String channel, String application,
-                                            String data, long timeout, OriginateCallback cb)
-            throws ManagerCommunicationException
+    public void originateToApplicationAsync(String channel, String application, String data, long timeout,
+            OriginateCallback cb) throws ManagerCommunicationException
     {
         originateToApplicationAsync(channel, application, data, timeout, null, null, cb);
     }
 
-    public void originateToApplicationAsync(String channel, String application,
-                                            String data, long timeout, CallerId callerId,
-                                            Map<String, String> variables, OriginateCallback cb)
-            throws ManagerCommunicationException
+    public void originateToApplicationAsync(String channel, String application, String data, long timeout,
+            CallerId callerId, Map<String, String> variables, OriginateCallback cb) throws ManagerCommunicationException
     {
         final OriginateAction originateAction;
 
@@ -459,8 +445,7 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
         originateAsync(originateAction, cb);
     }
 
-    public void originateAsync(OriginateAction originateAction,
-                               OriginateCallback cb) throws ManagerCommunicationException
+    public void originateAsync(OriginateAction originateAction, OriginateCallback cb) throws ManagerCommunicationException
     {
         final Map<String, String> variables;
         final String traceId;
@@ -475,7 +460,8 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
             variables = new HashMap<String, String>(originateAction.getVariables());
         }
 
-        // prefix variable name by "__" to enable variable inheritence across channels
+        // prefix variable name by "__" to enable variable inheritence across
+        // channels
         variables.put("__" + Constants.VARIABLE_TRACE_ID, traceId);
         originateAction.setVariables(variables);
 
@@ -536,15 +522,17 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
     }
 
     @Override
-	public AsteriskQueue getQueueByName(String queueName){
-    	initializeIfNeeded();
-    	return queueManager.getQueueByName(queueName);
+    public AsteriskQueue getQueueByName(String queueName)
+    {
+        initializeIfNeeded();
+        return queueManager.getQueueByName(queueName);
     }
 
     @Override
-	public List<AsteriskQueue> getQueuesUpdatedAfter(Date date){
-    	initializeIfNeeded();
-    	return queueManager.getQueuesUpdatedAfter(date);
+    public List<AsteriskQueue> getQueuesUpdatedAfter(Date date)
+    {
+        initializeIfNeeded();
+        return queueManager.getQueuesUpdatedAfter(date);
     }
 
     public synchronized String getVersion() throws ManagerCommunicationException
@@ -636,8 +624,7 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
                 }
                 else
                 {
-                    logger.error("Response to CommandAction(\""
-                            + command + "\") was not a CommandResponse but " + response);
+                    logger.error("Response to CommandAction(\"" + command + "\") was not a CommandResponse but " + response);
                 }
             }
             catch (Exception e)
@@ -703,8 +690,7 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
         response = sendAction(new SetVarAction(variable, value));
         if (response instanceof ManagerError)
         {
-            logger.error("Unable to set global variable '" + variable
-                    + "' to '" + value + "':" + response.getMessage());
+            logger.error("Unable to set global variable '" + variable + "' to '" + value + "':" + response.getMessage());
         }
     }
 
@@ -726,7 +712,8 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
         }
         if (!(response instanceof CommandResponse))
         {
-            logger.error("Response to CommandAction(\"" + SHOW_VOICEMAIL_USERS_COMMAND + "\") was not a CommandResponse but " + response);
+            logger.error("Response to CommandAction(\"" + SHOW_VOICEMAIL_USERS_COMMAND
+                    + "\") was not a CommandResponse but " + response);
             return voicemailboxes;
         }
 
@@ -766,8 +753,7 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
         {
             final String fullname;
 
-            fullname = voicemailbox.getMailbox() + "@"
-                    + voicemailbox.getContext();
+            fullname = voicemailbox.getMailbox() + "@" + voicemailbox.getContext();
             response = sendAction(new MailboxCountAction(fullname));
             if (response instanceof MailboxCountResponse)
             {
@@ -876,20 +862,20 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
     }
 
     @Override
-	public void addAsteriskServerListener(AsteriskServerListener listener) throws ManagerCommunicationException
+    public void addAsteriskServerListener(AsteriskServerListener listener) throws ManagerCommunicationException
     {
         initializeIfNeeded();
         synchronized (listeners)
         {
-        	if(!listeners.contains(listener))
-        	{
-        		listeners.add(listener);
-        	}
+            if (!listeners.contains(listener))
+            {
+                listeners.add(listener);
+            }
         }
     }
 
     @Override
-	public void removeAsteriskServerListener(AsteriskServerListener listener)
+    public void removeAsteriskServerListener(AsteriskServerListener listener)
     {
         synchronized (listeners)
         {
@@ -898,25 +884,25 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
     }
 
     @Override
-	public boolean isAsteriskServerListening(AsteriskServerListener listener)
+    public boolean isAsteriskServerListening(AsteriskServerListener listener)
     {
-    	return listeners.contains(listener);
+        return listeners.contains(listener);
     }
-    
-	public void addChainListener(ManagerEventListener chainListener)
-	{
-		synchronized (this.chainListeners)
-		{
-			if (!this.chainListeners.contains(chainListener))
-				this.chainListeners.add(chainListener);
-		}
 
-	}
+    public void addChainListener(ManagerEventListener chainListener)
+    {
+        synchronized (this.chainListeners)
+        {
+            if (!this.chainListeners.contains(chainListener))
+                this.chainListeners.add(chainListener);
+        }
 
-	public void removeChainListener(ManagerEventListener chainListener)
-	{
-		this.chainListeners.remove(chainListener);
-	}
+    }
+
+    public void removeChainListener(ManagerEventListener chainListener)
+    {
+        this.chainListeners.remove(chainListener);
+    }
 
     void fireNewAsteriskChannel(AsteriskChannel channel)
     {
@@ -992,8 +978,8 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
         }
     }
 
-    ResponseEvents sendEventGeneratingAction(EventGeneratingAction action,
-                                             long timeout) throws ManagerCommunicationException
+    ResponseEvents sendEventGeneratingAction(EventGeneratingAction action, long timeout)
+            throws ManagerCommunicationException
     {
         // return connectionPool.sendEventGeneratingAction(action, timeout);
         try
@@ -1017,8 +1003,7 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
     /* Implementation of the ManagerEventListener interface */
 
     /**
-     * Handles all events received from the Asterisk server.
-     * <br>
+     * Handles all events received from the Asterisk server. <br>
      * Events are queued until channels and queues are initialized and then
      * delegated to the dispatchEvent method.
      */
@@ -1178,23 +1163,23 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
         }
         // End of agent-related events
 
-		// dispatch the events to the chainListener if they exist.
-		fireChainListeners(event);
+        // dispatch the events to the chainListener if they exist.
+        fireChainListeners(event);
     }
 
-	/**
-	 * dispatch the event to the chainListener if they exist.
-	 * 
-	 * @param event
-	 */
-	private void fireChainListeners(ManagerEvent event)
-	{
-		synchronized (this.chainListeners)
-		{
-			for (ManagerEventListener listener : this.chainListeners)
-				listener.onManagerEvent(event);
-		}
-	}
+    /**
+     * dispatch the event to the chainListener if they exist.
+     * 
+     * @param event
+     */
+    private void fireChainListeners(ManagerEvent event)
+    {
+        synchronized (this.chainListeners)
+        {
+            for (ManagerEventListener listener : this.chainListeners)
+                listener.onManagerEvent(event);
+        }
+    }
 
     /*
      * Resets the internal state when the connection to the asterisk server is
@@ -1203,11 +1188,13 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
 
     private void handleDisconnectEvent(DisconnectEvent disconnectEvent)
     {
-        // reset version information as it might have changed while Asterisk restarted
+        // reset version information as it might have changed while Asterisk
+        // restarted
         version = null;
         versions = null;
 
-        // same for channels, agents and queues rooms, they are reinitialized when reconnected
+        // same for channels, agents and queues rooms, they are reinitialized
+        // when reconnected
         channelManager.disconnected();
         agentManager.disconnected();
         meetMeManager.disconnected();
@@ -1251,7 +1238,8 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
         final OriginateCallbackData callbackData;
         final OriginateCallback cb;
         final AsteriskChannelImpl channel;
-        final AsteriskChannelImpl otherChannel; // the other side if local channel
+        final AsteriskChannelImpl otherChannel; // the other side if local
+                                                // channel
 
         traceId = originateEvent.getActionId();
         if (traceId == null)
@@ -1285,7 +1273,8 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
             {
                 final LiveException cause;
 
-                cause = new NoSuchChannelException("Channel '" + callbackData.getOriginateAction().getChannel() + "' is not available");
+                cause = new NoSuchChannelException("Channel '" + callbackData.getOriginateAction().getChannel()
+                        + "' is not available");
                 cb.onFailure(cause);
                 return;
             }
@@ -1304,14 +1293,16 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
 
             otherChannel = channelManager.getOtherSideOfLocalChannel(channel);
             // special treatment of local channels:
-            // the interesting things happen to the other side so we have a look at that
+            // the interesting things happen to the other side so we have a look
+            // at that
             if (otherChannel != null)
             {
                 final AsteriskChannel dialedChannel;
 
                 dialedChannel = otherChannel.getDialedChannel();
 
-                // on busy the other channel is in state busy when we receive the originate event
+                // on busy the other channel is in state busy when we receive
+                // the originate event
                 if (otherChannel.wasBusy())
                 {
                     cb.onBusy(channel);
@@ -1341,31 +1332,43 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
         }
     }
 
-    @Override public void shutdown() {
-        if (eventConnection != null && (eventConnection.getState() == ManagerConnectionState.CONNECTED || eventConnection.getState() == ManagerConnectionState.RECONNECTING)) {
-						try {
-							eventConnection.logoff();
-						} catch (Exception ignore) {}
+    @Override
+    public void shutdown()
+    {
+        if (eventConnection != null
+                && (eventConnection.getState() == ManagerConnectionState.CONNECTED || eventConnection.getState() == ManagerConnectionState.RECONNECTING))
+        {
+            try
+            {
+                eventConnection.logoff();
+            }
+            catch (Exception ignore)
+            {
+            }
         }
-				
-        if (managerEventListenerProxy != null) {
-						if (eventConnection != null) {
-							eventConnection.removeEventListener(managerEventListenerProxy);
-						}
+
+        if (managerEventListenerProxy != null)
+        {
+            if (eventConnection != null)
+            {
+                eventConnection.removeEventListener(managerEventListenerProxy);
+            }
             managerEventListenerProxy.shutdown();
         }
 
-		if (eventConnection != null && eventListener != null) {
-		    	eventConnection.removeEventListener(eventListener);
-	    }
+        if (eventConnection != null && eventListener != null)
+        {
+            eventConnection.removeEventListener(eventListener);
+        }
 
-		managerEventListenerProxy = null;
+        managerEventListenerProxy = null;
         eventListener = null;
 
-	    if (initialized) {//incredible, but it happened
-	    	handleDisconnectEvent(null);
-	    }//i
-    }//shutdown
+        if (initialized)
+        {// incredible, but it happened
+            handleDisconnectEvent(null);
+        }// i
+    }// shutdown
 
     public List<PeerEntryEvent> getPeerEntries() throws ManagerCommunicationException
     {
@@ -1394,7 +1397,8 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
 
     public void dbDel(String family, String key) throws ManagerCommunicationException
     {
-        // The following only works with BRIStuffed asrterisk: sendAction(new DbDelAction(family,key));
+        // The following only works with BRIStuffed asrterisk: sendAction(new
+        // DbDelAction(family,key));
         // Use cli command instead ...
         sendAction(new CommandAction("database del " + family + " " + key));
     }
@@ -1454,12 +1458,14 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
 
     /* OCTAVIO LUNA */
     @Override
-    public void forceQueuesMonitor(boolean force) {
-    	queueManager.forceQueuesMonitor(force);
+    public void forceQueuesMonitor(boolean force)
+    {
+        queueManager.forceQueuesMonitor(force);
     }
 
     @Override
-    public boolean isQueuesMonitorForced() {
-    	return queueManager.isQueuesMonitorForced();
+    public boolean isQueuesMonitorForced()
+    {
+        return queueManager.isQueuesMonitorForced();
     }
 }

--- a/src/main/java/org/asteriskjava/live/internal/AsteriskServerImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskServerImpl.java
@@ -1332,14 +1332,8 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
                 }
             }
 
-            if (channel.wasInState(ChannelState.DOWN))
-            {
-                cb.onNoAnswer(channel);
-                return;
-            }
-
-            // if nothing else matched we asume success
-            cb.onSuccess(channel);
+            // if nothing else matched we asume no answer
+            cb.onNoAnswer(channel);
         }
         catch (Throwable t)
         {

--- a/src/main/java/org/asteriskjava/live/internal/MeetMeManager.java
+++ b/src/main/java/org/asteriskjava/live/internal/MeetMeManager.java
@@ -226,6 +226,10 @@ class MeetMeManager
 
             userNumber = Integer.valueOf(matcher.group(1));
             channel = channelManager.getChannelImplByName(matcher.group(2));
+			if(channel == null)	// User has left the room already in the meanwhile
+			{
+				continue;
+			}
 
             userNumbers.add(userNumber);
 

--- a/src/main/java/org/asteriskjava/live/internal/MeetMeManager.java
+++ b/src/main/java/org/asteriskjava/live/internal/MeetMeManager.java
@@ -74,11 +74,8 @@ class MeetMeManager
     void disconnected()
     {
         /*
-        synchronized (rooms)
-        {
-            rooms.clear();
-        }
-        */
+         * synchronized (rooms) { rooms.clear(); }
+         */
     }
 
     Collection<MeetMeRoom> getMeetMeRooms()
@@ -147,7 +144,8 @@ class MeetMeManager
                             + " but is user of no room");
                 }
             }
-            // Mmmm should remove from the room before firing PropertyChangeEvents ?
+            // Mmmm should remove from the room before firing
+            // PropertyChangeEvents ?
             user.left(event.getDateReceived());
             room.removeUser(user);
             channel.setMeetMeUserImpl(null);
@@ -183,7 +181,13 @@ class MeetMeManager
         final CommandAction meetMeListAction;
         final ManagerResponse response;
         final List<String> lines;
-        final Collection<Integer> userNumbers = new ArrayList<Integer>(); // list of user numbers in the room
+        final Collection<Integer> userNumbers = new ArrayList<Integer>(); // list
+                                                                          // of
+                                                                          // user
+                                                                          // numbers
+                                                                          // in
+                                                                          // the
+                                                                          // room
 
         meetMeListAction = new CommandAction(MEETME_LIST_COMMAND + " " + room.getRoomNumber());
         try
@@ -226,10 +230,11 @@ class MeetMeManager
 
             userNumber = Integer.valueOf(matcher.group(1));
             channel = channelManager.getChannelImplByName(matcher.group(2));
-			if(channel == null)	// User has left the room already in the meanwhile
-			{
-				continue;
-			}
+            if (channel == null) // User has left the room already in the
+                                 // meanwhile
+            {
+                continue;
+            }
 
             userNumbers.add(userNumber);
 

--- a/src/main/java/org/asteriskjava/manager/event/AbstractChannelEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AbstractChannelEvent.java
@@ -38,7 +38,7 @@ public abstract class AbstractChannelEvent extends ManagerEvent
      * The unique id of the channel.
      */
     private String uniqueId;
-    
+
     protected AbstractChannelEvent(Object source)
     {
         super(source);
@@ -75,13 +75,15 @@ public abstract class AbstractChannelEvent extends ManagerEvent
     }
 
     /**
-     * Returns the Caller*ID of the channel if set or <code>null</code> if none has been set.
+     * Returns the Caller*ID of the channel if set or <code>null</code> if none
+     * has been set.
      *
      * @return the Caller*ID
      * @deprecated
      * @see #getCallerIdNum()
      */
-    @Deprecated public final String getCallerId()
+    @Deprecated
+    public final String getCallerId()
     {
         return getCallerIdNum();
     }
@@ -92,9 +94,10 @@ public abstract class AbstractChannelEvent extends ManagerEvent
      * @param callerId the Caller*ID of the channel.
      * @deprecated
      */
-    @Deprecated public final void setCallerId(String callerId)
+    @Deprecated
+    public final void setCallerId(String callerId)
     {
-       setCallerIdNum(callerId);
+        setCallerIdNum(callerId);
     }
-    
+
 }

--- a/src/main/java/org/asteriskjava/manager/event/AbstractChannelEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AbstractChannelEvent.java
@@ -35,23 +35,10 @@ public abstract class AbstractChannelEvent extends ManagerEvent
     private String channel;
 
     /**
-     * This Caller*ID Number of the channel.
-     */
-    private String callerIdNum;
-
-    /**
-     * The Caller*ID Name of the channel.
-     */
-    private String callerIdName;
-
-    /**
      * The unique id of the channel.
      */
     private String uniqueId;
     
-    private String connectedlinenum;
-    private String connectedlinename;
-
     protected AbstractChannelEvent(Object source)
     {
         super(source);
@@ -96,7 +83,7 @@ public abstract class AbstractChannelEvent extends ManagerEvent
      */
     @Deprecated public final String getCallerId()
     {
-        return callerIdNum;
+        return getCallerIdNum();
     }
 
     /**
@@ -107,58 +94,7 @@ public abstract class AbstractChannelEvent extends ManagerEvent
      */
     @Deprecated public final void setCallerId(String callerId)
     {
-        this.callerIdNum = callerId;
+       setCallerIdNum(callerId);
     }
-
-    /**
-     * Returns the Caller*ID number of the channel if set or <code>null</code> if none has been set.
-     *
-     * @return the Caller*ID number
-     * @since 0.3
-     */
-    public final String getCallerIdNum()
-    {
-        return callerIdNum;
-    }
-
-    public final void setCallerIdNum(String callerIdNum)
-    {
-        this.callerIdNum = callerIdNum;
-    }
-
-    /**
-     * Returns the Caller*ID Name of the channel if set or <code>null</code> if none has been set.
-     * 
-     * @return the Caller*ID Name of the channel.
-     */
-    public final String getCallerIdName()
-    {
-        return callerIdName;
-    }
-
-    public final void setCallerIdName(String callerIdName)
-    {
-        this.callerIdName = callerIdName;
-    }
-
-	public String getConnectedlinenum()
-	{
-		return connectedlinenum;
-	}
-
-	public void setConnectedlinenum(String connectedlinenum)
-	{
-		this.connectedlinenum = connectedlinenum;
-	}
-
-	public String getConnectedlinename()
-	{
-		return connectedlinename;
-	}
-
-	public void setConnectedlinename(String connectedlinename)
-	{
-		this.connectedlinename = connectedlinename;
-	}
     
 }

--- a/src/main/java/org/asteriskjava/manager/event/AbstractChannelStateEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AbstractChannelStateEvent.java
@@ -27,110 +27,108 @@ import org.asteriskjava.util.AstState;
  */
 public abstract class AbstractChannelStateEvent extends AbstractChannelEvent
 {
-	/**
-	 * Serializable version identifier.
-	 */
-	static final long serialVersionUID = 0L;
+    /**
+     * Serializable version identifier.
+     */
+    static final long serialVersionUID = 0L;
 
-	private Integer channelState;
-	private String channelStateDesc;
+    private Integer channelState;
+    private String channelStateDesc;
 
-	protected AbstractChannelStateEvent(Object source)
-	{
-		super(source);
-	}
+    protected AbstractChannelStateEvent(Object source)
+    {
+        super(source);
+    }
 
-	/**
-	 * Returns the new state of the channel.
-	 * <p>
-	 * For Asterisk versions prior to 1.6 (that do not send the numeric value)
-	 * it is derived from the descriptive text.
-	 *
-	 * @return the new state of the channel.
-	 * @since 1.0.0
-	 */
-	@Override
-	public Integer getChannelState()
-	{
-		return channelState == null ? AstState.str2state(channelStateDesc) : channelState;
-	}
+    /**
+     * Returns the new state of the channel.
+     * <p>
+     * For Asterisk versions prior to 1.6 (that do not send the numeric value)
+     * it is derived from the descriptive text.
+     *
+     * @return the new state of the channel.
+     * @since 1.0.0
+     */
+    @Override
+    public Integer getChannelState()
+    {
+        return channelState == null ? AstState.str2state(channelStateDesc) : channelState;
+    }
 
-	/**
-	 * Sets the new state of the channel.
-	 *
-	 * @param channelState
-	 *            the new state of the channel.
-	 * @since 1.0.0
-	 */
-	@Override
-	public void setChannelState(Integer channelState)
-	{
-		this.channelState = channelState;
-	}
+    /**
+     * Sets the new state of the channel.
+     *
+     * @param channelState the new state of the channel.
+     * @since 1.0.0
+     */
+    @Override
+    public void setChannelState(Integer channelState)
+    {
+        this.channelState = channelState;
+    }
 
-	/**
-	 * Returns the new state of the channel as a descriptive text.
-	 * <p>
-	 * The following states are used:
-	 * <p>
-	 * <ul>
-	 * <li>Down</li>
-	 * <li>Rsrvd</li>
-	 * <li>OffHook</li>
-	 * <li>Dialing</li>
-	 * <li>Ring</li>
-	 * <li>Ringing</li>
-	 * <li>Up</li>
-	 * <li>Busy</li>
-	 * <li>Dialing Offhook (since Asterik 1.6)</li>
-	 * <li>Pre-ring (since Asterik 1.6)</li>
-	 * </ul>
-	 *
-	 * @return the new state of the channel as a descriptive text.
-	 * @since 1.0.0
-	 */
-	public String getChannelStateDesc()
-	{
-		return channelStateDesc;
-	}
+    /**
+     * Returns the new state of the channel as a descriptive text.
+     * <p>
+     * The following states are used:
+     * <p>
+     * <ul>
+     * <li>Down</li>
+     * <li>Rsrvd</li>
+     * <li>OffHook</li>
+     * <li>Dialing</li>
+     * <li>Ring</li>
+     * <li>Ringing</li>
+     * <li>Up</li>
+     * <li>Busy</li>
+     * <li>Dialing Offhook (since Asterik 1.6)</li>
+     * <li>Pre-ring (since Asterik 1.6)</li>
+     * </ul>
+     *
+     * @return the new state of the channel as a descriptive text.
+     * @since 1.0.0
+     */
+    public String getChannelStateDesc()
+    {
+        return channelStateDesc;
+    }
 
-	/**
-	 * Sets the new state of the channel as a descriptive text.
-	 *
-	 * @param channelStateDesc
-	 *            the new state of the channel as a descriptive text.
-	 * @since 1.0.0
-	 */
-	public void setChannelStateDesc(String channelStateDesc)
-	{
-		this.channelStateDesc = channelStateDesc;
-	}
+    /**
+     * Sets the new state of the channel as a descriptive text.
+     *
+     * @param channelStateDesc the new state of the channel as a descriptive
+     *            text.
+     * @since 1.0.0
+     */
+    public void setChannelStateDesc(String channelStateDesc)
+    {
+        this.channelStateDesc = channelStateDesc;
+    }
 
-	/**
-	 * Returns the new state of the channel as a descriptive text. <br>
-	 * This is an alias for {@link #getChannelStateDesc()}.
-	 *
-	 * @return the new state of the channel as a descriptive text.
-	 * @deprecated as of 1.0.0, use {@link #getChannelStateDesc()} instead or
-	 *             even better switch to numeric values as returned by
-	 *             {@link #getChannelState()}.
-	 */
-	@Deprecated
-	public String getState()
-	{
-		return channelStateDesc;
-	}
+    /**
+     * Returns the new state of the channel as a descriptive text. <br>
+     * This is an alias for {@link #getChannelStateDesc()}.
+     *
+     * @return the new state of the channel as a descriptive text.
+     * @deprecated as of 1.0.0, use {@link #getChannelStateDesc()} instead or
+     *             even better switch to numeric values as returned by
+     *             {@link #getChannelState()}.
+     */
+    @Deprecated
+    public String getState()
+    {
+        return channelStateDesc;
+    }
 
-	/**
-	 * Sets the new state of the channel as a descriptive text.
-	 * <p>
-	 * The state property is used by Asterisk versions prior to 1.6.
-	 *
-	 * @param state
-	 *            the new state of the channel as a descriptive text.
-	 */
-	public void setState(String state)
-	{
-		this.channelStateDesc = state;
-	}
+    /**
+     * Sets the new state of the channel as a descriptive text.
+     * <p>
+     * The state property is used by Asterisk versions prior to 1.6.
+     *
+     * @param state the new state of the channel as a descriptive text.
+     */
+    public void setState(String state)
+    {
+        this.channelStateDesc = state;
+    }
 }

--- a/src/main/java/org/asteriskjava/manager/event/AbstractChannelStateEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AbstractChannelStateEvent.java
@@ -34,32 +34,10 @@ public abstract class AbstractChannelStateEvent extends AbstractChannelEvent
 
 	private Integer channelState;
 	private String channelStateDesc;
-	private String connectedlinename;
-	private String connectedlinenum;
 
 	protected AbstractChannelStateEvent(Object source)
 	{
 		super(source);
-	}
-
-	public String getConnectedlinename()
-	{
-		return connectedlinename;
-	}
-
-	public void setConnectedlinename(String connectedlinename)
-	{
-		this.connectedlinename = connectedlinename;
-	}
-
-	public String getConnectedlinenum()
-	{
-		return connectedlinenum;
-	}
-
-	public void setConnectedlinenum(String connectedlinenum)
-	{
-		this.connectedlinenum = connectedlinenum;
 	}
 
 	/**
@@ -71,6 +49,7 @@ public abstract class AbstractChannelStateEvent extends AbstractChannelEvent
 	 * @return the new state of the channel.
 	 * @since 1.0.0
 	 */
+	@Override
 	public Integer getChannelState()
 	{
 		return channelState == null ? AstState.str2state(channelStateDesc) : channelState;
@@ -83,6 +62,7 @@ public abstract class AbstractChannelStateEvent extends AbstractChannelEvent
 	 *            the new state of the channel.
 	 * @since 1.0.0
 	 */
+	@Override
 	public void setChannelState(Integer channelState)
 	{
 		this.channelState = channelState;

--- a/src/main/java/org/asteriskjava/manager/event/AbstractHoldEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AbstractHoldEvent.java
@@ -1,0 +1,155 @@
+package org.asteriskjava.manager.event;
+
+/**
+ * A HoldEvent is triggered when a channel is put on hold (or no longer on hold).<p>
+ * It is implemented in <code>channels/chan_sip.c</code>.<p>
+ * Available since Asterisk 1.2 for SIP channels, as of Asterisk 1.6 this event
+ * is also supported for IAX2 channels.<p>
+ * To receive HoldEvents for SIP channels you must set <code>callevents = yes</code>
+ * in <code>sip.conf</code>.
+ *
+ * @author enro
+ * @version $Id$
+ * @since 1.0.0.10
+ */
+public class AbstractHoldEvent extends ManagerEvent
+{
+    /**
+     * Serializable version identifier.
+     */
+    private static final long serialVersionUID = 0L;
+
+    /**
+     * The name of the channel.
+     */
+    private String channel;
+    
+    private String callerIDNum;
+    private String callerIDName;
+    private String accountCode;
+
+    /**
+     * The unique id of the channel.
+     */
+    private String uniqueId;
+
+    private Boolean status;
+
+    /**
+     * Creates a new HoldEvent.
+     *
+     * @param source
+     */
+    public AbstractHoldEvent(Object source)
+    {
+        super(source);
+    }
+
+    /**
+     * Returns the name of the channel.
+     *
+     * @return channel the name of the channel.
+     */
+    public String getChannel()
+    {
+        return channel;
+    }
+
+    /**
+     * Sets the name of the channel.
+     *
+     * @param channel the name of the channel.
+     */
+    public void setChannel(String channel)
+    {
+        this.channel = channel;
+    }
+
+    /**
+     * Returns the unique id of the channel.
+     *
+     * @return the unique id of the channel.
+     */
+    public String getUniqueId()
+    {
+        return uniqueId;
+    }
+
+    /**
+     * Sets the unique id of the channel.
+     *
+     * @param uniqueId the unique id of the channel.
+     */
+    public void setUniqueId(String uniqueId)
+    {
+        this.uniqueId = uniqueId;
+    }
+
+    /**
+     * Returns whether this is a hold or unhold event.
+     *
+     * @return <code>true</code> if this a hold event, <code>false</code> if it's an unhold event.
+     * @since 1.0.0
+     */
+    public Boolean getStatus()
+    {
+        return status;
+    }
+
+    /**
+     * Returns whether this is a hold or unhold event.
+     *
+     * @param status <code>true</code> if this a hold event, <code>false</code> if it's an unhold event.
+     * @since 1.0.0
+     */
+    public void setStatus(Boolean status)
+    {
+        this.status = status;
+    }
+
+    /**
+     * Returns whether this is a hold event.
+     *
+     * @return <code>true</code> if this a hold event, <code>false</code> if it's an unhold event.
+     * @since 1.0.0
+     */
+    public boolean isHold()
+    {
+        return status != null && status;
+    }
+
+    /**
+     * Returns whether this is an unhold event.
+     *
+     * @return <code>true</code> if this an unhold event, <code>false</code> if it's a hold event.
+     * @since 1.0.0
+     */
+    public boolean isUnhold()
+    {
+        return status != null && !status;
+    }
+
+	public String getCallerIDNum() {
+		return callerIDNum;
+	}
+
+	public void setCallerIDNum(String callerIDNum) {
+		this.callerIDNum = callerIDNum;
+	}
+
+	public String getCallerIDName() {
+		return callerIDName;
+	}
+
+	public void setCallerIDName(String callerIDName) {
+		this.callerIDName = callerIDName;
+	}
+
+	public String getAccountCode() {
+		return accountCode;
+	}
+
+	public void setAccountCode(String accountCode) {
+		this.accountCode = accountCode;
+	}
+}

--- a/src/main/java/org/asteriskjava/manager/event/AbstractHoldEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AbstractHoldEvent.java
@@ -1,12 +1,16 @@
 package org.asteriskjava.manager.event;
 
 /**
- * A HoldEvent is triggered when a channel is put on hold (or no longer on hold).<p>
- * It is implemented in <code>channels/chan_sip.c</code>.<p>
+ * A HoldEvent is triggered when a channel is put on hold (or no longer on
+ * hold).
+ * <p>
+ * It is implemented in <code>channels/chan_sip.c</code>.
+ * <p>
  * Available since Asterisk 1.2 for SIP channels, as of Asterisk 1.6 this event
- * is also supported for IAX2 channels.<p>
- * To receive HoldEvents for SIP channels you must set <code>callevents = yes</code>
- * in <code>sip.conf</code>.
+ * is also supported for IAX2 channels.
+ * <p>
+ * To receive HoldEvents for SIP channels you must set
+ * <code>callevents = yes</code> in <code>sip.conf</code>.
  *
  * @author enro
  * @version $Id$
@@ -23,7 +27,7 @@ public class AbstractHoldEvent extends ManagerEvent
      * The name of the channel.
      */
     private String channel;
-    
+
     private String callerIDNum;
     private String callerIDName;
     private String accountCode;
@@ -88,7 +92,8 @@ public class AbstractHoldEvent extends ManagerEvent
     /**
      * Returns whether this is a hold or unhold event.
      *
-     * @return <code>true</code> if this a hold event, <code>false</code> if it's an unhold event.
+     * @return <code>true</code> if this a hold event, <code>false</code> if
+     *         it's an unhold event.
      * @since 1.0.0
      */
     public Boolean getStatus()
@@ -99,7 +104,8 @@ public class AbstractHoldEvent extends ManagerEvent
     /**
      * Returns whether this is a hold or unhold event.
      *
-     * @param status <code>true</code> if this a hold event, <code>false</code> if it's an unhold event.
+     * @param status <code>true</code> if this a hold event, <code>false</code>
+     *            if it's an unhold event.
      * @since 1.0.0
      */
     public void setStatus(Boolean status)
@@ -110,7 +116,8 @@ public class AbstractHoldEvent extends ManagerEvent
     /**
      * Returns whether this is a hold event.
      *
-     * @return <code>true</code> if this a hold event, <code>false</code> if it's an unhold event.
+     * @return <code>true</code> if this a hold event, <code>false</code> if
+     *         it's an unhold event.
      * @since 1.0.0
      */
     public boolean isHold()
@@ -121,7 +128,8 @@ public class AbstractHoldEvent extends ManagerEvent
     /**
      * Returns whether this is an unhold event.
      *
-     * @return <code>true</code> if this an unhold event, <code>false</code> if it's a hold event.
+     * @return <code>true</code> if this an unhold event, <code>false</code> if
+     *         it's a hold event.
      * @since 1.0.0
      */
     public boolean isUnhold()
@@ -129,27 +137,33 @@ public class AbstractHoldEvent extends ManagerEvent
         return status != null && !status;
     }
 
-	public String getCallerIDNum() {
-		return callerIDNum;
-	}
+    public String getCallerIDNum()
+    {
+        return callerIDNum;
+    }
 
-	public void setCallerIDNum(String callerIDNum) {
-		this.callerIDNum = callerIDNum;
-	}
+    public void setCallerIDNum(String callerIDNum)
+    {
+        this.callerIDNum = callerIDNum;
+    }
 
-	public String getCallerIDName() {
-		return callerIDName;
-	}
+    public String getCallerIDName()
+    {
+        return callerIDName;
+    }
 
-	public void setCallerIDName(String callerIDName) {
-		this.callerIDName = callerIDName;
-	}
+    public void setCallerIDName(String callerIDName)
+    {
+        this.callerIDName = callerIDName;
+    }
 
-	public String getAccountCode() {
-		return accountCode;
-	}
+    public String getAccountCode()
+    {
+        return accountCode;
+    }
 
-	public void setAccountCode(String accountCode) {
-		this.accountCode = accountCode;
-	}
+    public void setAccountCode(String accountCode)
+    {
+        this.accountCode = accountCode;
+    }
 }

--- a/src/main/java/org/asteriskjava/manager/event/AbstractMeetMeEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AbstractMeetMeEvent.java
@@ -30,7 +30,7 @@ public abstract class AbstractMeetMeEvent extends ManagerEvent
 	private String channel;
     private String uniqueId;
     private String meetMe;
-    private Integer userNum;
+    private Integer user;
 
     /**
      * @param source
@@ -110,9 +110,10 @@ public abstract class AbstractMeetMeEvent extends ManagerEvent
      * 
      * @return the index of the user in the conference.
      */
+    @Deprecated
     public Integer getUserNum()
     {
-        return userNum;
+        return getUser();
     }
 
     /**
@@ -120,8 +121,30 @@ public abstract class AbstractMeetMeEvent extends ManagerEvent
      * 
      * @param userNum the index of the user in the conference.
      */
+    @Deprecated
     public void setUserNum(Integer userNum)
     {
-        this.userNum = userNum;
+        this.setUser(userNum);
+    }
+    
+    /**
+     * Returns the index of the user in the conference.<p>
+     * This can be used for the "meetme (mute|unmute|kick)" commands.
+     * 
+     * @return the index of the user in the conference.
+     */
+    public Integer getUser()
+    {
+    	return user;
+    }
+    
+    /**
+     * Sets the index of the user in the conference.
+     * 
+     * @param userNum the index of the user in the conference.
+     */
+    public void setUser(Integer userNum)
+    {
+    	this.user = userNum;
     }
 }

--- a/src/main/java/org/asteriskjava/manager/event/AbstractMeetMeEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AbstractMeetMeEvent.java
@@ -17,8 +17,9 @@
 package org.asteriskjava.manager.event;
 
 /**
- * Abstract base class providing common properties for MeetMe
- * (Asterisk's conference system) events.<p>
+ * Abstract base class providing common properties for MeetMe (Asterisk's
+ * conference system) events.
+ * <p>
  * MeetMe events are implemented in <code>apps/app_meetme.c</code>
  * 
  * @author srt
@@ -26,8 +27,8 @@ package org.asteriskjava.manager.event;
  */
 public abstract class AbstractMeetMeEvent extends ManagerEvent
 {
-	private static final long serialVersionUID = 1L;
-	private String channel;
+    private static final long serialVersionUID = 1L;
+    private String channel;
     private String uniqueId;
     private String meetMe;
     private Integer user;
@@ -41,7 +42,8 @@ public abstract class AbstractMeetMeEvent extends ManagerEvent
     }
 
     /**
-     * Returns the name of the channel.<p>
+     * Returns the name of the channel.
+     * <p>
      * This property is available since Asterisk 1.4.
      * 
      * @return the name of the channel.
@@ -52,7 +54,8 @@ public abstract class AbstractMeetMeEvent extends ManagerEvent
     }
 
     /**
-     * Sets the name of the channel.<p>
+     * Sets the name of the channel.
+     * <p>
      * This property is available since Asterisk 1.4.
      * 
      * @param channel the name of the channel.
@@ -63,7 +66,8 @@ public abstract class AbstractMeetMeEvent extends ManagerEvent
     }
 
     /**
-     * Returns the unique id of the channel.<p>
+     * Returns the unique id of the channel.
+     * <p>
      * This property is available since Asterisk 1.4.
      * 
      * @return the unique id of the channel.
@@ -74,7 +78,8 @@ public abstract class AbstractMeetMeEvent extends ManagerEvent
     }
 
     /**
-     * Sets the unique id of the channel.<p>
+     * Sets the unique id of the channel.
+     * <p>
      * This property is available since Asterisk 1.4.
      * 
      * @param uniqueId the unique id of the channel.
@@ -105,7 +110,8 @@ public abstract class AbstractMeetMeEvent extends ManagerEvent
     }
 
     /**
-     * Returns the index of the user in the conference.<p>
+     * Returns the index of the user in the conference.
+     * <p>
      * This can be used for the "meetme (mute|unmute|kick)" commands.
      * 
      * @return the index of the user in the conference.
@@ -126,18 +132,19 @@ public abstract class AbstractMeetMeEvent extends ManagerEvent
     {
         this.setUser(userNum);
     }
-    
+
     /**
-     * Returns the index of the user in the conference.<p>
+     * Returns the index of the user in the conference.
+     * <p>
      * This can be used for the "meetme (mute|unmute|kick)" commands.
      * 
      * @return the index of the user in the conference.
      */
     public Integer getUser()
     {
-    	return user;
+        return user;
     }
-    
+
     /**
      * Sets the index of the user in the conference.
      * 
@@ -145,6 +152,6 @@ public abstract class AbstractMeetMeEvent extends ManagerEvent
      */
     public void setUser(Integer userNum)
     {
-    	this.user = userNum;
+        this.user = userNum;
     }
 }

--- a/src/main/java/org/asteriskjava/manager/event/AbstractParkedCallEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AbstractParkedCallEvent.java
@@ -26,46 +26,53 @@ package org.asteriskjava.manager.event;
 public abstract class AbstractParkedCallEvent extends ManagerEvent
 {
     private static final long serialVersionUID = 0L;
-    private String exten;
-    private String channel;
-    private String parkingLot;
-    private String callerIdNum;
-    private String callerIdName;
     private String uniqueId;
+    // Previously: Channel
+    private String parkeeChannel;
+    private Integer parkeeChannelState;
+    private String parkeeChannelStateDesc;
+    // previously CallerID
+    private String parkeeCallerIDNum;
+    // Previously CallerIDName
+    private String parkeeCallerIDName;
+    private Integer parkeeConnectedLineNum;
+    private String parkeeConnectedLineName;
+    private String parkeeLanguage;
+    private String parkeeAccountCode; 
+    private String parkeeContext;
+    private String parkeeExten;
+    private Integer parkeePriority;
+    private String parkeeUniqueid;
+    // Previously: From
+    private String parkerDialString;
+    private String parkingLot;
+    // previously Exten
+    private String parkingSpace;
+    private Long parkingTimeout;
+    private Long parkingDuration;
 
     protected AbstractParkedCallEvent(Object source)
     {
         super(source);
     }
 
-    /**
-     * Returns the extension the channel is or was parked at.
-     *
-     * @return the extension the channel is or was parked at.
-     */
-    public String getExten()
-    {
-        return exten;
-    }
 
-    public void setExten(String exten)
+    /**
+     * Returns the name of the channel that parked the call.
+     */
+    @Deprecated
+    public String getFrom()
     {
-        this.exten = exten;
+        return getParkerDialString();
     }
 
     /**
-     * Returns the name of the channel that is or was parked.
-     *
-     * @return the name of the channel that is or was parked.
+     * Sets the name of the channel that parked the call.
      */
-    public String getChannel()
+    @Deprecated
+    public void setFrom(String from)
     {
-        return channel;
-    }
-
-    public void setChannel(String channel)
-    {
-        this.channel = channel;
+        this.setParkerDialString(from);
     }
 
     /**
@@ -96,50 +103,16 @@ public abstract class AbstractParkedCallEvent extends ManagerEvent
      * @return the Caller*ID number of the parked channel.
      * @since 1.0.0
      */
+    @Override
     public String getCallerIdNum()
     {
-        return callerIdNum;
+        return getParkeeCallerIDNum();
     }
 
+    @Override
     public void setCallerIdNum(String callerIdNum)
     {
-        this.callerIdNum = callerIdNum;
-    }
-
-    /**
-     * Returns the Caller*ID number of the parked channel.
-     *
-     * @return the Caller*ID number of the parked channel.
-     * @deprecated since 1.0.0. Use {@link #getCallerIdNum()} instead.
-     */
-    @Deprecated public String getCallerId()
-    {
-        return callerIdNum;
-    }
-
-    public void setCallerId(String callerId)
-    {
-        this.callerIdNum = callerId;
-    }
-
-    /**
-     * Returns the Caller*ID name of the parked channel.
-     *
-     * @return the Caller*ID name of the parked channel.
-     */
-    public String getCallerIdName()
-    {
-        return callerIdName;
-    }
-
-    /**
-     * Sets the Caller*ID name of the parked channel.
-     *
-     * @param callerIdName the Caller*ID name of the parked channel.
-     */
-    public void setCallerIdName(String callerIdName)
-    {
-        this.callerIdName = callerIdName;
+        this.setParkeeCallerIDNum(callerIdNum);
     }
 
     /**
@@ -161,4 +134,188 @@ public abstract class AbstractParkedCallEvent extends ManagerEvent
     {
         this.uniqueId = uniqueId;
     }
+    
+    @Deprecated
+    public void setChannel(String channel) {
+    	this.setParkeeChannel(channel);
+    }
+    
+    @Deprecated
+    public String getChannel() {
+    	return this.getParkeeChannel();
+    }
+
+	public String getParkeeChannel() {
+		return parkeeChannel;
+	}
+
+	public void setParkeeChannel(String parkeeChannel) {
+		this.parkeeChannel = parkeeChannel;
+	}
+
+	public Integer getParkeeChannelState() {
+		return parkeeChannelState;
+	}
+
+	public void setParkeeChannelState(Integer parkeeChannelState) {
+		this.parkeeChannelState = parkeeChannelState;
+	}
+
+	public String getParkeeChannelStateDesc() {
+		return parkeeChannelStateDesc;
+	}
+
+	public void setParkeeChannelStateDesc(String parkeeChannelStateDesc) {
+		this.parkeeChannelStateDesc = parkeeChannelStateDesc;
+	}
+
+	public String getParkeeCallerIDNum() {
+		return parkeeCallerIDNum;
+	}
+
+	public void setParkeeCallerIDNum(String parkeeCallerIDNum) {
+		this.parkeeCallerIDNum = parkeeCallerIDNum;
+	}
+
+	public String getParkeeCallerIDName() {
+		return parkeeCallerIDName;
+	}
+
+	public void setParkeeCallerIDName(String parkeeCallerIDName) {
+		this.parkeeCallerIDName = parkeeCallerIDName;
+	}
+
+	public Integer getParkeeConnectedLineNum() {
+		return parkeeConnectedLineNum;
+	}
+
+	public void setParkeeConnectedLineNum(Integer parkeeConnectedLineNum) {
+		this.parkeeConnectedLineNum = parkeeConnectedLineNum;
+	}
+
+	public String getParkeeConnectedLineName() {
+		return parkeeConnectedLineName;
+	}
+
+	public void setParkeeConnectedLineName(String parkeeConnectedLineName) {
+		this.parkeeConnectedLineName = parkeeConnectedLineName;
+	}
+
+	public String getParkeeLanguage() {
+		return parkeeLanguage;
+	}
+
+	public void setParkeeLanguage(String parkeeLanguage) {
+		this.parkeeLanguage = parkeeLanguage;
+	}
+
+	public String getParkeeAccountCode() {
+		return parkeeAccountCode;
+	}
+
+	public void setParkeeAccountCode(String parkeeAccountCode) {
+		this.parkeeAccountCode = parkeeAccountCode;
+	}
+
+	public String getParkeeContext() {
+		return parkeeContext;
+	}
+
+	public void setParkeeContext(String parkeeContext) {
+		this.parkeeContext = parkeeContext;
+	}
+
+	public String getParkeeExten() {
+		return parkeeExten;
+	}
+
+	public void setParkeeExten(String parkeeExten) {
+		this.parkeeExten = parkeeExten;
+	}
+
+	public Integer getParkeePriority() {
+		return parkeePriority;
+	}
+
+	public void setParkeePriority(Integer parkeePriority) {
+		this.parkeePriority = parkeePriority;
+	}
+
+	public String getParkeeUniqueid() {
+		return parkeeUniqueid;
+	}
+
+	public void setParkeeUniqueid(String parkeeUniqueid) {
+		this.parkeeUniqueid = parkeeUniqueid;
+	}
+
+	public String getParkerDialString() {
+		return parkerDialString;
+	}
+
+	public void setParkerDialString(String parkerDialString) {
+		this.parkerDialString = parkerDialString;
+	}
+
+	public String getParkinglot() {
+		return parkingLot;
+	}
+
+	public void setParkinglot(String parkinglot) {
+		this.parkingLot = parkinglot;
+	}
+
+	public String getParkingSpace() {
+		return parkingSpace;
+	}
+
+	public void setParkingSpace(String parkingSpace) {
+		this.parkingSpace = parkingSpace;
+	}
+
+	public Long getParkingTimeout() {
+		return parkingTimeout;
+	}
+
+	public void setParkingTimeout(Long parkingTimeout) {
+		this.parkingTimeout = parkingTimeout;
+	}
+
+	public Long getParkingDuration() {
+		return parkingDuration;
+	}
+
+	public void setParkingDuration(Long parkingDuration) {
+		this.parkingDuration = parkingDuration;
+	}
+
+	@Deprecated
+	public String getCallerId() {
+		return getParkeeCallerIDNum();
+	}
+	
+	@Deprecated
+	public void setCallerId(String callerId) {
+		setParkeeCallerIDNum(callerId);
+	}
+	
+	@Deprecated
+	public String getCallerIdName() {
+		return getParkeeCallerIDName();
+	}
+	
+	@Deprecated
+	public void setCallerIdName(String callerIdName) {
+		setParkeeCallerIDName(callerIdName);
+	}
+
+	@Deprecated
+	public String getExten() {
+		return getParkingSpace();
+	}
+	
+	@Deprecated
+	public void setExten(String exten) {
+		setParkingSpace(exten);
+	}
 }

--- a/src/main/java/org/asteriskjava/manager/event/AbstractParkedCallEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AbstractParkedCallEvent.java
@@ -38,7 +38,7 @@ public abstract class AbstractParkedCallEvent extends ManagerEvent
     private Integer parkeeConnectedLineNum;
     private String parkeeConnectedLineName;
     private String parkeeLanguage;
-    private String parkeeAccountCode; 
+    private String parkeeAccountCode;
     private String parkeeContext;
     private String parkeeExten;
     private Integer parkeePriority;
@@ -55,7 +55,6 @@ public abstract class AbstractParkedCallEvent extends ManagerEvent
     {
         super(source);
     }
-
 
     /**
      * Returns the name of the channel that parked the call.
@@ -76,7 +75,8 @@ public abstract class AbstractParkedCallEvent extends ManagerEvent
     }
 
     /**
-     * Returns the parking lot.<p>
+     * Returns the parking lot.
+     * <p>
      * Available since Asterisk 1.6.
      *
      * @return the parking lot.
@@ -116,12 +116,15 @@ public abstract class AbstractParkedCallEvent extends ManagerEvent
     }
 
     /**
-     * Returns the unique id of the parked channel.<p>
+     * Returns the unique id of the parked channel.
+     * <p>
      * Note: This property is not set properly by all versions of Asterisk, see
-     * <a href="http://bugs.digium.com/view.php?id=13323">http://bugs.digium.com/view.php?id=13323</a>
-     * and
-     * <a href="http://bugs.digium.com/view.php?id=13358">http://bugs.digium.com/view.php?id=13358</a>
-     * for more information. Use {@link #getChannel()} instead.
+     * <a
+     * href="http://bugs.digium.com/view.php?id=13323">http://bugs.digium.com/
+     * view.php?id=13323</a> and <a
+     * href="http://bugs.digium.com/view.php?id=13358"
+     * >http://bugs.digium.com/view.php?id=13358</a> for more information. Use
+     * {@link #getChannel()} instead.
      *
      * @return the unique id of the parked channel.
      */
@@ -134,188 +137,232 @@ public abstract class AbstractParkedCallEvent extends ManagerEvent
     {
         this.uniqueId = uniqueId;
     }
-    
+
     @Deprecated
-    public void setChannel(String channel) {
-    	this.setParkeeChannel(channel);
-    }
-    
-    @Deprecated
-    public String getChannel() {
-    	return this.getParkeeChannel();
+    public void setChannel(String channel)
+    {
+        this.setParkeeChannel(channel);
     }
 
-	public String getParkeeChannel() {
-		return parkeeChannel;
-	}
+    @Deprecated
+    public String getChannel()
+    {
+        return this.getParkeeChannel();
+    }
 
-	public void setParkeeChannel(String parkeeChannel) {
-		this.parkeeChannel = parkeeChannel;
-	}
+    public String getParkeeChannel()
+    {
+        return parkeeChannel;
+    }
 
-	public Integer getParkeeChannelState() {
-		return parkeeChannelState;
-	}
+    public void setParkeeChannel(String parkeeChannel)
+    {
+        this.parkeeChannel = parkeeChannel;
+    }
 
-	public void setParkeeChannelState(Integer parkeeChannelState) {
-		this.parkeeChannelState = parkeeChannelState;
-	}
+    public Integer getParkeeChannelState()
+    {
+        return parkeeChannelState;
+    }
 
-	public String getParkeeChannelStateDesc() {
-		return parkeeChannelStateDesc;
-	}
+    public void setParkeeChannelState(Integer parkeeChannelState)
+    {
+        this.parkeeChannelState = parkeeChannelState;
+    }
 
-	public void setParkeeChannelStateDesc(String parkeeChannelStateDesc) {
-		this.parkeeChannelStateDesc = parkeeChannelStateDesc;
-	}
+    public String getParkeeChannelStateDesc()
+    {
+        return parkeeChannelStateDesc;
+    }
 
-	public String getParkeeCallerIDNum() {
-		return parkeeCallerIDNum;
-	}
+    public void setParkeeChannelStateDesc(String parkeeChannelStateDesc)
+    {
+        this.parkeeChannelStateDesc = parkeeChannelStateDesc;
+    }
 
-	public void setParkeeCallerIDNum(String parkeeCallerIDNum) {
-		this.parkeeCallerIDNum = parkeeCallerIDNum;
-	}
+    public String getParkeeCallerIDNum()
+    {
+        return parkeeCallerIDNum;
+    }
 
-	public String getParkeeCallerIDName() {
-		return parkeeCallerIDName;
-	}
+    public void setParkeeCallerIDNum(String parkeeCallerIDNum)
+    {
+        this.parkeeCallerIDNum = parkeeCallerIDNum;
+    }
 
-	public void setParkeeCallerIDName(String parkeeCallerIDName) {
-		this.parkeeCallerIDName = parkeeCallerIDName;
-	}
+    public String getParkeeCallerIDName()
+    {
+        return parkeeCallerIDName;
+    }
 
-	public Integer getParkeeConnectedLineNum() {
-		return parkeeConnectedLineNum;
-	}
+    public void setParkeeCallerIDName(String parkeeCallerIDName)
+    {
+        this.parkeeCallerIDName = parkeeCallerIDName;
+    }
 
-	public void setParkeeConnectedLineNum(Integer parkeeConnectedLineNum) {
-		this.parkeeConnectedLineNum = parkeeConnectedLineNum;
-	}
+    public Integer getParkeeConnectedLineNum()
+    {
+        return parkeeConnectedLineNum;
+    }
 
-	public String getParkeeConnectedLineName() {
-		return parkeeConnectedLineName;
-	}
+    public void setParkeeConnectedLineNum(Integer parkeeConnectedLineNum)
+    {
+        this.parkeeConnectedLineNum = parkeeConnectedLineNum;
+    }
 
-	public void setParkeeConnectedLineName(String parkeeConnectedLineName) {
-		this.parkeeConnectedLineName = parkeeConnectedLineName;
-	}
+    public String getParkeeConnectedLineName()
+    {
+        return parkeeConnectedLineName;
+    }
 
-	public String getParkeeLanguage() {
-		return parkeeLanguage;
-	}
+    public void setParkeeConnectedLineName(String parkeeConnectedLineName)
+    {
+        this.parkeeConnectedLineName = parkeeConnectedLineName;
+    }
 
-	public void setParkeeLanguage(String parkeeLanguage) {
-		this.parkeeLanguage = parkeeLanguage;
-	}
+    public String getParkeeLanguage()
+    {
+        return parkeeLanguage;
+    }
 
-	public String getParkeeAccountCode() {
-		return parkeeAccountCode;
-	}
+    public void setParkeeLanguage(String parkeeLanguage)
+    {
+        this.parkeeLanguage = parkeeLanguage;
+    }
 
-	public void setParkeeAccountCode(String parkeeAccountCode) {
-		this.parkeeAccountCode = parkeeAccountCode;
-	}
+    public String getParkeeAccountCode()
+    {
+        return parkeeAccountCode;
+    }
 
-	public String getParkeeContext() {
-		return parkeeContext;
-	}
+    public void setParkeeAccountCode(String parkeeAccountCode)
+    {
+        this.parkeeAccountCode = parkeeAccountCode;
+    }
 
-	public void setParkeeContext(String parkeeContext) {
-		this.parkeeContext = parkeeContext;
-	}
+    public String getParkeeContext()
+    {
+        return parkeeContext;
+    }
 
-	public String getParkeeExten() {
-		return parkeeExten;
-	}
+    public void setParkeeContext(String parkeeContext)
+    {
+        this.parkeeContext = parkeeContext;
+    }
 
-	public void setParkeeExten(String parkeeExten) {
-		this.parkeeExten = parkeeExten;
-	}
+    public String getParkeeExten()
+    {
+        return parkeeExten;
+    }
 
-	public Integer getParkeePriority() {
-		return parkeePriority;
-	}
+    public void setParkeeExten(String parkeeExten)
+    {
+        this.parkeeExten = parkeeExten;
+    }
 
-	public void setParkeePriority(Integer parkeePriority) {
-		this.parkeePriority = parkeePriority;
-	}
+    public Integer getParkeePriority()
+    {
+        return parkeePriority;
+    }
 
-	public String getParkeeUniqueid() {
-		return parkeeUniqueid;
-	}
+    public void setParkeePriority(Integer parkeePriority)
+    {
+        this.parkeePriority = parkeePriority;
+    }
 
-	public void setParkeeUniqueid(String parkeeUniqueid) {
-		this.parkeeUniqueid = parkeeUniqueid;
-	}
+    public String getParkeeUniqueid()
+    {
+        return parkeeUniqueid;
+    }
 
-	public String getParkerDialString() {
-		return parkerDialString;
-	}
+    public void setParkeeUniqueid(String parkeeUniqueid)
+    {
+        this.parkeeUniqueid = parkeeUniqueid;
+    }
 
-	public void setParkerDialString(String parkerDialString) {
-		this.parkerDialString = parkerDialString;
-	}
+    public String getParkerDialString()
+    {
+        return parkerDialString;
+    }
 
-	public String getParkinglot() {
-		return parkingLot;
-	}
+    public void setParkerDialString(String parkerDialString)
+    {
+        this.parkerDialString = parkerDialString;
+    }
 
-	public void setParkinglot(String parkinglot) {
-		this.parkingLot = parkinglot;
-	}
+    public String getParkinglot()
+    {
+        return parkingLot;
+    }
 
-	public String getParkingSpace() {
-		return parkingSpace;
-	}
+    public void setParkinglot(String parkinglot)
+    {
+        this.parkingLot = parkinglot;
+    }
 
-	public void setParkingSpace(String parkingSpace) {
-		this.parkingSpace = parkingSpace;
-	}
+    public String getParkingSpace()
+    {
+        return parkingSpace;
+    }
 
-	public Long getParkingTimeout() {
-		return parkingTimeout;
-	}
+    public void setParkingSpace(String parkingSpace)
+    {
+        this.parkingSpace = parkingSpace;
+    }
 
-	public void setParkingTimeout(Long parkingTimeout) {
-		this.parkingTimeout = parkingTimeout;
-	}
+    public Long getParkingTimeout()
+    {
+        return parkingTimeout;
+    }
 
-	public Long getParkingDuration() {
-		return parkingDuration;
-	}
+    public void setParkingTimeout(Long parkingTimeout)
+    {
+        this.parkingTimeout = parkingTimeout;
+    }
 
-	public void setParkingDuration(Long parkingDuration) {
-		this.parkingDuration = parkingDuration;
-	}
+    public Long getParkingDuration()
+    {
+        return parkingDuration;
+    }
 
-	@Deprecated
-	public String getCallerId() {
-		return getParkeeCallerIDNum();
-	}
-	
-	@Deprecated
-	public void setCallerId(String callerId) {
-		setParkeeCallerIDNum(callerId);
-	}
-	
-	@Deprecated
-	public String getCallerIdName() {
-		return getParkeeCallerIDName();
-	}
-	
-	@Deprecated
-	public void setCallerIdName(String callerIdName) {
-		setParkeeCallerIDName(callerIdName);
-	}
+    public void setParkingDuration(Long parkingDuration)
+    {
+        this.parkingDuration = parkingDuration;
+    }
 
-	@Deprecated
-	public String getExten() {
-		return getParkingSpace();
-	}
-	
-	@Deprecated
-	public void setExten(String exten) {
-		setParkingSpace(exten);
-	}
+    @Deprecated
+    public String getCallerId()
+    {
+        return getParkeeCallerIDNum();
+    }
+
+    @Deprecated
+    public void setCallerId(String callerId)
+    {
+        setParkeeCallerIDNum(callerId);
+    }
+
+    @Deprecated
+    public String getCallerIdName()
+    {
+        return getParkeeCallerIDName();
+    }
+
+    @Deprecated
+    public void setCallerIdName(String callerIdName)
+    {
+        setParkeeCallerIDName(callerIdName);
+    }
+
+    @Deprecated
+    public String getExten()
+    {
+        return getParkingSpace();
+    }
+
+    @Deprecated
+    public void setExten(String exten)
+    {
+        setParkingSpace(exten);
+    }
 }

--- a/src/main/java/org/asteriskjava/manager/event/AbstractUnParkedEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AbstractUnParkedEvent.java
@@ -38,8 +38,7 @@ public class AbstractUnParkedEvent extends AbstractParkedCallEvent
     private String parkerExten;
     private String parkerPriority;
     private String parkerUniqueid;
-    
-    
+
     /**
      * @param source
      */
@@ -48,123 +47,123 @@ public class AbstractUnParkedEvent extends AbstractParkedCallEvent
         super(source);
     }
 
+    public String getParkerChannel()
+    {
+        return parkerChannel;
+    }
 
-	public String getParkerChannel() {
-		return parkerChannel;
-	}
+    public void setParkerChannel(String parkerChannel)
+    {
+        this.parkerChannel = parkerChannel;
+    }
 
+    public Integer getParkerChannelState()
+    {
+        return parkerChannelState;
+    }
 
-	public void setParkerChannel(String parkerChannel) {
-		this.parkerChannel = parkerChannel;
-	}
+    public void setParkerChannelState(Integer parkerChannelState)
+    {
+        this.parkerChannelState = parkerChannelState;
+    }
 
+    public String getParkerChannelStateDesc()
+    {
+        return parkerChannelStateDesc;
+    }
 
-	public Integer getParkerChannelState() {
-		return parkerChannelState;
-	}
+    public void setParkerChannelStateDesc(String parkerChannelStateDesc)
+    {
+        this.parkerChannelStateDesc = parkerChannelStateDesc;
+    }
 
+    public String getParkerCallerIDNum()
+    {
+        return parkerCallerIDNum;
+    }
 
-	public void setParkerChannelState(Integer parkerChannelState) {
-		this.parkerChannelState = parkerChannelState;
-	}
+    public void setParkerCallerIDNum(String parkerCallerIDNum)
+    {
+        this.parkerCallerIDNum = parkerCallerIDNum;
+    }
 
+    public String getParkerCallerIDName()
+    {
+        return parkerCallerIDName;
+    }
 
-	public String getParkerChannelStateDesc() {
-		return parkerChannelStateDesc;
-	}
+    public void setParkerCallerIDName(String parkerCallerIDName)
+    {
+        this.parkerCallerIDName = parkerCallerIDName;
+    }
 
+    public String getParkerConnectedLineNum()
+    {
+        return parkerConnectedLineNum;
+    }
 
-	public void setParkerChannelStateDesc(String parkerChannelStateDesc) {
-		this.parkerChannelStateDesc = parkerChannelStateDesc;
-	}
+    public void setParkerConnectedLineNum(String parkerConnectedLineNum)
+    {
+        this.parkerConnectedLineNum = parkerConnectedLineNum;
+    }
 
+    public String getParkerConnectedLineName()
+    {
+        return parkerConnectedLineName;
+    }
 
-	public String getParkerCallerIDNum() {
-		return parkerCallerIDNum;
-	}
+    public void setParkerConnectedLineName(String parkerConnectedLineName)
+    {
+        this.parkerConnectedLineName = parkerConnectedLineName;
+    }
 
+    public String getParkerAccountCode()
+    {
+        return parkerAccountCode;
+    }
 
-	public void setParkerCallerIDNum(String parkerCallerIDNum) {
-		this.parkerCallerIDNum = parkerCallerIDNum;
-	}
+    public void setParkerAccountCode(String parkerAccountCode)
+    {
+        this.parkerAccountCode = parkerAccountCode;
+    }
 
+    public String getParkerContext()
+    {
+        return parkerContext;
+    }
 
-	public String getParkerCallerIDName() {
-		return parkerCallerIDName;
-	}
+    public void setParkerContext(String parkerContext)
+    {
+        this.parkerContext = parkerContext;
+    }
 
+    public String getParkerExten()
+    {
+        return parkerExten;
+    }
 
-	public void setParkerCallerIDName(String parkerCallerIDName) {
-		this.parkerCallerIDName = parkerCallerIDName;
-	}
+    public void setParkerExten(String parkerExten)
+    {
+        this.parkerExten = parkerExten;
+    }
 
+    public String getParkerPriority()
+    {
+        return parkerPriority;
+    }
 
-	public String getParkerConnectedLineNum() {
-		return parkerConnectedLineNum;
-	}
+    public void setParkerPriority(String parkerPriority)
+    {
+        this.parkerPriority = parkerPriority;
+    }
 
+    public String getParkerUniqueid()
+    {
+        return parkerUniqueid;
+    }
 
-	public void setParkerConnectedLineNum(String parkerConnectedLineNum) {
-		this.parkerConnectedLineNum = parkerConnectedLineNum;
-	}
-
-
-	public String getParkerConnectedLineName() {
-		return parkerConnectedLineName;
-	}
-
-
-	public void setParkerConnectedLineName(String parkerConnectedLineName) {
-		this.parkerConnectedLineName = parkerConnectedLineName;
-	}
-
-
-	public String getParkerAccountCode() {
-		return parkerAccountCode;
-	}
-
-
-	public void setParkerAccountCode(String parkerAccountCode) {
-		this.parkerAccountCode = parkerAccountCode;
-	}
-
-
-	public String getParkerContext() {
-		return parkerContext;
-	}
-
-
-	public void setParkerContext(String parkerContext) {
-		this.parkerContext = parkerContext;
-	}
-
-
-	public String getParkerExten() {
-		return parkerExten;
-	}
-
-
-	public void setParkerExten(String parkerExten) {
-		this.parkerExten = parkerExten;
-	}
-
-
-	public String getParkerPriority() {
-		return parkerPriority;
-	}
-
-
-	public void setParkerPriority(String parkerPriority) {
-		this.parkerPriority = parkerPriority;
-	}
-
-
-	public String getParkerUniqueid() {
-		return parkerUniqueid;
-	}
-
-
-	public void setParkerUniqueid(String parkerUniqueid) {
-		this.parkerUniqueid = parkerUniqueid;
-	}
+    public void setParkerUniqueid(String parkerUniqueid)
+    {
+        this.parkerUniqueid = parkerUniqueid;
+    }
 }

--- a/src/main/java/org/asteriskjava/manager/event/AbstractUnParkedEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AbstractUnParkedEvent.java
@@ -1,0 +1,170 @@
+/*
+ *  Copyright 2004-2006 Stefan Reuter
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.asteriskjava.manager.event;
+
+/**
+ * Enro 2015-03: Asterisk 13 Support
+ */
+public class AbstractUnParkedEvent extends AbstractParkedCallEvent
+{
+    /**
+     * Serializable version identifier
+     */
+    private static final long serialVersionUID = -7437833328723536814L;
+
+    private String parkerChannel;
+    private Integer parkerChannelState;
+    private String parkerChannelStateDesc;
+    private String parkerCallerIDNum;
+    private String parkerCallerIDName;
+    private String parkerConnectedLineNum;
+    private String parkerConnectedLineName;
+    private String parkerAccountCode;
+    private String parkerContext;
+    private String parkerExten;
+    private String parkerPriority;
+    private String parkerUniqueid;
+    
+    
+    /**
+     * @param source
+     */
+    public AbstractUnParkedEvent(Object source)
+    {
+        super(source);
+    }
+
+
+	public String getParkerChannel() {
+		return parkerChannel;
+	}
+
+
+	public void setParkerChannel(String parkerChannel) {
+		this.parkerChannel = parkerChannel;
+	}
+
+
+	public Integer getParkerChannelState() {
+		return parkerChannelState;
+	}
+
+
+	public void setParkerChannelState(Integer parkerChannelState) {
+		this.parkerChannelState = parkerChannelState;
+	}
+
+
+	public String getParkerChannelStateDesc() {
+		return parkerChannelStateDesc;
+	}
+
+
+	public void setParkerChannelStateDesc(String parkerChannelStateDesc) {
+		this.parkerChannelStateDesc = parkerChannelStateDesc;
+	}
+
+
+	public String getParkerCallerIDNum() {
+		return parkerCallerIDNum;
+	}
+
+
+	public void setParkerCallerIDNum(String parkerCallerIDNum) {
+		this.parkerCallerIDNum = parkerCallerIDNum;
+	}
+
+
+	public String getParkerCallerIDName() {
+		return parkerCallerIDName;
+	}
+
+
+	public void setParkerCallerIDName(String parkerCallerIDName) {
+		this.parkerCallerIDName = parkerCallerIDName;
+	}
+
+
+	public String getParkerConnectedLineNum() {
+		return parkerConnectedLineNum;
+	}
+
+
+	public void setParkerConnectedLineNum(String parkerConnectedLineNum) {
+		this.parkerConnectedLineNum = parkerConnectedLineNum;
+	}
+
+
+	public String getParkerConnectedLineName() {
+		return parkerConnectedLineName;
+	}
+
+
+	public void setParkerConnectedLineName(String parkerConnectedLineName) {
+		this.parkerConnectedLineName = parkerConnectedLineName;
+	}
+
+
+	public String getParkerAccountCode() {
+		return parkerAccountCode;
+	}
+
+
+	public void setParkerAccountCode(String parkerAccountCode) {
+		this.parkerAccountCode = parkerAccountCode;
+	}
+
+
+	public String getParkerContext() {
+		return parkerContext;
+	}
+
+
+	public void setParkerContext(String parkerContext) {
+		this.parkerContext = parkerContext;
+	}
+
+
+	public String getParkerExten() {
+		return parkerExten;
+	}
+
+
+	public void setParkerExten(String parkerExten) {
+		this.parkerExten = parkerExten;
+	}
+
+
+	public String getParkerPriority() {
+		return parkerPriority;
+	}
+
+
+	public void setParkerPriority(String parkerPriority) {
+		this.parkerPriority = parkerPriority;
+	}
+
+
+	public String getParkerUniqueid() {
+		return parkerUniqueid;
+	}
+
+
+	public void setParkerUniqueid(String parkerUniqueid) {
+		this.parkerUniqueid = parkerUniqueid;
+	}
+}

--- a/src/main/java/org/asteriskjava/manager/event/AgentCalledEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AgentCalledEvent.java
@@ -149,22 +149,6 @@ public class AgentCalledEvent extends ManagerEvent
     /**
      * Returns the Caller ID number of the caller's channel.
      *
-     * @return the Caller ID number of the caller's channel or "unknown" of none has been set.
-     * @since 1.0.0
-     */
-    public String getCallerIdNum()
-    {
-        return callerIdNum;
-    }
-
-    public void setCallerIdNum(String callerIdNum)
-    {
-        this.callerIdNum = callerIdNum;
-    }
-
-    /**
-     * Returns the Caller ID number of the caller's channel.
-     *
      * @return the Caller ID number of the caller's channel.
      * @deprecated as of 1.0.0, use {@link #getCallerIdNum()} instead.
      */
@@ -183,29 +167,6 @@ public class AgentCalledEvent extends ManagerEvent
         this.callerIdNum = callerId;
     }
 
-
-    public String getCallerIdName() { return callerIdName; }
-
-    /**
-     * Sets the Caller ID name of the caller's channel.
-     *
-     * @param callerIdName the Caller ID name of the caller's channel.
-     * @since 0.2
-     */
-    public void setCallerIdName(String callerIdName)
-    {
-        this.callerIdName = callerIdName;
-    }
-
-    public String getContext()
-    {
-        return context;
-    }
-
-    public void setContext(String context)
-    {
-        this.context = context;
-    }
 
     public String getExtension()
     {
@@ -259,19 +220,5 @@ public class AgentCalledEvent extends ManagerEvent
     {
         this.variables = variables;
     }
-
-    /**
-     * Returns the Caller*ID name of the channel connected if set.
-     * If the channel has no caller id set "unknown" is returned.
-     *
-     * @since 1.0.0
-     */
-
-    /**
-     * Returns the Caller*ID number of the channel connected if set.
-     * If the channel has no caller id set "unknown" is returned.
-     *
-     * @since 1.0.0
-     */
 
 }

--- a/src/main/java/org/asteriskjava/manager/event/AgentCalledEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AgentCalledEvent.java
@@ -19,11 +19,9 @@ package org.asteriskjava.manager.event;
 import java.util.Map;
 
 /**
- * An AgentCalledEvent is triggered when an agent is rung.
- * <br>
+ * An AgentCalledEvent is triggered when an agent is rung. <br>
  * To enable AgentCalledEvents you have to set
- * <code>eventwhencalled = yes</code> in <code>queues.conf</code>.
- * <br>
+ * <code>eventwhencalled = yes</code> in <code>queues.conf</code>. <br>
  * This event is implemented in <code>apps/app_queue.c</code>
  *
  * @author srt
@@ -53,7 +51,8 @@ public class AgentCalledEvent extends ManagerEvent
     }
 
     /**
-     * Returns the name of the queue.<p>
+     * Returns the name of the queue.
+     * <p>
      * Available since Asterisk 1.6.
      *
      * @return the name of the queue.
@@ -84,7 +83,7 @@ public class AgentCalledEvent extends ManagerEvent
      * Sets the member interface of the agent that has been called.
      *
      * @param agentCalled the member interface of the agent that has been
-     *                    called.
+     *            called.
      */
     public void setAgentCalled(String agentCalled)
     {
@@ -92,7 +91,8 @@ public class AgentCalledEvent extends ManagerEvent
     }
 
     /**
-     * Returns the name of the agent that has been called.<p>
+     * Returns the name of the agent that has been called.
+     * <p>
      * Available since Asterisk 1.6.
      *
      * @return the name of the agent that has been called.
@@ -130,7 +130,8 @@ public class AgentCalledEvent extends ManagerEvent
     }
 
     /**
-     * Returns the name of the channel calling the agent.<p>
+     * Returns the name of the channel calling the agent.
+     * <p>
      * Available since Asterisk 1.6
      *
      * @return the name of the channel calling the agent.
@@ -152,7 +153,8 @@ public class AgentCalledEvent extends ManagerEvent
      * @return the Caller ID number of the caller's channel.
      * @deprecated as of 1.0.0, use {@link #getCallerIdNum()} instead.
      */
-    @Deprecated public String getCallerId()
+    @Deprecated
+    public String getCallerId()
     {
         return callerIdNum;
     }
@@ -167,7 +169,6 @@ public class AgentCalledEvent extends ManagerEvent
         this.callerIdNum = callerId;
     }
 
-
     public String getExtension()
     {
         return exten;
@@ -179,8 +180,9 @@ public class AgentCalledEvent extends ManagerEvent
     }
 
     /**
-     * Returns the unique id of the caller's channel that is about to be handled by
-     * the agent. This corresponds to {@link #getChannelCalling()}.<p>
+     * Returns the unique id of the caller's channel that is about to be handled
+     * by the agent. This corresponds to {@link #getChannelCalling()}.
+     * <p>
      * Available since Asterisk 1.6
      *
      * @return the unique id of the caller's channel.
@@ -197,8 +199,9 @@ public class AgentCalledEvent extends ManagerEvent
     }
 
     /**
-     * Returns the channel variables if <code>eventwhencalled</code> is set to <code>vars</code>
-     * in <code>queues.conf</code>.<p>
+     * Returns the channel variables if <code>eventwhencalled</code> is set to
+     * <code>vars</code> in <code>queues.conf</code>.
+     * <p>
      * Available since Asterisk 1.6
      *
      * @return the channel variables.
@@ -210,7 +213,8 @@ public class AgentCalledEvent extends ManagerEvent
     }
 
     /**
-     * Sets the channel variables.<p>
+     * Sets the channel variables.
+     * <p>
      * Available since Asterisk 1.6
      *
      * @param variables the channel variables.

--- a/src/main/java/org/asteriskjava/manager/event/CoreShowChannelEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/CoreShowChannelEvent.java
@@ -17,7 +17,8 @@
 package org.asteriskjava.manager.event;
 
 /**
- * A CoreShowChannelEvent is triggered for each active channel in response to a CoreShowChannelsAction.
+ * A CoreShowChannelEvent is triggered for each active channel in response to a
+ * CoreShowChannelsAction.
  *
  * @author sebastian gutierrez
  * @version $Id$
@@ -55,7 +56,6 @@ public class CoreShowChannelEvent extends ResponseEvent
      * @return channel state
      */
 
-
     /**
      * Returns the Account code
      *
@@ -87,8 +87,8 @@ public class CoreShowChannelEvent extends ResponseEvent
     }
 
     /**
-     * Returns the Aplication Data is runnning that channel at that time
-     * this is the parameters passed to that dialplan application
+     * Returns the Aplication Data is runnning that channel at that time this is
+     * the parameters passed to that dialplan application
      *
      * @return aplication data
      */

--- a/src/main/java/org/asteriskjava/manager/event/CoreShowChannelEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/CoreShowChannelEvent.java
@@ -43,8 +43,6 @@ public class CoreShowChannelEvent extends ResponseEvent
     private String accountcode;
     private String bridgedChannel;
     private String bridgeduniqueid;
-    private String connectedlinenum;
-    private String connectedlinename;
 
     public CoreShowChannelEvent(Object source)
     {
@@ -225,13 +223,6 @@ public class CoreShowChannelEvent extends ResponseEvent
     }
 
     /**
-     * Returns the Priority the channel actualy is
-     *
-     * @return priority
-     */
-
-
-    /**
      * Returns the Uniqueid
      *
      * @return uniqueid
@@ -244,26 +235,6 @@ public class CoreShowChannelEvent extends ResponseEvent
     public void setUniqueid(String uniqueid)
     {
         this.uniqueid = uniqueid;
-    }
-
-    public String getConnectedlinenum()
-    {
-        return connectedlinenum;
-    }
-
-    public void setConnectedlinenum(String connectedlinenum)
-    {
-        this.connectedlinenum = connectedlinenum;
-    }
-
-    public String getConnectedlinename()
-    {
-        return connectedlinename;
-    }
-
-    public void setConnectedlinename(String connectedlinename)
-    {
-        this.connectedlinename = connectedlinename;
     }
 
 }

--- a/src/main/java/org/asteriskjava/manager/event/DialBeginEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/DialBeginEvent.java
@@ -9,6 +9,7 @@ public class DialBeginEvent extends DialEvent
 	private static final long serialVersionUID = 1L;
 	private String language;
 	private String destlanguage;
+    private String destAccountCode; 
 
 	public DialBeginEvent(Object source)
 	{
@@ -34,5 +35,13 @@ public class DialBeginEvent extends DialEvent
 	public void setDestLanguage(String destlanguage)
 	{
 		this.destlanguage = destlanguage;
+	}
+	
+	public String getDestAccountCode() {
+		return destAccountCode;
+	}
+
+	public void setDestAccountCode(String destAccountCode) {
+		this.destAccountCode = destAccountCode;
 	}
 }

--- a/src/main/java/org/asteriskjava/manager/event/DialBeginEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/DialBeginEvent.java
@@ -3,45 +3,47 @@ package org.asteriskjava.manager.event;
 public class DialBeginEvent extends DialEvent
 {
 
-	/**
+    /**
 	 * 
 	 */
-	private static final long serialVersionUID = 1L;
-	private String language;
-	private String destlanguage;
-    private String destAccountCode; 
+    private static final long serialVersionUID = 1L;
+    private String language;
+    private String destlanguage;
+    private String destAccountCode;
 
-	public DialBeginEvent(Object source)
-	{
-		super(source);
-		setSubEvent(SUBEVENT_BEGIN);
-	}
+    public DialBeginEvent(Object source)
+    {
+        super(source);
+        setSubEvent(SUBEVENT_BEGIN);
+    }
 
-	public String getLanguage()
-	{
-		return language;
-	}
+    public String getLanguage()
+    {
+        return language;
+    }
 
-	public void setLanguage(String language)
-	{
-		this.language = language;
-	}
+    public void setLanguage(String language)
+    {
+        this.language = language;
+    }
 
-	public String getDestLanguage()
-	{
-		return destlanguage;
-	}
+    public String getDestLanguage()
+    {
+        return destlanguage;
+    }
 
-	public void setDestLanguage(String destlanguage)
-	{
-		this.destlanguage = destlanguage;
-	}
-	
-	public String getDestAccountCode() {
-		return destAccountCode;
-	}
+    public void setDestLanguage(String destlanguage)
+    {
+        this.destlanguage = destlanguage;
+    }
 
-	public void setDestAccountCode(String destAccountCode) {
-		this.destAccountCode = destAccountCode;
-	}
+    public String getDestAccountCode()
+    {
+        return destAccountCode;
+    }
+
+    public void setDestAccountCode(String destAccountCode)
+    {
+        this.destAccountCode = destAccountCode;
+    }
 }

--- a/src/main/java/org/asteriskjava/manager/event/DialEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/DialEvent.java
@@ -17,8 +17,10 @@
 package org.asteriskjava.manager.event;
 
 /**
- * A dial event is triggered whenever a phone attempts to dial someone.<p>
- * This event is implemented in <code>apps/app_dial.c</code>.<p>
+ * A dial event is triggered whenever a phone attempts to dial someone.
+ * <p>
+ * This event is implemented in <code>apps/app_dial.c</code>.
+ * <p>
  * Available since Asterisk 1.2.
  *
  * @author Asteria Solutions Group, Inc. http://www.asteriasgi.com/
@@ -75,7 +77,6 @@ public class DialEvent extends ManagerEvent
     private String destCallerIdName;
     private String destCallerIdNum;
 
-
     /**
      * The new Caller*ID.
      */
@@ -98,39 +99,43 @@ public class DialEvent extends ManagerEvent
 
     private String dialString;
     private String dialStatus;
-    
+
     public DialEvent(Object source)
     {
         super(source);
     }
 
     /**
-     * Enro 2015-03
-     * Workaround to build legacy DialEvent (unsupported in Asterisk 13) from new DialBeginEvent Asterisk 13.
+     * Enro 2015-03 Workaround to build legacy DialEvent (unsupported in
+     * Asterisk 13) from new DialBeginEvent Asterisk 13.
      */
-    public DialEvent(DialBeginEvent dialBeginEvent){
-    	this(dialBeginEvent.getSource());
-    	setDateReceived(dialBeginEvent.getDateReceived());
-    	setTimestamp(dialBeginEvent.getTimestamp());
-    	setPrivilege(dialBeginEvent.getPrivilege());
-    	setCallerId(dialBeginEvent.getCallerIdNum());
-    	setCallerIdName(dialBeginEvent.getCallerIdName());
-    	setSrc(dialBeginEvent.getChannel());
-    	setUniqueId(dialBeginEvent.getSrcUniqueId());
-    	setDestUniqueId(dialBeginEvent.getDestUniqueId());
-    	setDestination(dialBeginEvent.getDestChannel());
-    	setDialStatus(dialBeginEvent.getDialStatus());
+    public DialEvent(DialBeginEvent dialBeginEvent)
+    {
+        this(dialBeginEvent.getSource());
+        setDateReceived(dialBeginEvent.getDateReceived());
+        setTimestamp(dialBeginEvent.getTimestamp());
+        setPrivilege(dialBeginEvent.getPrivilege());
+        setCallerId(dialBeginEvent.getCallerIdNum());
+        setCallerIdName(dialBeginEvent.getCallerIdName());
+        setSrc(dialBeginEvent.getChannel());
+        setUniqueId(dialBeginEvent.getSrcUniqueId());
+        setDestUniqueId(dialBeginEvent.getDestUniqueId());
+        setDestination(dialBeginEvent.getDestChannel());
+        setDialStatus(dialBeginEvent.getDialStatus());
     }
-    
+
     /**
-     * Since Asterisk 1.6 the begin and the end of a dial command generate a Dial event. The
-     * subEvent property returns whether the dial started execution ("Begin") or completed ("End").
-     * As Asterisk prior to 1.6 only sends one event per Dial command this always returns "Begin"
-     * for Asterisk prior to 1.6.<br>
-     * For an "End" sub event only the properies channel, unqiue id and dial status are available,
-     * for a "Begin" sub event all properties are available except for the dial status.
+     * Since Asterisk 1.6 the begin and the end of a dial command generate a
+     * Dial event. The subEvent property returns whether the dial started
+     * execution ("Begin") or completed ("End"). As Asterisk prior to 1.6 only
+     * sends one event per Dial command this always returns "Begin" for Asterisk
+     * prior to 1.6.<br>
+     * For an "End" sub event only the properies channel, unqiue id and dial
+     * status are available, for a "Begin" sub event all properties are
+     * available except for the dial status.
      *
-     * @return "Begin" or "End" for Asterisk since 1.6, "Begin" for Asterisk prior to 1.6.
+     * @return "Begin" or "End" for Asterisk since 1.6, "Begin" for Asterisk
+     *         prior to 1.6.
      * @since 1.0.0
      */
     public String getSubEvent()
@@ -171,14 +176,17 @@ public class DialEvent extends ManagerEvent
      * @return the name of the source channel.
      * @deprecated as of 1.0.0, use {@link #getChannel()} instead.
      */
-    @Deprecated public String getSrc()
+    @Deprecated
+    public String getSrc()
     {
         return channel;
     }
 
     /**
-     * Sets the name of the source channel.<p>
-     * Asterisk versions up to 1.4 use the "Source" property instead of "Channel".
+     * Sets the name of the source channel.
+     * <p>
+     * Asterisk versions up to 1.4 use the "Source" property instead of
+     * "Channel".
      *
      * @param src the name of the source channel.
      */
@@ -196,10 +204,10 @@ public class DialEvent extends ManagerEvent
     {
         return destination;
     }
-    
-    public String getDestChannel() 
-    { 
-    	return getDestination(); 
+
+    public String getDestChannel()
+    {
+        return getDestination();
     }
 
     /**
@@ -211,10 +219,10 @@ public class DialEvent extends ManagerEvent
     {
         this.destination = destination;
     }
-    
-    public void setDestChannel(String destination) 
-    { 
-    	setDestination(destination); 
+
+    public void setDestChannel(String destination)
+    {
+        setDestination(destination);
     }
 
     /**
@@ -223,7 +231,8 @@ public class DialEvent extends ManagerEvent
      * @return the Caller*ID or "&lt;unknown&gt;" if none has been set.
      * @deprecated as of 1.0.0, use {@link #getCallerIdNum()} instead.
      */
-    @Deprecated public String getCallerId()
+    @Deprecated
+    public String getCallerId()
     {
         return callerIdNum;
     }
@@ -266,14 +275,17 @@ public class DialEvent extends ManagerEvent
      * @return the unique ID of the source channel.
      * @deprecated as of 1.0.0, use {@link #getUniqueId()} instead.
      */
-    @Deprecated public String getSrcUniqueId()
+    @Deprecated
+    public String getSrcUniqueId()
     {
         return uniqueId;
     }
 
     /**
-     * Sets the unique ID of the source channel.<p>
-     * Asterisk versions up to 1.4 use the "SrcUniqueId" property instead of "UniqueId".
+     * Sets the unique ID of the source channel.
+     * <p>
+     * Asterisk versions up to 1.4 use the "SrcUniqueId" property instead of
+     * "UniqueId".
      *
      * @param srcUniqueId the unique ID of the source channel.
      */
@@ -303,7 +315,8 @@ public class DialEvent extends ManagerEvent
     }
 
     /**
-     * Returns the dial string passed to the Dial application.<p>
+     * Returns the dial string passed to the Dial application.
+     * <p>
      * Available since Asterisk 1.6.
      *
      * @return the dial string passed to the Dial application.
@@ -326,7 +339,8 @@ public class DialEvent extends ManagerEvent
     }
 
     /**
-     * For end subevents this returns whether the completion status of the dial application.<br>
+     * For end subevents this returns whether the completion status of the dial
+     * application.<br>
      * Possible values are:
      * <ul>
      * <li>CHANUNAVAIL</li>
@@ -339,7 +353,8 @@ public class DialEvent extends ManagerEvent
      * <li>TORTURE</li>
      * <li>INVALIDARGS</li>
      * </ul>
-     * It corresponds the the DIALSTATUS variable used in the dialplan.<p>
+     * It corresponds the the DIALSTATUS variable used in the dialplan.
+     * <p>
      * Available since Asterisk 1.6.
      *
      * @return the completion status of the dial application.
@@ -355,123 +370,123 @@ public class DialEvent extends ManagerEvent
         this.dialStatus = dialStatus;
     }
 
-	@Override
-	public String toString() 
-	{
-		StringBuilder builder = new StringBuilder();
-		builder.append("DialEvent [subEvent=");
-		builder.append(subEvent);
-		builder.append(", channel=");
-		builder.append(channel);
-		builder.append(", destination=");
-		builder.append(destination);
-		builder.append(", callerIdNum=");
-		builder.append(callerIdNum);
-		builder.append(", callerIdName=");
-		builder.append(callerIdName);
-		builder.append(", uniqueId=");
-		builder.append(uniqueId);
-		builder.append(", destUniqueId=");
-		builder.append(destUniqueId);
-		builder.append(", dialString=");
-		builder.append(dialString);
-		builder.append(", dialStatus=");
-		builder.append(dialStatus);
-		builder.append(", connectedLineNum=");
-		builder.append(connectedLineNum);
-		builder.append(", connectedLineName=");
-		builder.append(connectedLineName);
-		builder.append("]");
-		return builder.toString();
-	}
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append("DialEvent [subEvent=");
+        builder.append(subEvent);
+        builder.append(", channel=");
+        builder.append(channel);
+        builder.append(", destination=");
+        builder.append(destination);
+        builder.append(", callerIdNum=");
+        builder.append(callerIdNum);
+        builder.append(", callerIdName=");
+        builder.append(callerIdName);
+        builder.append(", uniqueId=");
+        builder.append(uniqueId);
+        builder.append(", destUniqueId=");
+        builder.append(destUniqueId);
+        builder.append(", dialString=");
+        builder.append(dialString);
+        builder.append(", dialStatus=");
+        builder.append(dialStatus);
+        builder.append(", connectedLineNum=");
+        builder.append(connectedLineNum);
+        builder.append(", connectedLineName=");
+        builder.append(connectedLineName);
+        builder.append("]");
+        return builder.toString();
+    }
 
-    public Integer getDestChannelState() 
-	{
+    public Integer getDestChannelState()
+    {
         return destChannelState;
     }
 
-    public void setDestChannelState(Integer destChannelState) 
-	{
+    public void setDestChannelState(Integer destChannelState)
+    {
         this.destChannelState = destChannelState;
     }
 
-    public String getDestContext() 
-	{
+    public String getDestContext()
+    {
         return destContext;
     }
 
-    public void setDestContext(String destContext) 
-	{
+    public void setDestContext(String destContext)
+    {
         this.destContext = destContext;
     }
 
-    public Integer getDestPriority() 
-	{
+    public Integer getDestPriority()
+    {
         return destPriority;
     }
 
-    public void setDestPriority(Integer destPriority) 
-	{
+    public void setDestPriority(Integer destPriority)
+    {
         this.destPriority = destPriority;
     }
 
-    public String getDestChannelStateDesc() 
-	{
+    public String getDestChannelStateDesc()
+    {
         return destChannelStateDesc;
     }
 
-    public void setDestChannelStateDesc(String destChannelStateDesc) 
-	{
+    public void setDestChannelStateDesc(String destChannelStateDesc)
+    {
         this.destChannelStateDesc = destChannelStateDesc;
     }
 
-    public String getDestExten() 
-	{
+    public String getDestExten()
+    {
         return destExten;
     }
 
-    public void setDestExten(String destExten) 
-	{
+    public void setDestExten(String destExten)
+    {
         this.destExten = destExten;
     }
 
-    public String getDestConnectedLineName() 
-	{
+    public String getDestConnectedLineName()
+    {
         return destConnectedLineName;
     }
 
-    public void setDestConnectedLineName(String destConnectedLineName) 
-	{
+    public void setDestConnectedLineName(String destConnectedLineName)
+    {
         this.destConnectedLineName = destConnectedLineName;
     }
 
-    public String getDestConnectedLineNum() 
-	{
+    public String getDestConnectedLineNum()
+    {
         return destConnectedLineNum;
     }
 
-    public void setDestConnectedLineNum(String destConnectedLineNum) 
-	{
+    public void setDestConnectedLineNum(String destConnectedLineNum)
+    {
         this.destConnectedLineNum = destConnectedLineNum;
     }
 
-    public String getDestCallerIdName() 
-	{
+    public String getDestCallerIdName()
+    {
         return destCallerIdName;
     }
 
-    public void setDestCallerIdName(String destCallerIdName) 
-	{
+    public void setDestCallerIdName(String destCallerIdName)
+    {
         this.destCallerIdName = destCallerIdName;
     }
 
-    public String getDestCallerIdNum() 
-	{
+    public String getDestCallerIdNum()
+    {
         return destCallerIdNum;
     }
 
-    public void setDestCallerIdNum(String destCallerIdNum) 
-	{
+    public void setDestCallerIdNum(String destCallerIdNum)
+    {
         this.destCallerIdNum = destCallerIdNum;
     }
 }

--- a/src/main/java/org/asteriskjava/manager/event/DialEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/DialEvent.java
@@ -99,15 +99,29 @@ public class DialEvent extends ManagerEvent
     private String dialString;
     private String dialStatus;
     
-    private String connectedLineNum;
-    
-    private String connectedLineName;
-    
     public DialEvent(Object source)
     {
         super(source);
     }
 
+    /**
+     * Enro 2015-03
+     * Workaround to build legacy DialEvent (unsupported in Asterisk 13) from new DialBeginEvent Asterisk 13.
+     */
+    public DialEvent(DialBeginEvent dialBeginEvent){
+    	this(dialBeginEvent.getSource());
+    	setDateReceived(dialBeginEvent.getDateReceived());
+    	setTimestamp(dialBeginEvent.getTimestamp());
+    	setPrivilege(dialBeginEvent.getPrivilege());
+    	setCallerId(dialBeginEvent.getCallerIdNum());
+    	setCallerIdName(dialBeginEvent.getCallerIdName());
+    	setSrc(dialBeginEvent.getChannel());
+    	setUniqueId(dialBeginEvent.getSrcUniqueId());
+    	setDestUniqueId(dialBeginEvent.getDestUniqueId());
+    	setDestination(dialBeginEvent.getDestChannel());
+    	setDialStatus(dialBeginEvent.getDialStatus());
+    }
+    
     /**
      * Since Asterisk 1.6 the begin and the end of a dial command generate a Dial event. The
      * subEvent property returns whether the dial started execution ("Begin") or completed ("End").
@@ -182,7 +196,11 @@ public class DialEvent extends ManagerEvent
     {
         return destination;
     }
-    public String getDestChannel() { return getDestination(); }
+    
+    public String getDestChannel() 
+    { 
+    	return getDestination(); 
+    }
 
     /**
      * Sets the name of the destination channel.
@@ -193,21 +211,10 @@ public class DialEvent extends ManagerEvent
     {
         this.destination = destination;
     }
-    public void setDestChannel(String destination) { setDestination(destination); }
-    /**
-     * Returns the the Caller*ID Number.
-     *
-     * @return the the Caller*ID Number or "&lt;unknown&gt;" if none has been set.
-     * @since 1.0.0
-     */
-    public String getCallerIdNum()
-    {
-        return callerIdNum;
-    }
-
-    public void setCallerIdNum(String callerIdNum)
-    {
-        this.callerIdNum = callerIdNum;
+    
+    public void setDestChannel(String destination) 
+    { 
+    	setDestination(destination); 
     }
 
     /**
@@ -229,26 +236,6 @@ public class DialEvent extends ManagerEvent
     public void setCallerId(String callerId)
     {
         this.callerIdNum = callerId;
-    }
-
-    /**
-     * Returns the Caller*ID Name.
-     *
-     * @return the Caller*ID Name or "&lt;unknown&gt;" if none has been set.
-     */
-    public String getCallerIdName()
-    {
-        return callerIdName;
-    }
-
-    /**
-     * Sets the Caller*Id Name.
-     *
-     * @param callerIdName the Caller*Id Name to set.
-     */
-    public void setCallerIdName(String callerIdName)
-    {
-        this.callerIdName = callerIdName;
     }
 
     /**
@@ -367,38 +354,6 @@ public class DialEvent extends ManagerEvent
     {
         this.dialStatus = dialStatus;
     }
-
-    /**
-     * Returns the Caller*ID number of the channel connected if set.
-     * If the channel has no caller id set "unknown" is returned.
-     *
-     * @since 1.0.0
-     */
-	public String getConnectedLineNum() 
-	{
-		return connectedLineNum;
-	}
-
-	public void setConnectedLineNum(String connectedLineNum) 
-	{
-		this.connectedLineNum = connectedLineNum;
-	}
-
-    /**
-     * Returns the Caller*ID name of the channel connected if set.
-     * If the channel has no caller id set "unknown" is returned.
-     *
-     * @since 1.0.0
-     */
-	public String getConnectedLineName() 
-	{
-		return connectedLineName;
-	}
-
-	public void setConnectedLineName(String connectedLineName) 
-	{
-		this.connectedLineName = connectedLineName;
-	}
 
 	@Override
 	public String toString() 

--- a/src/main/java/org/asteriskjava/manager/event/HoldEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/HoldEvent.java
@@ -17,12 +17,16 @@
 package org.asteriskjava.manager.event;
 
 /**
- * A HoldEvent is triggered when a channel is put on hold (or no longer on hold).<p>
- * It is implemented in <code>channels/chan_sip.c</code>.<p>
+ * A HoldEvent is triggered when a channel is put on hold (or no longer on
+ * hold).
+ * <p>
+ * It is implemented in <code>channels/chan_sip.c</code>.
+ * <p>
  * Available since Asterisk 1.2 for SIP channels, as of Asterisk 1.6 this event
- * is also supported for IAX2 channels.<p>
- * To receive HoldEvents for SIP channels you must set <code>callevents = yes</code>
- * in <code>sip.conf</code>.
+ * is also supported for IAX2 channels.
+ * <p>
+ * To receive HoldEvents for SIP channels you must set
+ * <code>callevents = yes</code> in <code>sip.conf</code>.
  *
  * @author srt
  * @version $Id$
@@ -36,6 +40,7 @@ public class HoldEvent extends AbstractHoldEvent
     private static final long serialVersionUID = 0L;
 
     private String musicClass;
+
     /**
      * Creates a new HoldEvent.
      *
@@ -44,19 +49,22 @@ public class HoldEvent extends AbstractHoldEvent
     public HoldEvent(Object source)
     {
         super(source);
-        /* Asterisk prior to 1.6 and after 11 uses Hold and Unhold events instead of the status
-         * So we set the status to true in the Hold event and to false in Unhold.
-         * For Asterisk 1.6-11 this is overridden by the status property received with
-         * the hold event.
+        /*
+         * Asterisk prior to 1.6 and after 11 uses Hold and Unhold events
+         * instead of the status So we set the status to true in the Hold event
+         * and to false in Unhold. For Asterisk 1.6-11 this is overridden by the
+         * status property received with the hold event.
          */
         setStatus(true);
     }
 
-    public String getMusicClass() {
-		return musicClass;
+    public String getMusicClass()
+    {
+        return musicClass;
     }
 
-    public void setMusicClass(String musicClass) {
-		this.musicClass = musicClass;
+    public void setMusicClass(String musicClass)
+    {
+        this.musicClass = musicClass;
     }
 }

--- a/src/main/java/org/asteriskjava/manager/event/HoldEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/HoldEvent.java
@@ -28,25 +28,14 @@ package org.asteriskjava.manager.event;
  * @version $Id$
  * @since 0.2
  */
-public class HoldEvent extends ManagerEvent
+public class HoldEvent extends AbstractHoldEvent
 {
     /**
      * Serializable version identifier.
      */
     private static final long serialVersionUID = 0L;
 
-    /**
-     * The name of the channel.
-     */
-    private String channel;
-
-    /**
-     * The unique id of the channel.
-     */
-    private String uniqueId;
-
-    private Boolean status;
-
+    private String musicClass;
     /**
      * Creates a new HoldEvent.
      *
@@ -55,96 +44,19 @@ public class HoldEvent extends ManagerEvent
     public HoldEvent(Object source)
     {
         super(source);
-
-        /* Asterisk prior to 1.6 uses Hold and Unhold events instead of the status
+        /* Asterisk prior to 1.6 and after 11 uses Hold and Unhold events instead of the status
          * So we set the status to true in the Hold event and to false in Unhold.
-         * For Asterisk 1.6 this is overridden by the status property received with
+         * For Asterisk 1.6-11 this is overridden by the status property received with
          * the hold event.
          */
         setStatus(true);
     }
 
-    /**
-     * Returns the name of the channel.
-     *
-     * @return channel the name of the channel.
-     */
-    public String getChannel()
-    {
-        return channel;
+    public String getMusicClass() {
+		return musicClass;
     }
 
-    /**
-     * Sets the name of the channel.
-     *
-     * @param channel the name of the channel.
-     */
-    public void setChannel(String channel)
-    {
-        this.channel = channel;
-    }
-
-    /**
-     * Returns the unique id of the channel.
-     *
-     * @return the unique id of the channel.
-     */
-    public String getUniqueId()
-    {
-        return uniqueId;
-    }
-
-    /**
-     * Sets the unique id of the channel.
-     *
-     * @param uniqueId the unique id of the channel.
-     */
-    public void setUniqueId(String uniqueId)
-    {
-        this.uniqueId = uniqueId;
-    }
-
-    /**
-     * Returns whether this is a hold or unhold event.
-     *
-     * @return <code>true</code> if this a hold event, <code>false</code> if it's an unhold event.
-     * @since 1.0.0
-     */
-    public Boolean getStatus()
-    {
-        return status;
-    }
-
-    /**
-     * Returns whether this is a hold or unhold event.
-     *
-     * @param status <code>true</code> if this a hold event, <code>false</code> if it's an unhold event.
-     * @since 1.0.0
-     */
-    public void setStatus(Boolean status)
-    {
-        this.status = status;
-    }
-
-    /**
-     * Returns whether this is a hold event.
-     *
-     * @return <code>true</code> if this a hold event, <code>false</code> if it's an unhold event.
-     * @since 1.0.0
-     */
-    public boolean isHold()
-    {
-        return status != null && status;
-    }
-
-    /**
-     * Returns whether this is an unhold event.
-     *
-     * @return <code>true</code> if this an unhold event, <code>false</code> if it's a hold event.
-     * @since 1.0.0
-     */
-    public boolean isUnhold()
-    {
-        return status != null && !status;
+    public void setMusicClass(String musicClass) {
+		this.musicClass = musicClass;
     }
 }

--- a/src/main/java/org/asteriskjava/manager/event/ManagerEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ManagerEvent.java
@@ -147,6 +147,8 @@ public abstract class ManagerEvent extends EventObject
      */
     private String server;
 
+    private String systemName;
+    
     // AJ-213 only used when debugging is turned on
     private String file;
     private Integer line;
@@ -259,6 +261,14 @@ public abstract class ManagerEvent extends EventObject
     {
         this.server = server;
     }
+
+	public String getSystemName() {
+		return systemName;
+	}
+
+	public void setSystemName(String systemName) {
+		this.systemName = systemName;
+	}
 
     /**
      * Returns the name of the file in Asterisk's source code that triggered this event. For example

--- a/src/main/java/org/asteriskjava/manager/event/ManagerEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ManagerEvent.java
@@ -23,11 +23,9 @@ import org.asteriskjava.util.ReflectionUtil;
 
 /**
  * Abstract base class for all Events that can be received from the Asterisk
- * server.
- * <br>
+ * server. <br>
  * Events contain data pertaining to an event generated from within the Asterisk
- * core or an extension module.
- * <br>
+ * core or an extension module. <br>
  * There is one conrete subclass of ManagerEvent per each supported Asterisk
  * Event.
  *
@@ -52,79 +50,98 @@ public abstract class ManagerEvent extends EventObject
     /**
      * Returns the Caller ID name of the caller's channel.
      *
-     * @return the Caller ID name of the caller's channel or "unknown" if none has been set.
+     * @return the Caller ID name of the caller's channel or "unknown" if none
+     *         has been set.
      * @since 0.2
      */
 
-    public String getCallerIdName() {
+    public String getCallerIdName()
+    {
         return callerIdName;
     }
 
-    public void setCallerIdName(String callerIdName) {
+    public void setCallerIdName(String callerIdName)
+    {
         this.callerIdName = callerIdName;
     }
 
-    public String getConnectedLineNum() {
+    public String getConnectedLineNum()
+    {
         return connectedLineNum;
     }
 
-    public void setConnectedLineNum(String connectedLineNum) {
+    public void setConnectedLineNum(String connectedLineNum)
+    {
         this.connectedLineNum = connectedLineNum;
     }
 
-    public String getConnectedLineName() {
+    public String getConnectedLineName()
+    {
         return connectedLineName;
     }
 
-    public void setConnectedLineName(String connectedLineName) {
+    public void setConnectedLineName(String connectedLineName)
+    {
         this.connectedLineName = connectedLineName;
     }
 
-    public Integer getPriority() {
+    public Integer getPriority()
+    {
         return priority;
     }
 
-    public void setPriority(Integer priority) {
+    public void setPriority(Integer priority)
+    {
         this.priority = priority;
     }
 
-    public Integer getChannelState() {
+    public Integer getChannelState()
+    {
         return channelState;
     }
 
-    public void setChannelState(Integer channelState) {
+    public void setChannelState(Integer channelState)
+    {
         this.channelState = channelState;
     }
 
-    public String getChannelStateDesc() {
+    public String getChannelStateDesc()
+    {
         return channelStateDesc;
     }
 
-    public void setChannelStateDesc(String channelStateDesc) {
+    public void setChannelStateDesc(String channelStateDesc)
+    {
         this.channelStateDesc = channelStateDesc;
     }
 
-    public String getExten() {
+    public String getExten()
+    {
         return exten;
     }
 
-    public void setExten(String exten) {
+    public void setExten(String exten)
+    {
         this.exten = exten;
     }
 
-    public String getCallerIdNum() {
+    public String getCallerIdNum()
+    {
         return callerIdNum;
     }
 
-    public void setCallerIdNum(String callerIdNum) {
+    public void setCallerIdNum(String callerIdNum)
+    {
         this.callerIdNum = callerIdNum;
     }
 
-    public String getContext() {
+    public String getContext()
+    {
         return context;
     }
 
-    public void setContext(String context) {
+    public void setContext(String context)
+    {
         this.context = context;
     }
 
@@ -143,12 +160,13 @@ public abstract class ManagerEvent extends EventObject
     private Double timestamp;
 
     /**
-     * The server from which this event has been received (only used with AstManProxy).
+     * The server from which this event has been received (only used with
+     * AstManProxy).
      */
     private String server;
 
     private String systemName;
-    
+
     // AJ-213 only used when debugging is turned on
     private String file;
     private Integer line;
@@ -163,8 +181,7 @@ public abstract class ManagerEvent extends EventObject
 
     /**
      * Returns the point in time this event was received from the Asterisk
-     * server.
-     * <br>
+     * server. <br>
      * Pseudo events that are not directly received from the asterisk server
      * (for example ConnectEvent and DisconnectEvent) may return
      * <code>null</code>.
@@ -183,11 +200,9 @@ public abstract class ManagerEvent extends EventObject
     }
 
     /**
-     * Returns the AMI authorization class of this event.
-     * <br>
+     * Returns the AMI authorization class of this event. <br>
      * This is one or more of system, call, log, verbose, command, agent or
-     * user. Multiple privileges are separated by comma.
-     * <br>
+     * user. Multiple privileges are separated by comma. <br>
      * Note: This property is not available from Asterisk 1.0 servers.
      *
      * @since 0.2
@@ -208,13 +223,10 @@ public abstract class ManagerEvent extends EventObject
     }
 
     /**
-     * Returns the timestamp for this event.
-     * <br>
+     * Returns the timestamp for this event. <br>
      * The timestamp property is available in Asterisk since 1.4 if enabled in
-     * <code>manager.conf</code> by setting <code>timestampevents = yes</code>.
-     * <br>
-     * In contains the time the event was generated in seconds since the epoch.
-     * <br>
+     * <code>manager.conf</code> by setting <code>timestampevents = yes</code>. <br>
+     * In contains the time the event was generated in seconds since the epoch. <br>
      * Example: 1159310429.569108
      *
      * @return the timestamp for this event.
@@ -237,13 +249,13 @@ public abstract class ManagerEvent extends EventObject
     }
 
     /**
-     * Returns the name of the Asterisk server from which this event has been received.
-     * <br>
+     * Returns the name of the Asterisk server from which this event has been
+     * received. <br>
      * This property is only available when using to AstManProxy.
      *
-     * @return the name of the Asterisk server from which this event has been received
-     *         or <code>null</code> when directly connected to an Asterisk server
-     *         instead of AstManProxy.
+     * @return the name of the Asterisk server from which this event has been
+     *         received or <code>null</code> when directly connected to an
+     *         Asterisk server instead of AstManProxy.
      * @since 1.0.0
      */
     public final String getServer()
@@ -252,9 +264,11 @@ public abstract class ManagerEvent extends EventObject
     }
 
     /**
-     * Sets the name of the Asterisk server from which this event has been received.
+     * Sets the name of the Asterisk server from which this event has been
+     * received.
      *
-     * @param server the name of the Asterisk server from which this event has been received.
+     * @param server the name of the Asterisk server from which this event has
+     *            been received.
      * @since 1.0.0
      */
     public final void setServer(String server)
@@ -262,22 +276,28 @@ public abstract class ManagerEvent extends EventObject
         this.server = server;
     }
 
-	public String getSystemName() {
-		return systemName;
-	}
+    public String getSystemName()
+    {
+        return systemName;
+    }
 
-	public void setSystemName(String systemName) {
-		this.systemName = systemName;
-	}
+    public void setSystemName(String systemName)
+    {
+        this.systemName = systemName;
+    }
 
     /**
-     * Returns the name of the file in Asterisk's source code that triggered this event. For example
-     * <code>pbx.c</code>.<p>
-     * This property is only available if debugging for the Manager API has been turned on in Asterisk. This can be
-     * done by calling <code>manager debug on</code> on Asterisk's command line interface or by adding
-     * <code>debug=on</code> to Asterisk's <code>manager.conf</code>. This feature is availble in Asterisk since 1.6.0.
+     * Returns the name of the file in Asterisk's source code that triggered
+     * this event. For example <code>pbx.c</code>.
+     * <p>
+     * This property is only available if debugging for the Manager API has been
+     * turned on in Asterisk. This can be done by calling
+     * <code>manager debug on</code> on Asterisk's command line interface or by
+     * adding <code>debug=on</code> to Asterisk's <code>manager.conf</code>.
+     * This feature is availble in Asterisk since 1.6.0.
      *
-     * @return the name of the file in that triggered this event or <code>null</code> if debgging is turned off.
+     * @return the name of the file in that triggered this event or
+     *         <code>null</code> if debgging is turned off.
      * @see #getFunc()
      * @see #getLine()
      * @since 1.0.0
@@ -293,12 +313,17 @@ public abstract class ManagerEvent extends EventObject
     }
 
     /**
-     * Returns the line number in Asterisk's source code where this event was triggered.<p>
-     * This property is only available if debugging for the Manager API has been turned on in Asterisk. This can be
-     * done by calling <code>manager debug on</code> on Asterisk's command line interface or by adding
-     * <code>debug=on</code> to Asterisk's <code>manager.conf</code>. This feature is availble in Asterisk since 1.6.0.
+     * Returns the line number in Asterisk's source code where this event was
+     * triggered.
+     * <p>
+     * This property is only available if debugging for the Manager API has been
+     * turned on in Asterisk. This can be done by calling
+     * <code>manager debug on</code> on Asterisk's command line interface or by
+     * adding <code>debug=on</code> to Asterisk's <code>manager.conf</code>.
+     * This feature is availble in Asterisk since 1.6.0.
      *
-     * @return the line number where this event was triggered or <code>null</code> if debgging is turned off.
+     * @return the line number where this event was triggered or
+     *         <code>null</code> if debgging is turned off.
      * @see #getFile()
      * @see #getFunc()
      * @since 1.0.0
@@ -314,13 +339,17 @@ public abstract class ManagerEvent extends EventObject
     }
 
     /**
-     * Returns the name of the C function in Asterisk's source code that triggered this event. For example
-     * <code>pbx_builtin_setvar_helper</code><p>
-     * This property is only available if debugging for the Manager API has been turned on in Asterisk. This can be
-     * done by calling <code>manager debug on</code> on Asterisk's command line interface or by adding
-     * <code>debug=on</code> to Asterisk's <code>manager.conf</code>. This feature is availble in Asterisk since 1.6.0.
+     * Returns the name of the C function in Asterisk's source code that
+     * triggered this event. For example <code>pbx_builtin_setvar_helper</code>
+     * <p>
+     * This property is only available if debugging for the Manager API has been
+     * turned on in Asterisk. This can be done by calling
+     * <code>manager debug on</code> on Asterisk's command line interface or by
+     * adding <code>debug=on</code> to Asterisk's <code>manager.conf</code>.
+     * This feature is availble in Asterisk since 1.6.0.
      *
-     * @return the name of the C function that triggered this event or <code>null</code> if debgging is turned off.
+     * @return the name of the C function that triggered this event or
+     *         <code>null</code> if debgging is turned off.
      * @see #getFile()
      * @see #getLine()
      * @since 1.0.0
@@ -336,12 +365,17 @@ public abstract class ManagerEvent extends EventObject
     }
 
     /**
-     * Returns the sequence numbers of this event. Sequence numbers are only incremented while debugging is enabled.<p>
-     * This property is only available if debugging for the Manager API has been turned on in Asterisk. This can be
-     * done by calling <code>manager debug on</code> on Asterisk's command line interface or by adding
-     * <code>debug=on</code> to Asterisk's <code>manager.conf</code>. This feature is availble in Asterisk since 1.6.0.
+     * Returns the sequence numbers of this event. Sequence numbers are only
+     * incremented while debugging is enabled.
+     * <p>
+     * This property is only available if debugging for the Manager API has been
+     * turned on in Asterisk. This can be done by calling
+     * <code>manager debug on</code> on Asterisk's command line interface or by
+     * adding <code>debug=on</code> to Asterisk's <code>manager.conf</code>.
+     * This feature is availble in Asterisk since 1.6.0.
      *
-     * @return the sequence number of this event or <code>null</code> if debgging is turned off.
+     * @return the sequence number of this event or <code>null</code> if
+     *         debgging is turned off.
      * @see #getFile()
      * @see #getLine()
      * @since 1.0.0
@@ -359,8 +393,8 @@ public abstract class ManagerEvent extends EventObject
     @Override
     public String toString()
     {
-        final List<String> ignoredProperties = Arrays.asList(
-                "file", "func", "line", "sequenceNumber", "datereceived", "privilege", "source", "class");
+        final List<String> ignoredProperties = Arrays.asList("file", "func", "line", "sequenceNumber", "datereceived",
+                "privilege", "source", "class");
         final StringBuilder sb = new StringBuilder(getClass().getName() + "[");
         appendPropertyIfNotNull(sb, "file", getFile());
         appendPropertyIfNotNull(sb, "func", getFunc());

--- a/src/main/java/org/asteriskjava/manager/event/MeetMeJoinEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/MeetMeJoinEvent.java
@@ -31,46 +31,11 @@ public class MeetMeJoinEvent extends AbstractMeetMeEvent
      */
     private static final long serialVersionUID = 0L;
 
-    private String callerIdNum;
-    private String callerIdName;
-
     /**
      * @param source
      */
     public MeetMeJoinEvent(Object source)
     {
         super(source);
-    }
-
-    /**
-     * Returns the Caller Id number.
-     *
-     * @return the Caller Id number or "&lt;unknown&gt;" if not set.
-     * @since 1.0.0
-     */
-    public String getCallerIdNum()
-    {
-        return callerIdNum;
-    }
-
-    public void setCallerIdNum(String callerIdNum)
-    {
-        this.callerIdNum = callerIdNum;
-    }
-
-    /**
-     * Returns the Caller Id name.
-     *
-     * @return the Caller Id name or "&lt;unknown&gt;" if not set.
-     * @since 1.0.0
-     */
-    public String getCallerIdName()
-    {
-        return callerIdName;
-    }
-
-    public void setCallerIdName(String callerIdName)
-    {
-        this.callerIdName = callerIdName;
     }
 }

--- a/src/main/java/org/asteriskjava/manager/event/MeetMeJoinEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/MeetMeJoinEvent.java
@@ -17,8 +17,11 @@
 package org.asteriskjava.manager.event;
 
 /**
- * A MeetMeJoinEvent is triggered if a channel joins a MeetMe conference.<p>
- * Channel and unqiueId properties for this event are available since Asterisk 1.0.<p>
+ * A MeetMeJoinEvent is triggered if a channel joins a MeetMe conference.
+ * <p>
+ * Channel and unqiueId properties for this event are available since Asterisk
+ * 1.0.
+ * <p>
  * It is implemented in <code>apps/app_meetme.c</code>
  *
  * @author srt

--- a/src/main/java/org/asteriskjava/manager/event/MeetMeLeaveEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/MeetMeLeaveEvent.java
@@ -17,8 +17,11 @@
 package org.asteriskjava.manager.event;
 
 /**
- * A MeetMeLeaveEvent is triggered if a channel leaves a MeetMe conference.<p>
- * Channel and unqiueId properties for this event are available since Asterisk 1.0.<p>
+ * A MeetMeLeaveEvent is triggered if a channel leaves a MeetMe conference.
+ * <p>
+ * Channel and unqiueId properties for this event are available since Asterisk
+ * 1.0.
+ * <p>
  * It is implemented in <code>apps/app_meetme.c</code>
  * 
  * @author srt
@@ -42,7 +45,8 @@ public class MeetMeLeaveEvent extends AbstractMeetMeEvent
     }
 
     /**
-     * Returns how long the user spent in the conference.<p>
+     * Returns how long the user spent in the conference.
+     * <p>
      * This property is available since Asterisk 1.4.
      * 
      * @return the duration in seconds the user spent in the conference.

--- a/src/main/java/org/asteriskjava/manager/event/MeetMeLeaveEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/MeetMeLeaveEvent.java
@@ -31,10 +31,6 @@ public class MeetMeLeaveEvent extends AbstractMeetMeEvent
      */
     private static final long serialVersionUID = 7692361610793036224L;
 
-    private String callerIdNum;
-    private String callerIdName;
-    private String connectedlinename;
-    private String connectedlinenum;    
     private Long duration;
 
     /**
@@ -43,48 +39,6 @@ public class MeetMeLeaveEvent extends AbstractMeetMeEvent
     public MeetMeLeaveEvent(Object source)
     {
         super(source);
-    }
-
-    /**
-     * Returns the Caller*ID Name of the channel that left the conference.<p>
-     * This property is available since Asterisk 1.4.
-     * 
-     * @return the Caller*ID Name of the channel that left the conference.
-     */
-    public String getCallerIdName()
-    {
-        return callerIdName;
-    }
-
-    /**
-     * Sets the Caller*ID Name of the channel that left the conference.
-     * 
-     * @param callerIdName the Caller*ID Name of the channel that left the conference.
-     */
-    public void setCallerIdName(String callerIdName)
-    {
-        this.callerIdName = callerIdName;
-    }
-
-    /**
-     * Returns the Caller*ID Number of the channel that left the conference.<p>
-     * This property is available since Asterisk 1.4.
-     * 
-     * @return the Caller*ID Number of the channel that left the conference.
-     */
-    public String getCallerIdNum()
-    {
-        return callerIdNum;
-    }
-
-    /**
-     * Sets the Caller*ID Number of the channel that left the conference.
-     * 
-     * @param callerIdNum the Caller*ID Number of the channel that left the conference.
-     */
-    public void setCallerIdNum(String callerIdNum)
-    {
-        this.callerIdNum = callerIdNum;
     }
 
     /**
@@ -107,25 +61,4 @@ public class MeetMeLeaveEvent extends AbstractMeetMeEvent
     {
         this.duration = duration;
     }
-
-	public String getConnectedlinename()
-	{
-		return connectedlinename;
-	}
-
-	public void setConnectedlinename(String connectedlinename)
-	{
-		this.connectedlinename = connectedlinename;
-	}
-
-	public String getConnectedlinenum()
-	{
-		return connectedlinenum;
-	}
-
-	public void setConnectedlinenum(String connectedlinenum)
-	{
-		this.connectedlinenum = connectedlinenum;
-	}
-    
 }

--- a/src/main/java/org/asteriskjava/manager/event/NewChannelEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/NewChannelEvent.java
@@ -17,7 +17,8 @@
 package org.asteriskjava.manager.event;
 
 /**
- * A NewChannelEvent is triggered when a new channel is created.<p>
+ * A NewChannelEvent is triggered when a new channel is created.
+ * <p>
  * It is implemented in <code>channel.c</code>
  *
  * @author srt
@@ -40,16 +41,17 @@ public class NewChannelEvent extends AbstractChannelStateEvent
 
     public String getLanguage()
     {
-    	return language;
+        return language;
     }
-    
+
     public void setLanguage(String language)
     {
-    	this.language = language;
+        this.language = language;
     }
-    
+
     /**
-     * Returns the account code of the new channel.<p>
+     * Returns the account code of the new channel.
+     * <p>
      * This property is available since Asterisk 1.6.
      *
      * @return the account code of the new channel.

--- a/src/main/java/org/asteriskjava/manager/event/NewChannelEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/NewChannelEvent.java
@@ -31,9 +31,6 @@ public class NewChannelEvent extends AbstractChannelStateEvent
     static final long serialVersionUID = 1L;
 
     private String accountCode;
-    private String context;
-    private String exten;
-    private Integer priority;
     private String language;
 
     public NewChannelEvent(Object source)
@@ -72,67 +69,5 @@ public class NewChannelEvent extends AbstractChannelStateEvent
     public void setAccountCode(String accountCode)
     {
         this.accountCode = accountCode;
-    }
-
-    /**
-     * Returns the context of the dialplan entry the channel started at.<p>
-     * This property is available since Asterisk 1.6.
-     *
-     * @return the context of the dialplan entry the channel started at.
-     * @since 1.0.0
-     */
-    public String getContext()
-    {
-        return context;
-    }
-
-    /**
-     * Sets the context of the dialplan entry the channel started at.
-     *
-     * @param context the context of the dialplan entry the channel started at.
-     * @since 1.0.0
-     */
-    public void setContext(String context)
-    {
-        this.context = context;
-    }
-
-    /**
-     * Returns the extension of the dialplan entry the channel started at.<p>
-     * This property is available since Asterisk 1.6.
-     *
-     * @return the extension of the dialplan entry the channel started at.
-     * @since 1.0.0
-     */
-    public String getExten()
-    {
-        return exten;
-    }
-
-    /**
-     * Sets the extension of the dialplan entry the channel started at.
-     *
-     * @param exten the extension of the dialplan entry the channel started at.
-     * @since 1.0.0
-     */
-    public void setExten(String exten)
-    {
-        this.exten = exten;
-    }
-
-    /**
-     * Returns the priority.
-     */
-    public Integer getPriority()
-    {
-        return priority;
-    }
-
-    /**
-     * Sets the priority.
-     */
-    public void setPriority(Integer priority)
-    {
-        this.priority = priority;
     }
 }

--- a/src/main/java/org/asteriskjava/manager/event/ParkedCallEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ParkedCallEvent.java
@@ -18,7 +18,8 @@ package org.asteriskjava.manager.event;
 
 /**
  * A ParkedCallEvent is triggered when a channel is parked (in this case no
- * action id is set) and in response to a ParkedCallsAction.<p>
+ * action id is set) and in response to a ParkedCallsAction.
+ * <p>
  * It is implemented in <code>res/res_features.c</code>
  * 
  * @see org.asteriskjava.manager.action.ParkedCallsAction
@@ -31,9 +32,8 @@ public class ParkedCallEvent extends AbstractParkedCallEvent
      * Serializable version identifier
      */
     private static final long serialVersionUID = 0L;
-    
+
     private Integer timeout;
-    
 
     /**
      * @param source
@@ -44,7 +44,8 @@ public class ParkedCallEvent extends AbstractParkedCallEvent
     }
 
     /**
-     * Returns the number of seconds this call will be parked.<p>
+     * Returns the number of seconds this call will be parked.
+     * <p>
      * This corresponds to the <code>parkingtime</code> option in
      * <code>features.conf</code>.
      */
@@ -60,10 +61,10 @@ public class ParkedCallEvent extends AbstractParkedCallEvent
     {
         this.timeout = timeout;
     }
-  
+
     /**
-     * Sets the unique id of the parked channel as a
-     * workaround for a typo in asterisk manager event.
+     * Sets the unique id of the parked channel as a workaround for a typo in
+     * asterisk manager event.
      */
     public void setUnqiueId(String unqiueId)
     {

--- a/src/main/java/org/asteriskjava/manager/event/ParkedCallEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ParkedCallEvent.java
@@ -32,7 +32,6 @@ public class ParkedCallEvent extends AbstractParkedCallEvent
      */
     private static final long serialVersionUID = 0L;
     
-    private String from;
     private Integer timeout;
     
 
@@ -42,22 +41,6 @@ public class ParkedCallEvent extends AbstractParkedCallEvent
     public ParkedCallEvent(Object source)
     {
         super(source);
-    }
-
-    /**
-     * Returns the name of the channel that parked the call.
-     */
-    public String getFrom()
-    {
-        return from;
-    }
-
-    /**
-     * Sets the name of the channel that parked the call.
-     */
-    public void setFrom(String from)
-    {
-        this.from = from;
     }
 
     /**

--- a/src/main/java/org/asteriskjava/manager/event/ParkedCallGiveUpEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ParkedCallGiveUpEvent.java
@@ -26,7 +26,7 @@ package org.asteriskjava.manager.event;
  * @version $Id$
  * @since 0.2
  */
-public class ParkedCallGiveUpEvent extends AbstractParkedCallEvent
+public class ParkedCallGiveUpEvent extends AbstractUnParkedEvent
 {
     /**
      * Serializable version identifier

--- a/src/main/java/org/asteriskjava/manager/event/ParkedCallGiveUpEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ParkedCallGiveUpEvent.java
@@ -18,8 +18,10 @@ package org.asteriskjava.manager.event;
 
 /**
  * A ParkedCallGiveUpEvent is triggered when a channel that has been parked is
- * hung up.<p>
- * It is implemented in <code>res/res_features.c</code><p>
+ * hung up.
+ * <p>
+ * It is implemented in <code>res/res_features.c</code>
+ * <p>
  * Available since Asterisk 1.2
  * 
  * @author srt

--- a/src/main/java/org/asteriskjava/manager/event/ParkedCallTimeOutEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ParkedCallTimeOutEvent.java
@@ -18,8 +18,10 @@ package org.asteriskjava.manager.event;
 
 /**
  * A ParkedCallTimeOutEvent is triggered when call parking times out for a given
- * channel.<p>
- * It is implemented in <code>res/res_features.c</code><p>
+ * channel.
+ * <p>
+ * It is implemented in <code>res/res_features.c</code>
+ * <p>
  * Available since Asterisk 1.2
  * 
  * @author srt

--- a/src/main/java/org/asteriskjava/manager/event/ParkedCallTimeOutEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ParkedCallTimeOutEvent.java
@@ -26,7 +26,7 @@ package org.asteriskjava.manager.event;
  * @version $Id$
  * @since 0.2
  */
-public class ParkedCallTimeOutEvent extends AbstractParkedCallEvent
+public class ParkedCallTimeOutEvent extends AbstractUnParkedEvent
 {
     /**
      * Serializable version identifier

--- a/src/main/java/org/asteriskjava/manager/event/ParkedCallsCompleteEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ParkedCallsCompleteEvent.java
@@ -17,12 +17,11 @@
 package org.asteriskjava.manager.event;
 
 /**
- * A ParkedCallsCompleteEvent is triggered after all parked calls have been reported in response to
- * a ParkedCallsAction.
+ * A ParkedCallsCompleteEvent is triggered after all parked calls have been
+ * reported in response to a ParkedCallsAction.
  * 
  * @see org.asteriskjava.manager.action.ParkedCallsAction
  * @see org.asteriskjava.manager.event.ParkedCallEvent
- * 
  * @author srt
  * @version $Id$
  */

--- a/src/main/java/org/asteriskjava/manager/event/QueueEntryEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/QueueEntryEvent.java
@@ -18,7 +18,8 @@ package org.asteriskjava.manager.event;
 
 /**
  * A QueueEntryEvent is triggered in response to a QueueStatusAction and
- * contains information about an entry in a queue.<p>
+ * contains information about an entry in a queue.
+ * <p>
  * It is implemented in <code>apps/app_queue.c</code>
  *
  * @author srt
@@ -87,7 +88,8 @@ public class QueueEntryEvent extends ResponseEvent
     }
 
     /**
-     * Returns the unique id of the channel of this entry.<p>
+     * Returns the unique id of the channel of this entry.
+     * <p>
      * Available since Asterisk 1.6.
      *
      * @return the unique id of the channel of this entry.
@@ -113,25 +115,25 @@ public class QueueEntryEvent extends ResponseEvent
         this.channel = channel;
     }
 
-	/**
+    /**
      * Returns the the Caller*ID number of this entry.
      *
      * @return the the Caller*ID number of this entry.
      */
-    public String getCallerId() 
+    public String getCallerId()
     {
-		return callerId;
-	}
+        return callerId;
+    }
 
     /**
      * Sets the the Caller*ID number of this entry.
      *
      * @param callerId the the Caller*ID number of this entry.
      */
-	public void setCallerId(String callerId) 
-	{
-		this.callerId = callerId;
-	}
+    public void setCallerId(String callerId)
+    {
+        this.callerId = callerId;
+    }
 
     /**
      * Returns the number of seconds this entry has spent in the queue.
@@ -148,5 +150,5 @@ public class QueueEntryEvent extends ResponseEvent
     {
         this.wait = wait;
     }
-   
+
 }

--- a/src/main/java/org/asteriskjava/manager/event/QueueEntryEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/QueueEntryEvent.java
@@ -36,10 +36,6 @@ public class QueueEntryEvent extends ResponseEvent
     private String uniqueId;
     private String channel;
     private String callerId;
-    private String callerIdName;
-    private String callerIdNum;
-    private String connectedlinename;
-    private String connectedlinenum;       
     private Long wait;
 
     /**
@@ -138,50 +134,6 @@ public class QueueEntryEvent extends ResponseEvent
 	}
 
     /**
-     * Returns the Caller*ID name of this entry.
-     *
-     * @return the Caller*ID name of this entry.
-     * @since 0.2
-     */
-    public String getCallerIdName()
-    {
-        return callerIdName;
-    }
-
-    /**
-     * Sets the Caller*ID name of this entry.
-     *
-     * @param callerIdName the Caller*ID name of this entry.
-     * @since 0.2
-     */
-    public void setCallerIdName(String callerIdName)
-    {
-        this.callerIdName = callerIdName;
-    }
-
-    /**
-     * Gets the Caller*ID num of this entry.
-     *
-     * @return the Caller*ID num of this entry.
-     * @since 1.0.0
-     */
-    public String getCallerIdNum()
-    {
-        return callerIdNum;
-    }
-
-    /**
-     * Sets the Caller*ID num of this entry.
-     *
-     * @param callerIdNum the Caller*ID num of this entry.
-     * @since 1.0.0
-     */
-    public void setCallerIdNum(String callerIdNum)
-    {
-        this.callerIdNum = callerIdNum;
-    }
-
-    /**
      * Returns the number of seconds this entry has spent in the queue.
      */
     public Long getWait()
@@ -196,25 +148,5 @@ public class QueueEntryEvent extends ResponseEvent
     {
         this.wait = wait;
     }
-
-	public String getConnectedlinename()
-	{
-		return connectedlinename;
-	}
-
-	public void setConnectedlinename(String connectedlinename)
-	{
-		this.connectedlinename = connectedlinename;
-	}
-
-	public String getConnectedlinenum()
-	{
-		return connectedlinenum;
-	}
-
-	public void setConnectedlinenum(String connectedlinenum)
-	{
-		this.connectedlinenum = connectedlinenum;
-	}
    
 }

--- a/src/main/java/org/asteriskjava/manager/event/StatusEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/StatusEvent.java
@@ -34,20 +34,12 @@ public class StatusEvent extends ResponseEvent
      */
     private static final long serialVersionUID = -3619197512835308812L;
     private String channel;
-    private String callerIdNum;
-    private String callerIdName;
     private String accountCode;
     private Integer channelState;
-    private String channelStateDesc;
-    private String context;
-    private String extension;
-    private Integer priority;
     private Integer seconds;
     private String bridgedChannel;
     private String bridgedUniqueId;
     private String uniqueId;
-    private String connectedlinenum;
-    private String connectedlinename;
     private Map<String, String> variables;
 
     public StatusEvent(Object source)
@@ -232,42 +224,22 @@ public class StatusEvent extends ResponseEvent
      */
     @Deprecated public String getState()
     {
-        return channelStateDesc;
+        return getChannelStateDesc();
     }
 
     public void setState(String state)
     {
-        this.channelStateDesc = state;
-    }
-
-    public String getContext()
-    {
-        return context;
-    }
-
-    public void setContext(String context)
-    {
-        this.context = context;
+        setChannelStateDesc(state);
     }
 
     public String getExtension()
     {
-        return extension;
+        return getExten();
     }
 
     public void setExtension(String extension)
     {
-        this.extension = extension;
-    }
-
-    public Integer getPriority()
-    {
-        return priority;
-    }
-
-    public void setPriority(Integer priority)
-    {
-        this.priority = priority;
+        setExten(extension);
     }
 
     /**
@@ -402,25 +374,5 @@ public class StatusEvent extends ResponseEvent
     {
         this.variables = variables;
     }
-
-	public String getConnectedlinenum()
-	{
-		return connectedlinenum;
-	}
-
-	public void setConnectedlinenum(String connectedlinenum)
-	{
-		this.connectedlinenum = connectedlinenum;
-	}
-
-	public String getConnectedlinename()
-	{
-		return connectedlinename;
-	}
-
-	public void setConnectedlinename(String connectedlinename)
-	{
-		this.connectedlinename = connectedlinename;
-	}
     
 }

--- a/src/main/java/org/asteriskjava/manager/event/StatusEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/StatusEvent.java
@@ -21,7 +21,8 @@ import org.asteriskjava.util.AstState;
 import java.util.Map;
 
 /**
- * A StatusEvent is triggered for each active channel in response to a StatusAction.
+ * A StatusEvent is triggered for each active channel in response to a
+ * StatusAction.
  *
  * @author srt
  * @version $Id$
@@ -68,19 +69,24 @@ public class StatusEvent extends ResponseEvent
     }
 
     /**
-     * Returns the Caller*ID Number of this channel.<p>
-     * This property is deprecated as of Asterisk 1.4, use {@link #getCallerIdNum()} instead.
+     * Returns the Caller*ID Number of this channel.
+     * <p>
+     * This property is deprecated as of Asterisk 1.4, use
+     * {@link #getCallerIdNum()} instead.
      *
-     * @return the Caller*ID Number of this channel or <code>null</code> if none is available.
+     * @return the Caller*ID Number of this channel or <code>null</code> if none
+     *         is available.
      * @deprecated
      */
-    @Deprecated public String getCallerId()
+    @Deprecated
+    public String getCallerId()
     {
         return callerIdNum;
     }
 
     /**
-     * Sets the Caller*ID Number of this channel.<p>
+     * Sets the Caller*ID Number of this channel.
+     * <p>
      * This property is deprecated as of Asterisk 1.4.
      *
      * @param callerIdNum the Caller*ID Number to set.
@@ -93,7 +99,8 @@ public class StatusEvent extends ResponseEvent
     /**
      * Returns the Caller*ID Number of this channel.
      *
-     * @return the Caller*ID Number of this channel or <code>null</code> if none is available.
+     * @return the Caller*ID Number of this channel or <code>null</code> if none
+     *         is available.
      * @since 0.3
      */
     public String getCallerIdNum()
@@ -115,7 +122,8 @@ public class StatusEvent extends ResponseEvent
     /**
      * Returns the Caller*ID Name of this channel.
      *
-     * @return the Caller*ID Name of this channel or <code>null</code> if none is available.
+     * @return the Caller*ID Name of this channel or <code>null</code> if none
+     *         is available.
      */
     public String getCallerIdName()
     {
@@ -160,14 +168,17 @@ public class StatusEvent extends ResponseEvent
      * @return the account code of this channel.
      * @deprecated since 1.0.0, use {@link #getAccountCode()} instead.
      */
-    @Deprecated public String getAccount()
+    @Deprecated
+    public String getAccount()
     {
         return accountCode;
     }
 
     /**
-     * Sets the account code of this channel.<p>
-     * Asterisk versions up to 1.4 use the "Account" property instead of "AccountCode".
+     * Sets the account code of this channel.
+     * <p>
+     * Asterisk versions up to 1.4 use the "Account" property instead of
+     * "AccountCode".
      *
      * @param account the account code of this channel.
      */
@@ -177,9 +188,10 @@ public class StatusEvent extends ResponseEvent
     }
 
     /**
-     * Returns the state of the channel.<p>
-     * For Asterisk versions prior to 1.6 (that do not send the numeric value) it is derived
-     * from the descriptive text.
+     * Returns the state of the channel.
+     * <p>
+     * For Asterisk versions prior to 1.6 (that do not send the numeric value)
+     * it is derived from the descriptive text.
      *
      * @return the state of the channel.
      * @since 1.0.0
@@ -222,7 +234,8 @@ public class StatusEvent extends ResponseEvent
      * @return the state of the channel as a descriptive text.
      * @deprecated use {@link #getChannelStateDesc()} instead.
      */
-    @Deprecated public String getState()
+    @Deprecated
+    public String getState()
     {
         return getChannelStateDesc();
     }
@@ -276,7 +289,8 @@ public class StatusEvent extends ResponseEvent
     /**
      * Sets the name of the linked channel.
      *
-     * @param bridgedChannel the name of the linked channel if this channel is bridged.
+     * @param bridgedChannel the name of the linked channel if this channel is
+     *            bridged.
      * @since 1.0.0
      */
     public void setBridgedChannel(String bridgedChannel)
@@ -290,13 +304,15 @@ public class StatusEvent extends ResponseEvent
      * @return the name of the linked channel if this channel is bridged.
      * @deprecated as of 1.0.0, use {@link #getBridgedChannel()} instead.
      */
-    @Deprecated public String getLink()
+    @Deprecated
+    public String getLink()
     {
         return bridgedChannel;
     }
 
     /**
-     * Sets the name of the linked channel.<p>
+     * Sets the name of the linked channel.
+     * <p>
      * Asterisk versions up to 1.4 use "Link" instead of "BridgedChannel".
      *
      * @param link the name of the linked channel if this channel is bridged.
@@ -307,7 +323,8 @@ public class StatusEvent extends ResponseEvent
     }
 
     /**
-     * Returns the unique id of the linked channel if this channel is bridged.<p>
+     * Returns the unique id of the linked channel if this channel is bridged.
+     * <p>
      * Available since Asterisk 1.6.
      *
      * @return the unique id of the linked channel if this channel is bridged.
@@ -319,10 +336,12 @@ public class StatusEvent extends ResponseEvent
     }
 
     /**
-     * Sets the unique id of the linked channel if this channel is bridged.<p>
+     * Sets the unique id of the linked channel if this channel is bridged.
+     * <p>
      * Available since Asterisk 1.6.
      *
-     * @param bridgedUniqueId the unique id of the linked channel if this channel is bridged.
+     * @param bridgedUniqueId the unique id of the linked channel if this
+     *            channel is bridged.
      * @since 1.0.0
      */
     public void setBridgedUniqueId(String bridgedUniqueId)
@@ -351,8 +370,10 @@ public class StatusEvent extends ResponseEvent
     }
 
     /**
-     * Returns the channel variables if the {@link org.asteriskjava.manager.action.StatusAction#setVariables(String)}
-     * property has been set.<p>
+     * Returns the channel variables if the
+     * {@link org.asteriskjava.manager.action.StatusAction#setVariables(String)}
+     * property has been set.
+     * <p>
      * Available since Asterisk 1.6
      *
      * @return the channel variables.
@@ -364,7 +385,8 @@ public class StatusEvent extends ResponseEvent
     }
 
     /**
-     * Sets the channel variables.<p>
+     * Sets the channel variables.
+     * <p>
      * Available since Asterisk 1.6
      *
      * @param variables the channel variables.
@@ -374,5 +396,5 @@ public class StatusEvent extends ResponseEvent
     {
         this.variables = variables;
     }
-    
+
 }

--- a/src/main/java/org/asteriskjava/manager/event/UnholdEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/UnholdEvent.java
@@ -27,10 +27,9 @@ package org.asteriskjava.manager.event;
  * @version $Id$
  * @see org.asteriskjava.manager.event.HoldEvent
  * @since 0.2
- * @deprecated as of 1.0.0, use {@link org.asteriskjava.manager.event.HoldEvent} and its
- *             {@link #isUnhold()} method instead.
+ * Enro 2015-03: No longer deprecated since Asterisk 13 uses this again.
  */
-@Deprecated public class UnholdEvent extends HoldEvent
+public class UnholdEvent extends AbstractHoldEvent
 {
     /**
      * Serializable version identifier.

--- a/src/main/java/org/asteriskjava/manager/event/UnholdEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/UnholdEvent.java
@@ -18,16 +18,19 @@ package org.asteriskjava.manager.event;
 
 /**
  * An UnholdEvent is triggered by the SIP channel driver when a channel is no
- * longer put on hold.<p>
- * It is implemented in <code>channels/chan_sip.c</code>.<p>
- * Available since Asterisk 1.2, as of Asterisk 1.6 only {@link org.asteriskjava.manager.event.HoldEvent} is sent
- * with the status set to <code>false</code> to indicate unhold.
+ * longer put on hold.
+ * <p>
+ * It is implemented in <code>channels/chan_sip.c</code>.
+ * <p>
+ * Available since Asterisk 1.2, as of Asterisk 1.6 only
+ * {@link org.asteriskjava.manager.event.HoldEvent} is sent with the status set
+ * to <code>false</code> to indicate unhold.
  *
  * @author srt
  * @version $Id$
  * @see org.asteriskjava.manager.event.HoldEvent
- * @since 0.2
- * Enro 2015-03: No longer deprecated since Asterisk 13 uses this again.
+ * @since 0.2 Enro 2015-03: No longer deprecated since Asterisk 13 uses this
+ *        again.
  */
 public class UnholdEvent extends AbstractHoldEvent
 {

--- a/src/main/java/org/asteriskjava/manager/event/UnparkedCallEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/UnparkedCallEvent.java
@@ -26,15 +26,28 @@ package org.asteriskjava.manager.event;
  * @version $Id$
  * @since 0.2
  */
-public class UnparkedCallEvent extends AbstractParkedCallEvent
+public class UnparkedCallEvent extends AbstractUnParkedEvent
 {
     /**
      * Serializable version identifier
      */
     private static final long serialVersionUID = -7437833328723536814L;
 
-    private String from;
-
+    /**
+     * Enro 2015-03: Asterisk 13 Support
+     */
+    private String RetrieverChannel;
+    private Integer RetrieverChannelState;
+    private String RetrieverChannelStateDesc;
+    private String RetrieverCallerIDNum;
+    private String RetrieverCallerIDName;
+    private String RetrieverConnectedLineNum;
+    private String RetrieverConnectedLineName;
+    private String RetrieverAccountCode;
+    private String RetrieverContext;
+    private String RetrieverExten;
+    private String RetrieverPriority;
+    private String RetrieverUniqueid;
     /**
      * @param source
      */
@@ -42,20 +55,76 @@ public class UnparkedCallEvent extends AbstractParkedCallEvent
     {
         super(source);
     }
-
-    /**
-     * Returns the name of the channel that parked the call.
-     */
-    public String getFrom()
-    {
-        return from;
+	public String getRetrieverChannel() {
+		return RetrieverChannel;
+	}
+	public void setRetrieverChannel(String retrieverChannel) {
+		RetrieverChannel = retrieverChannel;
+	}
+	public Integer getRetrieverChannelState() {
+		return RetrieverChannelState;
+	}
+	public void setRetrieverChannelState(Integer retrieverChannelState) {
+		RetrieverChannelState = retrieverChannelState;
+	}
+	public String getRetrieverChannelStateDesc() {
+		return RetrieverChannelStateDesc;
+	}
+	public void setRetrieverChannelStateDesc(String retrieverChannelStateDesc) {
+		RetrieverChannelStateDesc = retrieverChannelStateDesc;
+	}
+	public String getRetrieverCallerIDNum() {
+		return RetrieverCallerIDNum;
+	}
+	public void setRetrieverCallerIDNum(String retrieverCallerIDNum) {
+		RetrieverCallerIDNum = retrieverCallerIDNum;
+	}
+	public String getRetrieverCallerIDName() {
+		return RetrieverCallerIDName;
+	}
+	public void setRetrieverCallerIDName(String retrieverCallerIDName) {
+		RetrieverCallerIDName = retrieverCallerIDName;
+	}
+	public String getRetrieverConnectedLineNum() {
+		return RetrieverConnectedLineNum;
+	}
+	public void setRetrieverConnectedLineNum(String retrieverConnectedLineNum) {
+		RetrieverConnectedLineNum = retrieverConnectedLineNum;
+	}
+	public String getRetrieverConnectedLineName() {
+		return RetrieverConnectedLineName;
+	}
+	public void setRetrieverConnectedLineName(String retrieverConnectedLineName) {
+		RetrieverConnectedLineName = retrieverConnectedLineName;
+	}
+	public String getRetrieverAccountCode() {
+		return RetrieverAccountCode;
+	}
+	public void setRetrieverAccountCode(String retrieverAccountCode) {
+		RetrieverAccountCode = retrieverAccountCode;
+	}
+	public String getRetrieverContext() {
+		return RetrieverContext;
+	}
+	public void setRetrieverContext(String retrieverContext) {
+		RetrieverContext = retrieverContext;
+	}
+	public String getRetrieverExten() {
+		return RetrieverExten;
+	}
+	public void setRetrieverExten(String retrieverExten) {
+		RetrieverExten = retrieverExten;
+	}
+	public String getRetrieverPriority() {
+		return RetrieverPriority;
+	}
+	public void setRetrieverPriority(String retrieverPriority) {
+		RetrieverPriority = retrieverPriority;
+	}
+	public String getRetrieverUniqueid() {
+		return RetrieverUniqueid;
     }
-
-    /**
-     * Sets the name of the channel that parked the call.
-     */
-    public void setFrom(String from)
-    {
-        this.from = from;
+	public void setRetrieverUniqueid(String retrieverUniqueid) {
+		RetrieverUniqueid = retrieverUniqueid;
     }
 }

--- a/src/main/java/org/asteriskjava/manager/event/UnparkedCallEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/UnparkedCallEvent.java
@@ -18,8 +18,10 @@ package org.asteriskjava.manager.event;
 
 /**
  * A UnparkedCallEvent is triggered when a channel that has been parked is
- * resumed.<p>
- * It is implemented in <code>res/res_features.c</code><p>
+ * resumed.
+ * <p>
+ * It is implemented in <code>res/res_features.c</code>
+ * <p>
  * Available since Asterisk 1.2
  * 
  * @author srt
@@ -48,6 +50,7 @@ public class UnparkedCallEvent extends AbstractUnParkedEvent
     private String RetrieverExten;
     private String RetrieverPriority;
     private String RetrieverUniqueid;
+
     /**
      * @param source
      */
@@ -55,76 +58,124 @@ public class UnparkedCallEvent extends AbstractUnParkedEvent
     {
         super(source);
     }
-	public String getRetrieverChannel() {
-		return RetrieverChannel;
-	}
-	public void setRetrieverChannel(String retrieverChannel) {
-		RetrieverChannel = retrieverChannel;
-	}
-	public Integer getRetrieverChannelState() {
-		return RetrieverChannelState;
-	}
-	public void setRetrieverChannelState(Integer retrieverChannelState) {
-		RetrieverChannelState = retrieverChannelState;
-	}
-	public String getRetrieverChannelStateDesc() {
-		return RetrieverChannelStateDesc;
-	}
-	public void setRetrieverChannelStateDesc(String retrieverChannelStateDesc) {
-		RetrieverChannelStateDesc = retrieverChannelStateDesc;
-	}
-	public String getRetrieverCallerIDNum() {
-		return RetrieverCallerIDNum;
-	}
-	public void setRetrieverCallerIDNum(String retrieverCallerIDNum) {
-		RetrieverCallerIDNum = retrieverCallerIDNum;
-	}
-	public String getRetrieverCallerIDName() {
-		return RetrieverCallerIDName;
-	}
-	public void setRetrieverCallerIDName(String retrieverCallerIDName) {
-		RetrieverCallerIDName = retrieverCallerIDName;
-	}
-	public String getRetrieverConnectedLineNum() {
-		return RetrieverConnectedLineNum;
-	}
-	public void setRetrieverConnectedLineNum(String retrieverConnectedLineNum) {
-		RetrieverConnectedLineNum = retrieverConnectedLineNum;
-	}
-	public String getRetrieverConnectedLineName() {
-		return RetrieverConnectedLineName;
-	}
-	public void setRetrieverConnectedLineName(String retrieverConnectedLineName) {
-		RetrieverConnectedLineName = retrieverConnectedLineName;
-	}
-	public String getRetrieverAccountCode() {
-		return RetrieverAccountCode;
-	}
-	public void setRetrieverAccountCode(String retrieverAccountCode) {
-		RetrieverAccountCode = retrieverAccountCode;
-	}
-	public String getRetrieverContext() {
-		return RetrieverContext;
-	}
-	public void setRetrieverContext(String retrieverContext) {
-		RetrieverContext = retrieverContext;
-	}
-	public String getRetrieverExten() {
-		return RetrieverExten;
-	}
-	public void setRetrieverExten(String retrieverExten) {
-		RetrieverExten = retrieverExten;
-	}
-	public String getRetrieverPriority() {
-		return RetrieverPriority;
-	}
-	public void setRetrieverPriority(String retrieverPriority) {
-		RetrieverPriority = retrieverPriority;
-	}
-	public String getRetrieverUniqueid() {
-		return RetrieverUniqueid;
+
+    public String getRetrieverChannel()
+    {
+        return RetrieverChannel;
     }
-	public void setRetrieverUniqueid(String retrieverUniqueid) {
-		RetrieverUniqueid = retrieverUniqueid;
+
+    public void setRetrieverChannel(String retrieverChannel)
+    {
+        RetrieverChannel = retrieverChannel;
+    }
+
+    public Integer getRetrieverChannelState()
+    {
+        return RetrieverChannelState;
+    }
+
+    public void setRetrieverChannelState(Integer retrieverChannelState)
+    {
+        RetrieverChannelState = retrieverChannelState;
+    }
+
+    public String getRetrieverChannelStateDesc()
+    {
+        return RetrieverChannelStateDesc;
+    }
+
+    public void setRetrieverChannelStateDesc(String retrieverChannelStateDesc)
+    {
+        RetrieverChannelStateDesc = retrieverChannelStateDesc;
+    }
+
+    public String getRetrieverCallerIDNum()
+    {
+        return RetrieverCallerIDNum;
+    }
+
+    public void setRetrieverCallerIDNum(String retrieverCallerIDNum)
+    {
+        RetrieverCallerIDNum = retrieverCallerIDNum;
+    }
+
+    public String getRetrieverCallerIDName()
+    {
+        return RetrieverCallerIDName;
+    }
+
+    public void setRetrieverCallerIDName(String retrieverCallerIDName)
+    {
+        RetrieverCallerIDName = retrieverCallerIDName;
+    }
+
+    public String getRetrieverConnectedLineNum()
+    {
+        return RetrieverConnectedLineNum;
+    }
+
+    public void setRetrieverConnectedLineNum(String retrieverConnectedLineNum)
+    {
+        RetrieverConnectedLineNum = retrieverConnectedLineNum;
+    }
+
+    public String getRetrieverConnectedLineName()
+    {
+        return RetrieverConnectedLineName;
+    }
+
+    public void setRetrieverConnectedLineName(String retrieverConnectedLineName)
+    {
+        RetrieverConnectedLineName = retrieverConnectedLineName;
+    }
+
+    public String getRetrieverAccountCode()
+    {
+        return RetrieverAccountCode;
+    }
+
+    public void setRetrieverAccountCode(String retrieverAccountCode)
+    {
+        RetrieverAccountCode = retrieverAccountCode;
+    }
+
+    public String getRetrieverContext()
+    {
+        return RetrieverContext;
+    }
+
+    public void setRetrieverContext(String retrieverContext)
+    {
+        RetrieverContext = retrieverContext;
+    }
+
+    public String getRetrieverExten()
+    {
+        return RetrieverExten;
+    }
+
+    public void setRetrieverExten(String retrieverExten)
+    {
+        RetrieverExten = retrieverExten;
+    }
+
+    public String getRetrieverPriority()
+    {
+        return RetrieverPriority;
+    }
+
+    public void setRetrieverPriority(String retrieverPriority)
+    {
+        RetrieverPriority = retrieverPriority;
+    }
+
+    public String getRetrieverUniqueid()
+    {
+        return RetrieverUniqueid;
+    }
+
+    public void setRetrieverUniqueid(String retrieverUniqueid)
+    {
+        RetrieverUniqueid = retrieverUniqueid;
     }
 }

--- a/src/main/java/org/asteriskjava/manager/event/VarSetEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/VarSetEvent.java
@@ -17,8 +17,11 @@
 package org.asteriskjava.manager.event;
 
 /**
- * A VarSetEvent is triggered when a channel or global variable is set in Asterisk.<p>
- * Available since Asterisk 1.6<p>
+ * A VarSetEvent is triggered when a channel or global variable is set in
+ * Asterisk.
+ * <p>
+ * Available since Asterisk 1.6
+ * <p>
  * It is implemented in <code>main/pbx.c</code>
  *
  * @author srt
@@ -34,13 +37,15 @@ public class VarSetEvent extends ManagerEvent
     private String variable;
     private String value;
     private String language;
-    
-    public String getLanguage(){
-    	return language;
+
+    public String getLanguage()
+    {
+        return language;
     }
-    
-    public void setLanguage(String language){
-    	this.language = language;
+
+    public void setLanguage(String language)
+    {
+        this.language = language;
     }
 
     public VarSetEvent(Object source)
@@ -49,9 +54,11 @@ public class VarSetEvent extends ManagerEvent
     }
 
     /**
-     * Returns the name of the channel or <code>null</code> for global variables.
+     * Returns the name of the channel or <code>null</code> for global
+     * variables.
      *
-     * @return the name of the channel or <code>null</code> for global variables.
+     * @return the name of the channel or <code>null</code> for global
+     *         variables.
      */
     public String getChannel()
     {
@@ -64,9 +71,11 @@ public class VarSetEvent extends ManagerEvent
     }
 
     /**
-     * Returns the unique id of the channel or <code>null</code> for global variables.
+     * Returns the unique id of the channel or <code>null</code> for global
+     * variables.
      *
-     * @return the unique id of the channel or <code>null</code> for global variables.
+     * @return the unique id of the channel or <code>null</code> for global
+     *         variables.
      */
     public String getUniqueId()
     {

--- a/src/main/java/org/asteriskjava/manager/event/VarSetEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/VarSetEvent.java
@@ -33,7 +33,6 @@ public class VarSetEvent extends ManagerEvent
     private String uniqueId;
     private String variable;
     private String value;
-    private String callerIdName;
     private String language;
     
     public String getLanguage(){
@@ -42,78 +41,6 @@ public class VarSetEvent extends ManagerEvent
     
     public void setLanguage(String language){
     	this.language = language;
-    }
-    
-    public String getConnectedLineName() {
-        return connectedLineName;
-    }
-
-    public void setConnectedLineName(String connectedLineName) {
-        this.connectedLineName = connectedLineName;
-    }
-
-    public String getChannelStateDesc() {
-        return channelStateDesc;
-    }
-
-    public void setChannelStateDesc(String channelStateDesc) {
-        this.channelStateDesc = channelStateDesc;
-    }
-
-    public Integer getPriority() {
-        return priority;
-    }
-
-    public void setPriority(Integer priority) {
-        this.priority = priority;
-    }
-
-    public String getExten() {
-        return exten;
-    }
-
-    public void setExten(String exten) {
-        this.exten = exten;
-    }
-
-    public String getCallerIdName() {
-        return callerIdName;
-    }
-
-    public void setCallerIdName(String callerIdName) {
-        this.callerIdName = callerIdName;
-    }
-
-    public String getConnectedLineNum() {
-        return connectedLineNum;
-    }
-
-    public void setConnectedLineNum(String connectedLineName) {
-        this.connectedLineNum = connectedLineName;
-    }
-
-    public Integer getChannelState() {
-        return channelState;
-    }
-
-    public void setChannelState(Integer channelState) {
-        this.channelState = channelState;
-    }
-
-    public String getCallerIdNum() {
-        return callerIdNum;
-    }
-
-    public void setCallerIdNum(String callerIdNum) {
-        this.callerIdNum = callerIdNum;
-    }
-
-    public String getContext() {
-        return context;
-    }
-
-    public void setContext(String context) {
-        this.context = context;
     }
 
     public VarSetEvent(Object source)

--- a/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
@@ -46,6 +46,8 @@ import org.asteriskjava.manager.action.LoginAction;
 import org.asteriskjava.manager.action.LogoffAction;
 import org.asteriskjava.manager.action.ManagerAction;
 import org.asteriskjava.manager.event.ConnectEvent;
+import org.asteriskjava.manager.event.DialBeginEvent;
+import org.asteriskjava.manager.event.DialEvent;
 import org.asteriskjava.manager.event.DisconnectEvent;
 import org.asteriskjava.manager.event.ManagerEvent;
 import org.asteriskjava.manager.event.ProtocolIdentifierReceivedEvent;
@@ -1199,7 +1201,7 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
 			logger.error("Unable to dispatch null event. This should never happen. Please file a bug.");
 			return;
 		}
-
+        dispatchLegacyEventIfNeeded(event);
 		logger.debug("Dispatching event:\n" + event.toString());
 
 		// Some events need special treatment besides forwarding them to the
@@ -1295,6 +1297,17 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
 		}
 
 		fireEvent(event);
+	}
+
+	/**
+     * Enro 2015-03
+     * Workaround to continue having Legacy Events from Asterisk 13.
+     */
+    private void dispatchLegacyEventIfNeeded(ManagerEvent event) {
+		if (event instanceof DialBeginEvent){
+        	DialEvent legacyEvent = (new DialEvent((DialBeginEvent) event));
+        	dispatchEvent(legacyEvent);
+		}
 	}
 
 	/**

--- a/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
@@ -72,592 +72,588 @@ import org.asteriskjava.manager.action.UserEventAction;
  */
 public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
 {
-	private static final int RECONNECTION_INTERVAL_1 = 50;
-	private static final int RECONNECTION_INTERVAL_2 = 5000;
-	private static final String DEFAULT_HOSTNAME = "localhost";
-	private static final int DEFAULT_PORT = 5038;
-	private static final int RECONNECTION_VERSION_INTERVAL = 500;
-	private static final int MAX_VERSION_ATTEMPTS = 4;
-	private static final Pattern SHOW_VERSION_PATTERN = Pattern.compile("^(core )?show version.*");
+    private static final int RECONNECTION_INTERVAL_1 = 50;
+    private static final int RECONNECTION_INTERVAL_2 = 5000;
+    private static final String DEFAULT_HOSTNAME = "localhost";
+    private static final int DEFAULT_PORT = 5038;
+    private static final int RECONNECTION_VERSION_INTERVAL = 500;
+    private static final int MAX_VERSION_ATTEMPTS = 4;
+    private static final Pattern SHOW_VERSION_PATTERN = Pattern.compile("^(core )?show version.*");
 
     private static final Pattern VERSION_PATTERN_1_6 = Pattern.compile("^\\s*Asterisk (SVN-branch-)?1\\.6[-. ].*");
     private static final Pattern VERSION_PATTERN_1_8 = Pattern.compile("^\\s*Asterisk (SVN-branch-)?1\\.8[-. ].*");
-    private static final Pattern VERSION_PATTERN_10  = Pattern.compile("^\\s*Asterisk (SVN-branch-)?10[-. ].*");
-    private static final Pattern VERSION_PATTERN_11  = Pattern.compile("^\\s*Asterisk (SVN-branch-)?11[-. ].*");
-    private static final Pattern VERSION_PATTERN_12  = Pattern.compile("^\\s*Asterisk (SVN-branch-)?12[-. ].*");
-    private static final Pattern VERSION_PATTERN_13  = Pattern.compile("^\\s*Asterisk (SVN-branch-)?13[-. ].*");
+    private static final Pattern VERSION_PATTERN_10 = Pattern.compile("^\\s*Asterisk (SVN-branch-)?10[-. ].*");
+    private static final Pattern VERSION_PATTERN_11 = Pattern.compile("^\\s*Asterisk (SVN-branch-)?11[-. ].*");
+    private static final Pattern VERSION_PATTERN_12 = Pattern.compile("^\\s*Asterisk (SVN-branch-)?12[-. ].*");
+    private static final Pattern VERSION_PATTERN_13 = Pattern.compile("^\\s*Asterisk (SVN-branch-)?13[-. ].*");
 
-	private static final AtomicLong idCounter = new AtomicLong(0);
+    private static final AtomicLong idCounter = new AtomicLong(0);
 
-	/**
-	 * Instance logger.
-	 */
-	private final Log logger = LogFactory.getLog(getClass());
+    /**
+     * Instance logger.
+     */
+    private final Log logger = LogFactory.getLog(getClass());
 
-	private final long id;
+    private final long id;
 
-	/**
-	 * Used to construct the internalActionId.
-	 */
-	private AtomicLong actionIdCounter = new AtomicLong(0);
+    /**
+     * Used to construct the internalActionId.
+     */
+    private AtomicLong actionIdCounter = new AtomicLong(0);
 
-	/* Config attributes */
-	/**
-	 * Hostname of the Asterisk server to connect to.
-	 */
-	private String hostname = DEFAULT_HOSTNAME;
+    /* Config attributes */
+    /**
+     * Hostname of the Asterisk server to connect to.
+     */
+    private String hostname = DEFAULT_HOSTNAME;
 
-	/**
-	 * TCP port to connect to.
-	 */
-	private int port = DEFAULT_PORT;
+    /**
+     * TCP port to connect to.
+     */
+    private int port = DEFAULT_PORT;
 
-	/**
-	 * <code>true</code> to use SSL for the connection, <code>false</code> for a
-	 * plain text connection.
-	 */
-	private boolean ssl = false;
+    /**
+     * <code>true</code> to use SSL for the connection, <code>false</code> for a
+     * plain text connection.
+     */
+    private boolean ssl = false;
 
-	/**
-	 * The username to use for login as defined in Asterisk's
-	 * <code>manager.conf</code>.
-	 */
-	protected String username;
+    /**
+     * The username to use for login as defined in Asterisk's
+     * <code>manager.conf</code>.
+     */
+    protected String username;
 
-	/**
-	 * The password to use for login as defined in Asterisk's
-	 * <code>manager.conf</code>.
-	 */
-	protected String password;
+    /**
+     * The password to use for login as defined in Asterisk's
+     * <code>manager.conf</code>.
+     */
+    protected String password;
 
-	/**
-	 * The default timeout to wait for a ManagerResponse after sending a
-	 * ManagerAction.
-	 */
-	private long defaultResponseTimeout = 2000;
+    /**
+     * The default timeout to wait for a ManagerResponse after sending a
+     * ManagerAction.
+     */
+    private long defaultResponseTimeout = 2000;
 
-	/**
-	 * The default timeout to wait for the last ResponseEvent after sending an
-	 * EventGeneratingAction.
-	 */
-	private long defaultEventTimeout = 5000;
+    /**
+     * The default timeout to wait for the last ResponseEvent after sending an
+     * EventGeneratingAction.
+     */
+    private long defaultEventTimeout = 5000;
 
-	/**
-	 * The timeout to use when connecting the the Asterisk server.
-	 */
-	private int socketTimeout = 0;
+    /**
+     * The timeout to use when connecting the the Asterisk server.
+     */
+    private int socketTimeout = 0;
 
-	/**
-     * Closes the connection (and reconnects) if no input has been read for the given amount
-     * of milliseconds. A timeout of zero is interpreted as an infinite timeout.
-	 * 
-	 * @see Socket#setSoTimeout(int)
-	 */
-	private int socketReadTimeout = 0;
+    /**
+     * Closes the connection (and reconnects) if no input has been read for the
+     * given amount of milliseconds. A timeout of zero is interpreted as an
+     * infinite timeout.
+     * 
+     * @see Socket#setSoTimeout(int)
+     */
+    private int socketReadTimeout = 0;
 
-	/**
-	 * <code>true</code> to continue to reconnect after an authentication
-	 * failure.
-	 */
-	private boolean keepAliveAfterAuthenticationFailure = true;
+    /**
+     * <code>true</code> to continue to reconnect after an authentication
+     * failure.
+     */
+    private boolean keepAliveAfterAuthenticationFailure = true;
 
-	/**
-	 * The socket to use for TCP/IP communication with Asterisk.
-	 */
-	private SocketConnectionFacade socket;
+    /**
+     * The socket to use for TCP/IP communication with Asterisk.
+     */
+    private SocketConnectionFacade socket;
 
-	/**
-	 * The thread that runs the reader.
-	 */
-	private Thread readerThread;
-	private final AtomicLong readerThreadCounter = new AtomicLong(0);
+    /**
+     * The thread that runs the reader.
+     */
+    private Thread readerThread;
+    private final AtomicLong readerThreadCounter = new AtomicLong(0);
 
-	private final AtomicLong reconnectThreadCounter = new AtomicLong(0);
+    private final AtomicLong reconnectThreadCounter = new AtomicLong(0);
 
-	/**
-	 * The reader to use to receive events and responses from asterisk.
-	 */
-	private ManagerReader reader;
+    /**
+     * The reader to use to receive events and responses from asterisk.
+     */
+    private ManagerReader reader;
 
-	/**
-	 * The writer to use to send actions to asterisk.
-	 */
-	private ManagerWriter writer;
+    /**
+     * The writer to use to send actions to asterisk.
+     */
+    private ManagerWriter writer;
 
-	/**
-	 * The protocol identifer Asterisk sends on connect wrapped into an object
-	 * to be used as mutex.
-	 */
-	private final ProtocolIdentifierWrapper protocolIdentifier;
+    /**
+     * The protocol identifer Asterisk sends on connect wrapped into an object
+     * to be used as mutex.
+     */
+    private final ProtocolIdentifierWrapper protocolIdentifier;
 
-	/**
-	 * The version of the Asterisk server we are connected to.
-	 */
-	private AsteriskVersion version;
+    /**
+     * The version of the Asterisk server we are connected to.
+     */
+    private AsteriskVersion version;
 
-	/**
-	 * Contains the registered handlers that process the ManagerResponses.
-	 * <p/>
-	 * Key is the internalActionId of the Action sent and value the
-	 * corresponding ResponseListener.
-	 */
-	private final Map<String, SendActionCallback> responseListeners;
+    /**
+     * Contains the registered handlers that process the ManagerResponses.
+     * <p/>
+     * Key is the internalActionId of the Action sent and value the
+     * corresponding ResponseListener.
+     */
+    private final Map<String, SendActionCallback> responseListeners;
 
-	/**
-	 * Contains the event handlers that handle ResponseEvents for the
-	 * sendEventGeneratingAction methods.
-	 * <p/>
-	 * Key is the internalActionId of the Action sent and value the
-	 * corresponding EventHandler.
-	 */
-	private final Map<String, ManagerEventListener> responseEventListeners;
+    /**
+     * Contains the event handlers that handle ResponseEvents for the
+     * sendEventGeneratingAction methods.
+     * <p/>
+     * Key is the internalActionId of the Action sent and value the
+     * corresponding EventHandler.
+     */
+    private final Map<String, ManagerEventListener> responseEventListeners;
 
-	/**
-	 * Contains the event handlers that users registered.
-	 */
-	private final List<ManagerEventListener> eventListeners;
+    /**
+     * Contains the event handlers that users registered.
+     */
+    private final List<ManagerEventListener> eventListeners;
 
-	protected ManagerConnectionState state = INITIAL;
+    protected ManagerConnectionState state = INITIAL;
 
-	private String eventMask;
+    private String eventMask;
 
-	/**
-	 * Creates a new instance.
-	 */
-	public ManagerConnectionImpl()
-	{
-		this.id = idCounter.getAndIncrement();
-		this.responseListeners = new HashMap<String, SendActionCallback>();
-		this.responseEventListeners = new HashMap<String, ManagerEventListener>();
-		this.eventListeners = new ArrayList<ManagerEventListener>();
-		this.protocolIdentifier = new ProtocolIdentifierWrapper();
-	}
+    /**
+     * Creates a new instance.
+     */
+    public ManagerConnectionImpl()
+    {
+        this.id = idCounter.getAndIncrement();
+        this.responseListeners = new HashMap<String, SendActionCallback>();
+        this.responseEventListeners = new HashMap<String, ManagerEventListener>();
+        this.eventListeners = new ArrayList<ManagerEventListener>();
+        this.protocolIdentifier = new ProtocolIdentifierWrapper();
+    }
 
-	// the following two methods can be overriden when running test cases to
-	// return a mock object
-	protected ManagerReader createReader(Dispatcher dispatcher, Object source)
-	{
-		return new ManagerReaderImpl(dispatcher, source);
-	}
+    // the following two methods can be overriden when running test cases to
+    // return a mock object
+    protected ManagerReader createReader(Dispatcher dispatcher, Object source)
+    {
+        return new ManagerReaderImpl(dispatcher, source);
+    }
 
-	protected ManagerWriter createWriter()
-	{
-		return new ManagerWriterImpl();
-	}
+    protected ManagerWriter createWriter()
+    {
+        return new ManagerWriterImpl();
+    }
 
-	/**
-	 * Sets the hostname of the asterisk server to connect to.
-	 * <p/>
-	 * Default is <code>localhost</code>.
-	 * 
-	 * @param hostname the hostname to connect to
-	 */
-	public void setHostname(String hostname)
-	{
-		this.hostname = hostname;
-	}
+    /**
+     * Sets the hostname of the asterisk server to connect to.
+     * <p/>
+     * Default is <code>localhost</code>.
+     * 
+     * @param hostname the hostname to connect to
+     */
+    public void setHostname(String hostname)
+    {
+        this.hostname = hostname;
+    }
 
-	/**
-	 * Sets the port to use to connect to the asterisk server. This is the port
-	 * specified in asterisk's <code>manager.conf</code> file.
-	 * <p/>
-	 * Default is 5038.
-	 * 
-	 * @param port the port to connect to
-	 */
-	public void setPort(int port)
-	{
-		if (port <= 0)
-		{
-			this.port = DEFAULT_PORT;
-		}
-		else
-		{
-			this.port = port;
-		}
-	}
+    /**
+     * Sets the port to use to connect to the asterisk server. This is the port
+     * specified in asterisk's <code>manager.conf</code> file.
+     * <p/>
+     * Default is 5038.
+     * 
+     * @param port the port to connect to
+     */
+    public void setPort(int port)
+    {
+        if (port <= 0)
+        {
+            this.port = DEFAULT_PORT;
+        }
+        else
+        {
+            this.port = port;
+        }
+    }
 
-	/**
-	 * Sets whether to use SSL.
-     * <br>
-	 * Default is false.
-	 * 
+    /**
+     * Sets whether to use SSL. <br>
+     * Default is false.
+     * 
      * @param ssl <code>true</code> to use SSL for the connection,
-	 *            <code>false</code> for a plain text connection.
-	 * @since 0.3
-	 */
-	public void setSsl(boolean ssl)
-	{
-		this.ssl = ssl;
-	}
+     *            <code>false</code> for a plain text connection.
+     * @since 0.3
+     */
+    public void setSsl(boolean ssl)
+    {
+        this.ssl = ssl;
+    }
 
-	/**
-	 * Sets the username to use to connect to the asterisk server. This is the
-	 * username specified in asterisk's <code>manager.conf</code> file.
-	 * 
+    /**
+     * Sets the username to use to connect to the asterisk server. This is the
+     * username specified in asterisk's <code>manager.conf</code> file.
+     * 
      * @param username the username to use for login
-	 */
-	public void setUsername(String username)
-	{
-		this.username = username;
-	}
+     */
+    public void setUsername(String username)
+    {
+        this.username = username;
+    }
 
-	/**
-	 * Sets the password to use to connect to the asterisk server. This is the
-	 * password specified in Asterisk's <code>manager.conf</code> file.
-	 * 
+    /**
+     * Sets the password to use to connect to the asterisk server. This is the
+     * password specified in Asterisk's <code>manager.conf</code> file.
+     * 
      * @param password the password to use for login
-	 */
-	public void setPassword(String password)
-	{
-		this.password = password;
-	}
+     */
+    public void setPassword(String password)
+    {
+        this.password = password;
+    }
 
-	/**
-	 * Sets the time in milliseconds the synchronous method
-	 * {@link #sendAction(ManagerAction)} will wait for a response before
-	 * throwing a TimeoutException.
-     * <br>
-	 * Default is 2000.
-	 * 
+    /**
+     * Sets the time in milliseconds the synchronous method
+     * {@link #sendAction(ManagerAction)} will wait for a response before
+     * throwing a TimeoutException. <br>
+     * Default is 2000.
+     * 
      * @param defaultResponseTimeout default response timeout in milliseconds
-	 * @since 0.2
-	 */
-	public void setDefaultResponseTimeout(long defaultResponseTimeout)
-	{
-		this.defaultResponseTimeout = defaultResponseTimeout;
-	}
+     * @since 0.2
+     */
+    public void setDefaultResponseTimeout(long defaultResponseTimeout)
+    {
+        this.defaultResponseTimeout = defaultResponseTimeout;
+    }
 
-	/**
-	 * Sets the time in milliseconds the synchronous method
-	 * {@link #sendEventGeneratingAction(EventGeneratingAction)} will wait for a
-	 * response and the last response event before throwing a TimeoutException.
-     * <br>
-	 * Default is 5000.
-	 * 
+    /**
+     * Sets the time in milliseconds the synchronous method
+     * {@link #sendEventGeneratingAction(EventGeneratingAction)} will wait for a
+     * response and the last response event before throwing a TimeoutException. <br>
+     * Default is 5000.
+     * 
      * @param defaultEventTimeout default event timeout in milliseconds
-	 * @since 0.2
-	 */
-	public void setDefaultEventTimeout(long defaultEventTimeout)
-	{
-		this.defaultEventTimeout = defaultEventTimeout;
-	}
+     * @since 0.2
+     */
+    public void setDefaultEventTimeout(long defaultEventTimeout)
+    {
+        this.defaultEventTimeout = defaultEventTimeout;
+    }
 
-	/**
-     * Set to <code>true</code> to try reconnecting to ther asterisk serve
-     * even if the reconnection attempt threw an AuthenticationFailedException.
-     * <br>
-	 * Default is <code>true</code>.
-	 * 
-	 * @param keepAliveAfterAuthenticationFailure
-	 *            <code>true</code> to try reconnecting to ther asterisk serve
-     *         even if the reconnection attempt threw an AuthenticationFailedException,
-     *         <code>false</code> otherwise.
-	 */
-	public void setKeepAliveAfterAuthenticationFailure(boolean keepAliveAfterAuthenticationFailure)
-	{
-		this.keepAliveAfterAuthenticationFailure = keepAliveAfterAuthenticationFailure;
-	}
+    /**
+     * Set to <code>true</code> to try reconnecting to ther asterisk serve even
+     * if the reconnection attempt threw an AuthenticationFailedException. <br>
+     * Default is <code>true</code>.
+     * 
+     * @param keepAliveAfterAuthenticationFailure <code>true</code> to try
+     *            reconnecting to ther asterisk serve even if the reconnection
+     *            attempt threw an AuthenticationFailedException,
+     *            <code>false</code> otherwise.
+     */
+    public void setKeepAliveAfterAuthenticationFailure(boolean keepAliveAfterAuthenticationFailure)
+    {
+        this.keepAliveAfterAuthenticationFailure = keepAliveAfterAuthenticationFailure;
+    }
 
-	/* Implementation of ManagerConnection interface */
+    /* Implementation of ManagerConnection interface */
 
-	public String getUsername()
-	{
-		return username;
-	}
+    public String getUsername()
+    {
+        return username;
+    }
 
-	public String getPassword()
-	{
-		return password;
-	}
+    public String getPassword()
+    {
+        return password;
+    }
 
-	public AsteriskVersion getVersion()
-	{
-		return version;
-	}
+    public AsteriskVersion getVersion()
+    {
+        return version;
+    }
 
-	public String getHostname()
-	{
-		return hostname;
-	}
+    public String getHostname()
+    {
+        return hostname;
+    }
 
-	public int getPort()
-	{
-		return port;
-	}
+    public int getPort()
+    {
+        return port;
+    }
 
-	public boolean isSsl()
-	{
-		return ssl;
-	}
+    public boolean isSsl()
+    {
+        return ssl;
+    }
 
-	public InetAddress getLocalAddress()
-	{
-		return socket.getLocalAddress();
-	}
+    public InetAddress getLocalAddress()
+    {
+        return socket.getLocalAddress();
+    }
 
-	public int getLocalPort()
-	{
-		return socket.getLocalPort();
-	}
+    public int getLocalPort()
+    {
+        return socket.getLocalPort();
+    }
 
-	public InetAddress getRemoteAddress()
-	{
-		return socket.getRemoteAddress();
-	}
+    public InetAddress getRemoteAddress()
+    {
+        return socket.getRemoteAddress();
+    }
 
-	public int getRemotePort()
-	{
-		return socket.getRemotePort();
-	}
+    public int getRemotePort()
+    {
+        return socket.getRemotePort();
+    }
 
-	public void registerUserEventClass(Class<? extends ManagerEvent> userEventClass)
-	{
-		if (reader == null)
-		{
-			reader = createReader(this, this);
-		}
+    public void registerUserEventClass(Class< ? extends ManagerEvent> userEventClass)
+    {
+        if (reader == null)
+        {
+            reader = createReader(this, this);
+        }
 
-		reader.registerEventClass(userEventClass);
-	}
+        reader.registerEventClass(userEventClass);
+    }
 
-	public void setSocketTimeout(int socketTimeout)
-	{
-		this.socketTimeout = socketTimeout;
-	}
+    public void setSocketTimeout(int socketTimeout)
+    {
+        this.socketTimeout = socketTimeout;
+    }
 
-	public void setSocketReadTimeout(int socketReadTimeout)
-	{
-		this.socketReadTimeout = socketReadTimeout;
-	}
+    public void setSocketReadTimeout(int socketReadTimeout)
+    {
+        this.socketReadTimeout = socketReadTimeout;
+    }
 
-	public synchronized void login() throws IOException, AuthenticationFailedException, TimeoutException
-	{
-		login(null);
-	}
+    public synchronized void login() throws IOException, AuthenticationFailedException, TimeoutException
+    {
+        login(null);
+    }
 
     public synchronized void login(String eventMask) throws IOException, AuthenticationFailedException, TimeoutException
-	{
-		if (state != INITIAL && state != DISCONNECTED)
-		{
-			throw new IllegalStateException("Login may only be perfomed when in state "
-					+ "INITIAL or DISCONNECTED, but connection is in state " + state);
-		}
+    {
+        if (state != INITIAL && state != DISCONNECTED)
+        {
+            throw new IllegalStateException("Login may only be perfomed when in state "
+                    + "INITIAL or DISCONNECTED, but connection is in state " + state);
+        }
 
-		state = CONNECTING;
-		this.eventMask = eventMask;
-		try
-		{
-			doLogin(defaultResponseTimeout, eventMask);
-		}
-		finally
-		{
-			if (state != CONNECTED)
-			{
-				state = DISCONNECTED;
-			}
-		}
-	}
+        state = CONNECTING;
+        this.eventMask = eventMask;
+        try
+        {
+            doLogin(defaultResponseTimeout, eventMask);
+        }
+        finally
+        {
+            if (state != CONNECTED)
+            {
+                state = DISCONNECTED;
+            }
+        }
+    }
 
-	/**
-	 * Does the real login, following the steps outlined below.
-     * <br>
-	 * <ol>
-	 * <li>Connects to the asterisk server by calling {@link #connect()} if not
-	 * already connected
-	 * <li>Waits until the protocol identifier is received but not longer than
-	 * timeout ms.
-	 * <li>Sends a {@link ChallengeAction} requesting a challenge for authType
-	 * MD5.
-	 * <li>When the {@link ChallengeResponse} is received a {@link LoginAction}
-	 * is sent using the calculated key (MD5 hash of the password appended to
-	 * the received challenge).
-	 * </ol>
-	 * 
-
-     * @param timeout   the maximum time to wait for the protocol identifier (in
-     *                  ms)
+    /**
+     * Does the real login, following the steps outlined below. <br>
+     * <ol>
+     * <li>Connects to the asterisk server by calling {@link #connect()} if not
+     * already connected
+     * <li>Waits until the protocol identifier is received but not longer than
+     * timeout ms.
+     * <li>Sends a {@link ChallengeAction} requesting a challenge for authType
+     * MD5.
+     * <li>When the {@link ChallengeResponse} is received a {@link LoginAction}
+     * is sent using the calculated key (MD5 hash of the password appended to
+     * the received challenge).
+     * </ol>
+     * @param timeout the maximum time to wait for the protocol identifier (in
+     *            ms)
      * @param eventMask the event mask. Set to "on" if all events should be
-     *                  send, "off" if not events should be sent or a combination of
-	 *            "system", "call" and "log" (separated by ',') to specify what
-	 *            kind of events should be sent.
-     * @throws IOException                   if there is an i/o problem.
+     *            send, "off" if not events should be sent or a combination of
+     *            "system", "call" and "log" (separated by ',') to specify what
+     *            kind of events should be sent.
+     * @throws IOException if there is an i/o problem.
      * @throws AuthenticationFailedException if username or password are
-     *                                       incorrect and the login action returns an error or if the MD5
-     *                                       hash cannot be computed. The connection is closed in this
-     *                                       case.
-     * @throws TimeoutException              if a timeout occurs while waiting for the
-     *                                       protocol identifier. The connection is closed in this case.
-	 */
+     *             incorrect and the login action returns an error or if the MD5
+     *             hash cannot be computed. The connection is closed in this
+     *             case.
+     * @throws TimeoutException if a timeout occurs while waiting for the
+     *             protocol identifier. The connection is closed in this case.
+     */
     protected synchronized void doLogin(long timeout, String eventMask) throws IOException, AuthenticationFailedException,
             TimeoutException
-	{
-		ChallengeAction challengeAction;
-		ManagerResponse challengeResponse;
-		String challenge;
-		String key;
-		LoginAction loginAction;
-		ManagerResponse loginResponse;
+    {
+        ChallengeAction challengeAction;
+        ManagerResponse challengeResponse;
+        String challenge;
+        String key;
+        LoginAction loginAction;
+        ManagerResponse loginResponse;
 
-		if (socket == null)
-		{
-			connect();
-		}
+        if (socket == null)
+        {
+            connect();
+        }
 
-		synchronized (protocolIdentifier)
-		{
-			if (protocolIdentifier.value == null)
-			{
-				try
-				{
-					protocolIdentifier.wait(timeout);
-				}
-				catch (InterruptedException e) // NOPMD
-				{
-					Thread.currentThread().interrupt();
-				}
-			}
+        synchronized (protocolIdentifier)
+        {
+            if (protocolIdentifier.value == null)
+            {
+                try
+                {
+                    protocolIdentifier.wait(timeout);
+                }
+                catch (InterruptedException e) // NOPMD
+                {
+                    Thread.currentThread().interrupt();
+                }
+            }
 
-			if (protocolIdentifier.value == null)
-			{
-				disconnect();
-				if (reader != null && reader.getTerminationException() != null)
-				{
-					throw reader.getTerminationException();
-				}
-				else
-				{
-					throw new TimeoutException("Timeout waiting for protocol identifier");
-				}
-			}
-		}
+            if (protocolIdentifier.value == null)
+            {
+                disconnect();
+                if (reader != null && reader.getTerminationException() != null)
+                {
+                    throw reader.getTerminationException();
+                }
+                else
+                {
+                    throw new TimeoutException("Timeout waiting for protocol identifier");
+                }
+            }
+        }
 
-		challengeAction = new ChallengeAction("MD5");
-		try
-		{
-			challengeResponse = sendAction(challengeAction);
-		}
-		catch (Exception e)
-		{
-			disconnect();
-			throw new AuthenticationFailedException("Unable to send challenge action", e);
-		}
+        challengeAction = new ChallengeAction("MD5");
+        try
+        {
+            challengeResponse = sendAction(challengeAction);
+        }
+        catch (Exception e)
+        {
+            disconnect();
+            throw new AuthenticationFailedException("Unable to send challenge action", e);
+        }
 
-		if (challengeResponse instanceof ChallengeResponse)
-		{
-			challenge = ((ChallengeResponse) challengeResponse).getChallenge();
-		}
-		else
-		{
-			disconnect();
-			throw new AuthenticationFailedException("Unable to get challenge from Asterisk. ChallengeAction returned: "
-					+ challengeResponse.getMessage());
-		}
+        if (challengeResponse instanceof ChallengeResponse)
+        {
+            challenge = ((ChallengeResponse) challengeResponse).getChallenge();
+        }
+        else
+        {
+            disconnect();
+            throw new AuthenticationFailedException("Unable to get challenge from Asterisk. ChallengeAction returned: "
+                    + challengeResponse.getMessage());
+        }
 
-		try
-		{
-			MessageDigest md;
+        try
+        {
+            MessageDigest md;
 
-			md = MessageDigest.getInstance("MD5");
-			if (challenge != null)
-			{
-				md.update(challenge.getBytes());
-			}
-			if (password != null)
-			{
-				md.update(password.getBytes());
-			}
-			key = ManagerUtil.toHexString(md.digest());
-		}
-		catch (NoSuchAlgorithmException ex)
-		{
-			disconnect();
-			throw new AuthenticationFailedException("Unable to create login key using MD5 Message Digest", ex);
-		}
+            md = MessageDigest.getInstance("MD5");
+            if (challenge != null)
+            {
+                md.update(challenge.getBytes());
+            }
+            if (password != null)
+            {
+                md.update(password.getBytes());
+            }
+            key = ManagerUtil.toHexString(md.digest());
+        }
+        catch (NoSuchAlgorithmException ex)
+        {
+            disconnect();
+            throw new AuthenticationFailedException("Unable to create login key using MD5 Message Digest", ex);
+        }
 
-		loginAction = new LoginAction(username, "MD5", key, eventMask);
-		try
-		{
-			loginResponse = sendAction(loginAction);
-		}
-		catch (Exception e)
-		{
-			disconnect();
-			throw new AuthenticationFailedException("Unable to send login action", e);
-		}
+        loginAction = new LoginAction(username, "MD5", key, eventMask);
+        try
+        {
+            loginResponse = sendAction(loginAction);
+        }
+        catch (Exception e)
+        {
+            disconnect();
+            throw new AuthenticationFailedException("Unable to send login action", e);
+        }
 
-		if (loginResponse instanceof ManagerError)
-		{
-			disconnect();
-			throw new AuthenticationFailedException(loginResponse.getMessage());
-		}
+        if (loginResponse instanceof ManagerError)
+        {
+            disconnect();
+            throw new AuthenticationFailedException(loginResponse.getMessage());
+        }
 
-		logger.info("Successfully logged in");
+        logger.info("Successfully logged in");
 
-		version = determineVersion();
+        version = determineVersion();
 
-		state = CONNECTED;
+        state = CONNECTED;
 
-		writer.setTargetVersion(version);
+        writer.setTargetVersion(version);
 
-		logger.info("Determined Asterisk version: " + version);
+        logger.info("Determined Asterisk version: " + version);
 
-		// generate pseudo event indicating a successful login
-		ConnectEvent connectEvent = new ConnectEvent(this);
-		connectEvent.setProtocolIdentifier(getProtocolIdentifier());
-		connectEvent.setDateReceived(DateUtil.getDate());
-		// TODO could this cause a deadlock?
-		fireEvent(connectEvent);
-	}
+        // generate pseudo event indicating a successful login
+        ConnectEvent connectEvent = new ConnectEvent(this);
+        connectEvent.setProtocolIdentifier(getProtocolIdentifier());
+        connectEvent.setDateReceived(DateUtil.getDate());
+        // TODO could this cause a deadlock?
+        fireEvent(connectEvent);
+    }
 
-	protected AsteriskVersion determineVersion() throws IOException, TimeoutException
-	{
-		int attempts = 0;
+    protected AsteriskVersion determineVersion() throws IOException, TimeoutException
+    {
+        int attempts = 0;
 
-		// if ("Asterisk Call Manager/1.1".equals(protocolIdentifier.value))
-		// {
-		// return AsteriskVersion.ASTERISK_1_6;
-		// }
+        // if ("Asterisk Call Manager/1.1".equals(protocolIdentifier.value))
+        // {
+        // return AsteriskVersion.ASTERISK_1_6;
+        // }
 
-		while (attempts++ < MAX_VERSION_ATTEMPTS)
-		{
-			final ManagerResponse showVersionFilesResponse;
-			final List<String> showVersionFilesResult;
+        while (attempts++ < MAX_VERSION_ATTEMPTS)
+        {
+            final ManagerResponse showVersionFilesResponse;
+            final List<String> showVersionFilesResult;
 
-			// increase timeout as output is quite large
+            // increase timeout as output is quite large
             showVersionFilesResponse = sendAction(new CommandAction("show version files pbx.c"), defaultResponseTimeout * 2);
-			if (!(showVersionFilesResponse instanceof CommandResponse))
-			{
-				// return early in case of permission problems
-				// org.asteriskjava.manager.response.ManagerError:
-                // actionId='null'; message='Permission denied'; response='Error';
-				// uniqueId='null'; systemHashcode=15231583
-				break;
-			}
+            if (!(showVersionFilesResponse instanceof CommandResponse))
+            {
+                // return early in case of permission problems
+                // org.asteriskjava.manager.response.ManagerError:
+                // actionId='null'; message='Permission denied';
+                // response='Error';
+                // uniqueId='null'; systemHashcode=15231583
+                break;
+            }
 
-			showVersionFilesResult = ((CommandResponse) showVersionFilesResponse).getResult();
-			if (showVersionFilesResult != null && showVersionFilesResult.size() > 0)
-			{
+            showVersionFilesResult = ((CommandResponse) showVersionFilesResponse).getResult();
+            if (showVersionFilesResult != null && showVersionFilesResult.size() > 0)
+            {
                 final String line1 = showVersionFilesResult.get(0);
 
                 if (line1 != null && line1.startsWith("File"))
-				{
-					final String rawVersion;
+                {
+                    final String rawVersion;
 
-					rawVersion = getRawVersion();
-					if (rawVersion != null && rawVersion.startsWith("Asterisk 1.4"))
-					{
-						return AsteriskVersion.ASTERISK_1_4;
-					}
-					return AsteriskVersion.ASTERISK_1_2;
-				}
-				else if (line1 != null && line1.contains("No such command"))
-				{
+                    rawVersion = getRawVersion();
+                    if (rawVersion != null && rawVersion.startsWith("Asterisk 1.4"))
+                    {
+                        return AsteriskVersion.ASTERISK_1_4;
+                    }
+                    return AsteriskVersion.ASTERISK_1_2;
+                }
+                else if (line1 != null && line1.contains("No such command"))
+                {
 
-                    final ManagerResponse coreShowVersionResponse = sendAction(new CommandAction("core show version"), defaultResponseTimeout * 2);
+                    final ManagerResponse coreShowVersionResponse = sendAction(new CommandAction("core show version"),
+                            defaultResponseTimeout * 2);
 
-					if (coreShowVersionResponse != null && coreShowVersionResponse instanceof CommandResponse)
-					{
+                    if (coreShowVersionResponse != null && coreShowVersionResponse instanceof CommandResponse)
+                    {
                         final List<String> coreShowVersionResult = ((CommandResponse) coreShowVersionResponse).getResult();
 
                         if (coreShowVersionResult != null && coreShowVersionResult.size() > 0)
@@ -702,902 +698,905 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
                 }
                 else
                 {
-                    // if it isn't the "no such command", break and return the lowest version immediately
-					break;
-				}
-			}
-		}
+                    // if it isn't the "no such command", break and return the
+                    // lowest version immediately
+                    break;
+                }
+            }
+        }
 
-		// as a fallback assume 1.6
-		return AsteriskVersion.ASTERISK_1_6;
-	}
+        // as a fallback assume 1.6
+        return AsteriskVersion.ASTERISK_1_6;
+    }
 
-	protected String getRawVersion()
-	{
-		final ManagerResponse showVersionResponse;
+    protected String getRawVersion()
+    {
+        final ManagerResponse showVersionResponse;
 
-		try
-		{
-			showVersionResponse = sendAction(new CommandAction("show version"), defaultResponseTimeout * 2);
-		}
-		catch (Exception e)
-		{
-			return null;
-		}
+        try
+        {
+            showVersionResponse = sendAction(new CommandAction("show version"), defaultResponseTimeout * 2);
+        }
+        catch (Exception e)
+        {
+            return null;
+        }
 
-		if (showVersionResponse instanceof CommandResponse)
-		{
-			final List<String> showVersionResult;
+        if (showVersionResponse instanceof CommandResponse)
+        {
+            final List<String> showVersionResult;
 
-			showVersionResult = ((CommandResponse) showVersionResponse).getResult();
-			if (showVersionResult != null && showVersionResult.size() > 0)
-			{
-				return showVersionResult.get(0);
-			}
-		}
+            showVersionResult = ((CommandResponse) showVersionResponse).getResult();
+            if (showVersionResult != null && showVersionResult.size() > 0)
+            {
+                return showVersionResult.get(0);
+            }
+        }
 
-		return null;
-	}
+        return null;
+    }
 
-	protected synchronized void connect() throws IOException
-	{
-		logger.info("Connecting to " + hostname + ":" + port);
+    protected synchronized void connect() throws IOException
+    {
+        logger.info("Connecting to " + hostname + ":" + port);
 
-		if (reader == null)
-		{
-			logger.debug("Creating reader for " + hostname + ":" + port);
-			reader = createReader(this, this);
-		}
+        if (reader == null)
+        {
+            logger.debug("Creating reader for " + hostname + ":" + port);
+            reader = createReader(this, this);
+        }
 
-		if (writer == null)
-		{
-			logger.debug("Creating writer");
-			writer = createWriter();
-		}
+        if (writer == null)
+        {
+            logger.debug("Creating writer");
+            writer = createWriter();
+        }
 
-		logger.debug("Creating socket");
-		socket = createSocket();
+        logger.debug("Creating socket");
+        socket = createSocket();
 
-		logger.debug("Passing socket to reader");
-		reader.setSocket(socket);
+        logger.debug("Passing socket to reader");
+        reader.setSocket(socket);
 
-		if (readerThread == null || !readerThread.isAlive() || reader.isDead())
-		{
-			logger.debug("Creating and starting reader thread");
-			readerThread = new Thread(reader);
-			readerThread.setName("Asterisk-Java ManagerConnection-" + id + "-Reader-"
-					+ readerThreadCounter.getAndIncrement());
-			readerThread.setDaemon(true);
-			readerThread.start();
-		}
+        if (readerThread == null || !readerThread.isAlive() || reader.isDead())
+        {
+            logger.debug("Creating and starting reader thread");
+            readerThread = new Thread(reader);
+            readerThread.setName("Asterisk-Java ManagerConnection-" + id + "-Reader-"
+                    + readerThreadCounter.getAndIncrement());
+            readerThread.setDaemon(true);
+            readerThread.start();
+        }
 
-		logger.debug("Passing socket to writer");
-		writer.setSocket(socket);
-	}
+        logger.debug("Passing socket to writer");
+        writer.setSocket(socket);
+    }
 
-	protected SocketConnectionFacade createSocket() throws IOException
-	{
-		return new SocketConnectionFacadeImpl(hostname, port, ssl, socketTimeout, socketReadTimeout);
-	}
+    protected SocketConnectionFacade createSocket() throws IOException
+    {
+        return new SocketConnectionFacadeImpl(hostname, port, ssl, socketTimeout, socketReadTimeout);
+    }
 
-	public synchronized void logoff() throws IllegalStateException
-	{
-		if (state != CONNECTED && state != RECONNECTING)
-		{
-			throw new IllegalStateException("Logoff may only be perfomed when in state "
-					+ "CONNECTED or RECONNECTING, but connection is in state " + state);
-		}
+    public synchronized void logoff() throws IllegalStateException
+    {
+        if (state != CONNECTED && state != RECONNECTING)
+        {
+            throw new IllegalStateException("Logoff may only be perfomed when in state "
+                    + "CONNECTED or RECONNECTING, but connection is in state " + state);
+        }
 
-		state = DISCONNECTING;
+        state = DISCONNECTING;
 
-		if (socket != null)
-		{
-			try
-			{
-				sendAction(new LogoffAction());
-			}
-			catch (Exception e)
-			{
-				logger.warn("Unable to send LogOff action", e);
-			}
-		}
-		cleanup();
-		state = DISCONNECTED;
-	}
+        if (socket != null)
+        {
+            try
+            {
+                sendAction(new LogoffAction());
+            }
+            catch (Exception e)
+            {
+                logger.warn("Unable to send LogOff action", e);
+            }
+        }
+        cleanup();
+        state = DISCONNECTED;
+    }
 
-	/**
-	 * Closes the socket connection.
-	 */
-	protected synchronized void disconnect()
-	{
-		if (socket != null)
-		{
-			logger.info("Closing socket.");
-			try
-			{
-				socket.close();
-			}
-			catch (IOException ex)
-			{
-				logger.warn("Unable to close socket: " + ex.getMessage());
-			}
-			socket = null;
-		}
-		protocolIdentifier.value = null;
-	}
+    /**
+     * Closes the socket connection.
+     */
+    protected synchronized void disconnect()
+    {
+        if (socket != null)
+        {
+            logger.info("Closing socket.");
+            try
+            {
+                socket.close();
+            }
+            catch (IOException ex)
+            {
+                logger.warn("Unable to close socket: " + ex.getMessage());
+            }
+            socket = null;
+        }
+        protocolIdentifier.value = null;
+    }
 
     public ManagerResponse sendAction(ManagerAction action) throws IOException, TimeoutException, IllegalArgumentException,
             IllegalStateException
-	{
-		return sendAction(action, defaultResponseTimeout);
-	}
+    {
+        return sendAction(action, defaultResponseTimeout);
+    }
 
-	/*
-	 * Implements synchronous sending of "simple" actions.
-	 */
-	public ManagerResponse sendAction(ManagerAction action, long timeout) throws IOException, TimeoutException,
-			IllegalArgumentException, IllegalStateException
-	{
-		ResponseHandlerResult result;
-		SendActionCallback callbackHandler;
+    /*
+     * Implements synchronous sending of "simple" actions.
+     */
+    public ManagerResponse sendAction(ManagerAction action, long timeout) throws IOException, TimeoutException,
+            IllegalArgumentException, IllegalStateException
+    {
+        ResponseHandlerResult result;
+        SendActionCallback callbackHandler;
 
-		result = new ResponseHandlerResult();
-		callbackHandler = new DefaultSendActionCallback(result);
+        result = new ResponseHandlerResult();
+        callbackHandler = new DefaultSendActionCallback(result);
 
-		synchronized (result)
-		{
-			sendAction(action, callbackHandler);
+        synchronized (result)
+        {
+            sendAction(action, callbackHandler);
 
-			// definitely return null for the response of user events
-			if (action instanceof UserEventAction)
-			{
-				return null;
-			}
+            // definitely return null for the response of user events
+            if (action instanceof UserEventAction)
+            {
+                return null;
+            }
 
-			// only wait if we did not yet receive the response.
-			// Responses may be returned really fast.
-			if (result.getResponse() == null)
-			{
-				try
-				{
-					result.wait(timeout);
-				}
-				catch (InterruptedException ex)
-				{
-					logger.warn("Interrupted while waiting for result");
-					Thread.currentThread().interrupt();
-				}
-			}
-		}
+            // only wait if we did not yet receive the response.
+            // Responses may be returned really fast.
+            if (result.getResponse() == null)
+            {
+                try
+                {
+                    result.wait(timeout);
+                }
+                catch (InterruptedException ex)
+                {
+                    logger.warn("Interrupted while waiting for result");
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
 
-		// still no response?
-		if (result.getResponse() == null)
-		{
-			throw new TimeoutException("Timeout waiting for response to " + action.getAction()
-					+ (action.getActionId() == null ? "" : " (actionId: " + action.getActionId() + ")"));
-		}
+        // still no response?
+        if (result.getResponse() == null)
+        {
+            throw new TimeoutException("Timeout waiting for response to " + action.getAction()
+                    + (action.getActionId() == null ? "" : " (actionId: " + action.getActionId() + ")"));
+        }
 
-		return result.getResponse();
-	}
+        return result.getResponse();
+    }
 
     public void sendAction(ManagerAction action, SendActionCallback callback) throws IOException, IllegalArgumentException,
             IllegalStateException
-	{
-		final String internalActionId;
+    {
+        final String internalActionId;
 
-		if (action == null)
-		{
-			throw new IllegalArgumentException("Unable to send action: action is null.");
-		}
+        if (action == null)
+        {
+            throw new IllegalArgumentException("Unable to send action: action is null.");
+        }
 
-		// In general sending actions is only allowed while connected, though
-		// there are a few exceptions, these are handled here:
-		if ((state == CONNECTING || state == RECONNECTING)
-				&& (action instanceof ChallengeAction || action instanceof LoginAction || isShowVersionCommandAction(action)))
-		{
-			// when (re-)connecting challenge and login actions are ok.
-		} // NOPMD
-		else if (state == DISCONNECTING && action instanceof LogoffAction)
-		{
-			// when disconnecting logoff action is ok.
-		} // NOPMD
-		else if (state != CONNECTED)
-		{
-			throw new IllegalStateException("Actions may only be sent when in state "
-					+ "CONNECTED, but connection is in state " + state);
-		}
+        // In general sending actions is only allowed while connected, though
+        // there are a few exceptions, these are handled here:
+        if ((state == CONNECTING || state == RECONNECTING)
+                && (action instanceof ChallengeAction || action instanceof LoginAction || isShowVersionCommandAction(action)))
+        {
+            // when (re-)connecting challenge and login actions are ok.
+        } // NOPMD
+        else if (state == DISCONNECTING && action instanceof LogoffAction)
+        {
+            // when disconnecting logoff action is ok.
+        } // NOPMD
+        else if (state != CONNECTED)
+        {
+            throw new IllegalStateException("Actions may only be sent when in state "
+                    + "CONNECTED, but connection is in state " + state);
+        }
 
-		if (socket == null)
-		{
-			throw new IllegalStateException("Unable to send " + action.getAction() + " action: socket not connected.");
-		}
+        if (socket == null)
+        {
+            throw new IllegalStateException("Unable to send " + action.getAction() + " action: socket not connected.");
+        }
 
-		internalActionId = createInternalActionId();
+        internalActionId = createInternalActionId();
 
-		// if the callbackHandler is null the user is obviously not interested
-		// in the response, thats fine.
-		if (callback != null)
-		{
-			synchronized (this.responseListeners)
-			{
-				this.responseListeners.put(internalActionId, callback);
-			}
-		}
+        // if the callbackHandler is null the user is obviously not interested
+        // in the response, thats fine.
+        if (callback != null)
+        {
+            synchronized (this.responseListeners)
+            {
+                this.responseListeners.put(internalActionId, callback);
+            }
+        }
 
-		Class<? extends ManagerResponse> responseClass = getExpectedResponseClass(action.getClass());
-		if (responseClass != null)
-		{
-			reader.expectResponseClass(internalActionId, responseClass);
-		}
+        Class< ? extends ManagerResponse> responseClass = getExpectedResponseClass(action.getClass());
+        if (responseClass != null)
+        {
+            reader.expectResponseClass(internalActionId, responseClass);
+        }
 
-		writer.sendAction(action, internalActionId);
-	}
+        writer.sendAction(action, internalActionId);
+    }
 
-	boolean isShowVersionCommandAction(ManagerAction action)
-	{
-        if (! (action instanceof CommandAction)) {
-			return false;
-		}
-		final Matcher showVersionMatcher = SHOW_VERSION_PATTERN.matcher(((CommandAction) action).getCommand());
-		return showVersionMatcher.matches();
-	}
+    boolean isShowVersionCommandAction(ManagerAction action)
+    {
+        if (!(action instanceof CommandAction))
+        {
+            return false;
+        }
+        final Matcher showVersionMatcher = SHOW_VERSION_PATTERN.matcher(((CommandAction) action).getCommand());
+        return showVersionMatcher.matches();
+    }
 
-	private Class<? extends ManagerResponse> getExpectedResponseClass(Class<? extends ManagerAction> actionClass)
-	{
-		final ExpectedResponse annotation = actionClass.getAnnotation(ExpectedResponse.class);
-		if (annotation == null)
-		{
-			return null;
-		}
+    private Class< ? extends ManagerResponse> getExpectedResponseClass(Class< ? extends ManagerAction> actionClass)
+    {
+        final ExpectedResponse annotation = actionClass.getAnnotation(ExpectedResponse.class);
+        if (annotation == null)
+        {
+            return null;
+        }
 
-		return annotation.value();
-	}
+        return annotation.value();
+    }
 
     public ResponseEvents sendEventGeneratingAction(EventGeneratingAction action) throws IOException, EventTimeoutException,
             IllegalArgumentException, IllegalStateException
-	{
-		return sendEventGeneratingAction(action, defaultEventTimeout);
-	}
+    {
+        return sendEventGeneratingAction(action, defaultEventTimeout);
+    }
 
-	/*
-	 * Implements synchronous sending of event generating actions.
-	 */
-	public ResponseEvents sendEventGeneratingAction(EventGeneratingAction action, long timeout) throws IOException,
-			EventTimeoutException, IllegalArgumentException, IllegalStateException
-	{
-		final ResponseEventsImpl responseEvents;
-		final ResponseEventHandler responseEventHandler;
-		final String internalActionId;
+    /*
+     * Implements synchronous sending of event generating actions.
+     */
+    public ResponseEvents sendEventGeneratingAction(EventGeneratingAction action, long timeout) throws IOException,
+            EventTimeoutException, IllegalArgumentException, IllegalStateException
+    {
+        final ResponseEventsImpl responseEvents;
+        final ResponseEventHandler responseEventHandler;
+        final String internalActionId;
 
-		if (action == null)
-		{
-			throw new IllegalArgumentException("Unable to send action: action is null.");
-		}
-		else if (action.getActionCompleteEventClass() == null)
-		{
-			throw new IllegalArgumentException("Unable to send action: actionCompleteEventClass for "
-					+ action.getClass().getName() + " is null.");
-		}
-		else if (!ResponseEvent.class.isAssignableFrom(action.getActionCompleteEventClass()))
-		{
-			throw new IllegalArgumentException("Unable to send action: actionCompleteEventClass ("
-					+ action.getActionCompleteEventClass().getName() + ") for " + action.getClass().getName()
-					+ " is not a ResponseEvent.");
-		}
+        if (action == null)
+        {
+            throw new IllegalArgumentException("Unable to send action: action is null.");
+        }
+        else if (action.getActionCompleteEventClass() == null)
+        {
+            throw new IllegalArgumentException("Unable to send action: actionCompleteEventClass for "
+                    + action.getClass().getName() + " is null.");
+        }
+        else if (!ResponseEvent.class.isAssignableFrom(action.getActionCompleteEventClass()))
+        {
+            throw new IllegalArgumentException("Unable to send action: actionCompleteEventClass ("
+                    + action.getActionCompleteEventClass().getName() + ") for " + action.getClass().getName()
+                    + " is not a ResponseEvent.");
+        }
 
-		if (state != CONNECTED)
-		{
-			throw new IllegalStateException("Actions may only be sent when in state "
-					+ "CONNECTED but connection is in state " + state);
-		}
+        if (state != CONNECTED)
+        {
+            throw new IllegalStateException("Actions may only be sent when in state "
+                    + "CONNECTED but connection is in state " + state);
+        }
 
-		responseEvents = new ResponseEventsImpl();
-		responseEventHandler = new ResponseEventHandler(responseEvents, action.getActionCompleteEventClass());
+        responseEvents = new ResponseEventsImpl();
+        responseEventHandler = new ResponseEventHandler(responseEvents, action.getActionCompleteEventClass());
 
-		internalActionId = createInternalActionId();
+        internalActionId = createInternalActionId();
 
-		try
-		{
-			// register response handler...
-			synchronized (this.responseListeners)
-			{
-				this.responseListeners.put(internalActionId, responseEventHandler);
-			}
+        try
+        {
+            // register response handler...
+            synchronized (this.responseListeners)
+            {
+                this.responseListeners.put(internalActionId, responseEventHandler);
+            }
 
-			// ...and event handler.
-			synchronized (this.responseEventListeners)
-			{
-				this.responseEventListeners.put(internalActionId, responseEventHandler);
-			}
+            // ...and event handler.
+            synchronized (this.responseEventListeners)
+            {
+                this.responseEventListeners.put(internalActionId, responseEventHandler);
+            }
 
-			synchronized (responseEvents)
-			{
-				writer.sendAction(action, internalActionId);
-				// only wait if response has not yet arrived.
-				if ((responseEvents.getResponse() == null || !responseEvents.isComplete()))
-				{
-					try
-					{
-						responseEvents.wait(timeout);
-					}
-					catch (InterruptedException e)
-					{
-						logger.warn("Interrupted while waiting for response events.");
-						Thread.currentThread().interrupt();
-					}
-				}
-			}
+            synchronized (responseEvents)
+            {
+                writer.sendAction(action, internalActionId);
+                // only wait if response has not yet arrived.
+                if ((responseEvents.getResponse() == null || !responseEvents.isComplete()))
+                {
+                    try
+                    {
+                        responseEvents.wait(timeout);
+                    }
+                    catch (InterruptedException e)
+                    {
+                        logger.warn("Interrupted while waiting for response events.");
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            }
 
-			// still no response or not all events received and timed out?
-			if ((responseEvents.getResponse() == null || !responseEvents.isComplete()))
-			{
-				throw new EventTimeoutException("Timeout waiting for response or response events to "
-						+ action.getAction()
-						+ (action.getActionId() == null ? "" : " (actionId: " + action.getActionId() + ")"),
-						responseEvents);
-			}
+            // still no response or not all events received and timed out?
+            if ((responseEvents.getResponse() == null || !responseEvents.isComplete()))
+            {
+                throw new EventTimeoutException("Timeout waiting for response or response events to " + action.getAction()
+                        + (action.getActionId() == null ? "" : " (actionId: " + action.getActionId() + ")"), responseEvents);
+            }
 
-		}
-		finally
-		{
-			// remove the event handler
-			synchronized (this.responseEventListeners)
-			{
-				this.responseEventListeners.remove(internalActionId);
-			}
-			
-			
-			// Note: The response handler should have already been removed
-			// when the response was received, however we remove it here
-			// just in case it was never received.
-			synchronized (this.responseListeners)
-			{
-				this.responseListeners.remove(internalActionId);
-			}
+        }
+        finally
+        {
+            // remove the event handler
+            synchronized (this.responseEventListeners)
+            {
+                this.responseEventListeners.remove(internalActionId);
+            }
 
-		}
+            // Note: The response handler should have already been removed
+            // when the response was received, however we remove it here
+            // just in case it was never received.
+            synchronized (this.responseListeners)
+            {
+                this.responseListeners.remove(internalActionId);
+            }
 
-		return responseEvents;
-	}
+        }
 
-	/**
-	 * Creates a new unique internal action id based on the hash code of this
-	 * connection and a sequence.
-	 * 
-	 * @return a new internal action id
-	 * @see ManagerUtil#addInternalActionId(String,String)
-	 * @see ManagerUtil#getInternalActionId(String)
-	 * @see ManagerUtil#stripInternalActionId(String)
-	 */
-	private String createInternalActionId()
-	{
-		final StringBuffer sb;
+        return responseEvents;
+    }
 
-		sb = new StringBuffer();
-		sb.append(this.hashCode());
-		sb.append("_");
-		sb.append(actionIdCounter.getAndIncrement());
+    /**
+     * Creates a new unique internal action id based on the hash code of this
+     * connection and a sequence.
+     * 
+     * @return a new internal action id
+     * @see ManagerUtil#addInternalActionId(String,String)
+     * @see ManagerUtil#getInternalActionId(String)
+     * @see ManagerUtil#stripInternalActionId(String)
+     */
+    private String createInternalActionId()
+    {
+        final StringBuffer sb;
 
-		return sb.toString();
-	}
+        sb = new StringBuffer();
+        sb.append(this.hashCode());
+        sb.append("_");
+        sb.append(actionIdCounter.getAndIncrement());
 
-	public void addEventListener(final ManagerEventListener listener)
-	{
-		synchronized (this.eventListeners)
-		{
-			// only add it if its not already there
-			if (!this.eventListeners.contains(listener))
-			{
-				this.eventListeners.add(listener);
-			}
-		}
-	}
+        return sb.toString();
+    }
 
-	public void removeEventListener(final ManagerEventListener listener)
-	{
-		synchronized (this.eventListeners)
-		{
-			if (this.eventListeners.contains(listener))
-			{
-				this.eventListeners.remove(listener);
-			}
-		}
-	}
+    public void addEventListener(final ManagerEventListener listener)
+    {
+        synchronized (this.eventListeners)
+        {
+            // only add it if its not already there
+            if (!this.eventListeners.contains(listener))
+            {
+                this.eventListeners.add(listener);
+            }
+        }
+    }
 
-	public String getProtocolIdentifier()
-	{
-		return protocolIdentifier.value;
-	}
+    public void removeEventListener(final ManagerEventListener listener)
+    {
+        synchronized (this.eventListeners)
+        {
+            if (this.eventListeners.contains(listener))
+            {
+                this.eventListeners.remove(listener);
+            }
+        }
+    }
 
-	public ManagerConnectionState getState()
-	{
-		return state;
-	}
+    public String getProtocolIdentifier()
+    {
+        return protocolIdentifier.value;
+    }
 
-	/* Implementation of Dispatcher: callbacks for ManagerReader */
+    public ManagerConnectionState getState()
+    {
+        return state;
+    }
 
-	/**
-	 * This method is called by the reader whenever a {@link ManagerResponse} is
-	 * received. The response is dispatched to the associated
-	 * {@link SendActionCallback}.
-	 * 
+    /* Implementation of Dispatcher: callbacks for ManagerReader */
+
+    /**
+     * This method is called by the reader whenever a {@link ManagerResponse} is
+     * received. The response is dispatched to the associated
+     * {@link SendActionCallback}.
+     * 
      * @param response the response received by the reader
-	 * @see ManagerReader
-	 */
-	public void dispatchResponse(ManagerResponse response)
-	{
-		final String actionId;
-		String internalActionId;
-		SendActionCallback listener;
+     * @see ManagerReader
+     */
+    public void dispatchResponse(ManagerResponse response)
+    {
+        final String actionId;
+        String internalActionId;
+        SendActionCallback listener;
 
-		// shouldn't happen
-		if (response == null)
-		{
-			logger.error("Unable to dispatch null response. This should never happen. Please file a bug.");
-			return;
-		}
+        // shouldn't happen
+        if (response == null)
+        {
+            logger.error("Unable to dispatch null response. This should never happen. Please file a bug.");
+            return;
+        }
 
-		actionId = response.getActionId();
-		internalActionId = null;
-		listener = null;
+        actionId = response.getActionId();
+        internalActionId = null;
+        listener = null;
 
-		if (actionId != null)
-		{
-			internalActionId = ManagerUtil.getInternalActionId(actionId);
-			response.setActionId(ManagerUtil.stripInternalActionId(actionId));
-		}
+        if (actionId != null)
+        {
+            internalActionId = ManagerUtil.getInternalActionId(actionId);
+            response.setActionId(ManagerUtil.stripInternalActionId(actionId));
+        }
 
-		logger.debug("Dispatching response with internalActionId '" + internalActionId + "':\n" + response);
+        logger.debug("Dispatching response with internalActionId '" + internalActionId + "':\n" + response);
 
-		if (internalActionId != null)
-		{
-			synchronized (this.responseListeners)
-			{
-				listener = responseListeners.get(internalActionId);
-				if (listener != null)
-				{
-					this.responseListeners.remove(internalActionId);
-				}
-				else
-				{
-					// when using the async sendAction it's ok not to register a
-					// callback so if we don't find a response handler thats ok
-					logger.debug("No response listener registered for " + "internalActionId '" + internalActionId + "'");
-				}
-			}
-		}
-		else
-		{
+        if (internalActionId != null)
+        {
+            synchronized (this.responseListeners)
+            {
+                listener = responseListeners.get(internalActionId);
+                if (listener != null)
+                {
+                    this.responseListeners.remove(internalActionId);
+                }
+                else
+                {
+                    // when using the async sendAction it's ok not to register a
+                    // callback so if we don't find a response handler thats ok
+                    logger.debug("No response listener registered for " + "internalActionId '" + internalActionId + "'");
+                }
+            }
+        }
+        else
+        {
             logger.error("Unable to retrieve internalActionId from response: " + "actionId '" + actionId + "':\n" + response);
-		}
+        }
 
-		if (listener != null)
-		{
-			try
-			{
-				listener.onResponse(response);
-			}
-			catch (Exception e)
-			{
-				logger.warn("Unexpected exception in response listener " + listener.getClass().getName(), e);
-			}
-		}
-	}
+        if (listener != null)
+        {
+            try
+            {
+                listener.onResponse(response);
+            }
+            catch (Exception e)
+            {
+                logger.warn("Unexpected exception in response listener " + listener.getClass().getName(), e);
+            }
+        }
+    }
 
-	/**
-	 * This method is called by the reader whenever a ManagerEvent is received.
-	 * The event is dispatched to all registered ManagerEventHandlers.
-	 * 
+    /**
+     * This method is called by the reader whenever a ManagerEvent is received.
+     * The event is dispatched to all registered ManagerEventHandlers.
+     * 
      * @param event the event received by the reader
-	 * @see #addEventListener(ManagerEventListener)
-	 * @see #removeEventListener(ManagerEventListener)
-	 * @see ManagerReader
-	 */
-	public void dispatchEvent(ManagerEvent event)
-	{
-		// shouldn't happen
-		if (event == null)
-		{
-			logger.error("Unable to dispatch null event. This should never happen. Please file a bug.");
-			return;
-		}
+     * @see #addEventListener(ManagerEventListener)
+     * @see #removeEventListener(ManagerEventListener)
+     * @see ManagerReader
+     */
+    public void dispatchEvent(ManagerEvent event)
+    {
+        // shouldn't happen
+        if (event == null)
+        {
+            logger.error("Unable to dispatch null event. This should never happen. Please file a bug.");
+            return;
+        }
         dispatchLegacyEventIfNeeded(event);
-		logger.debug("Dispatching event:\n" + event.toString());
+        logger.debug("Dispatching event:\n" + event.toString());
 
-		// Some events need special treatment besides forwarding them to the
-		// registered eventListeners (clients)
-		// These events are handled here at first:
+        // Some events need special treatment besides forwarding them to the
+        // registered eventListeners (clients)
+        // These events are handled here at first:
 
-		// Dispatch ResponseEvents to the appropriate responseEventListener
-		if (event instanceof ResponseEvent)
-		{
-			ResponseEvent responseEvent;
-			String internalActionId;
+        // Dispatch ResponseEvents to the appropriate responseEventListener
+        if (event instanceof ResponseEvent)
+        {
+            ResponseEvent responseEvent;
+            String internalActionId;
 
-			responseEvent = (ResponseEvent) event;
-			internalActionId = responseEvent.getInternalActionId();
-			if (internalActionId != null)
-			{
-				synchronized (responseEventListeners)
-				{
-					ManagerEventListener listener;
+            responseEvent = (ResponseEvent) event;
+            internalActionId = responseEvent.getInternalActionId();
+            if (internalActionId != null)
+            {
+                synchronized (responseEventListeners)
+                {
+                    ManagerEventListener listener;
 
-					listener = responseEventListeners.get(internalActionId);
-					if (listener != null)
-					{
-						try
-						{
-							listener.onManagerEvent(event);
-						}
-						catch (Exception e)
-						{
+                    listener = responseEventListeners.get(internalActionId);
+                    if (listener != null)
+                    {
+                        try
+                        {
+                            listener.onManagerEvent(event);
+                        }
+                        catch (Exception e)
+                        {
                             logger.warn("Unexpected exception in response event listener " + listener.getClass().getName(),
                                     e);
-						}
-					}
-				}
-			}
-			else
-			{
-				// ResponseEvent without internalActionId:
-				// this happens if the same event class is used as response
-				// event
-				// and as an event that is not triggered by a Manager command
-				// Example: QueueMemberStatusEvent.
-				// logger.debug("ResponseEvent without "
-				// + "internalActionId:\n" + responseEvent);
-			} // NOPMD
-		}
-		if (event instanceof DisconnectEvent)
-		{
-			// When we receive get disconnected while we are connected start
-			// a new reconnect thread and set the state to RECONNECTING.
-			if (state == CONNECTED)
-			{
-				state = RECONNECTING;
-				// close socket if still open and remove reference to
-				// readerThread
-				// After sending the DisconnectThread that thread will die
-				// anyway.
-				cleanup();
-				Thread reconnectThread = new Thread(new Runnable()
-				{
-					public void run()
-					{
-						reconnect();
-					}
-				});
-				reconnectThread.setName("Asterisk-Java ManagerConnection-" + id + "-Reconnect-"
-						+ reconnectThreadCounter.getAndIncrement());
-				reconnectThread.setDaemon(true);
-				reconnectThread.start();
-				// now the DisconnectEvent is dispatched to registered
-				// eventListeners
-				// (clients) and after that the ManagerReaderThread is gone.
-				// So effectively we replaced the reader thread by a
-				// ReconnectThread.
-			}
-			else
-			{
-				// when we receive a DisconnectEvent while not connected we
-				// ignore it and do not send it to clients
-				return;
-			}
-		}
-		if (event instanceof ProtocolIdentifierReceivedEvent)
-		{
-			ProtocolIdentifierReceivedEvent protocolIdentifierReceivedEvent;
-			String protocolIdentifier;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                // ResponseEvent without internalActionId:
+                // this happens if the same event class is used as response
+                // event
+                // and as an event that is not triggered by a Manager command
+                // Example: QueueMemberStatusEvent.
+                // logger.debug("ResponseEvent without "
+                // + "internalActionId:\n" + responseEvent);
+            } // NOPMD
+        }
+        if (event instanceof DisconnectEvent)
+        {
+            // When we receive get disconnected while we are connected start
+            // a new reconnect thread and set the state to RECONNECTING.
+            if (state == CONNECTED)
+            {
+                state = RECONNECTING;
+                // close socket if still open and remove reference to
+                // readerThread
+                // After sending the DisconnectThread that thread will die
+                // anyway.
+                cleanup();
+                Thread reconnectThread = new Thread(new Runnable()
+                {
+                    public void run()
+                    {
+                        reconnect();
+                    }
+                });
+                reconnectThread.setName("Asterisk-Java ManagerConnection-" + id + "-Reconnect-"
+                        + reconnectThreadCounter.getAndIncrement());
+                reconnectThread.setDaemon(true);
+                reconnectThread.start();
+                // now the DisconnectEvent is dispatched to registered
+                // eventListeners
+                // (clients) and after that the ManagerReaderThread is gone.
+                // So effectively we replaced the reader thread by a
+                // ReconnectThread.
+            }
+            else
+            {
+                // when we receive a DisconnectEvent while not connected we
+                // ignore it and do not send it to clients
+                return;
+            }
+        }
+        if (event instanceof ProtocolIdentifierReceivedEvent)
+        {
+            ProtocolIdentifierReceivedEvent protocolIdentifierReceivedEvent;
+            String protocolIdentifier;
 
-			protocolIdentifierReceivedEvent = (ProtocolIdentifierReceivedEvent) event;
-			protocolIdentifier = protocolIdentifierReceivedEvent.getProtocolIdentifier();
-			setProtocolIdentifier(protocolIdentifier);
-			// no need to send this event to clients
-			return;
-		}
+            protocolIdentifierReceivedEvent = (ProtocolIdentifierReceivedEvent) event;
+            protocolIdentifier = protocolIdentifierReceivedEvent.getProtocolIdentifier();
+            setProtocolIdentifier(protocolIdentifier);
+            // no need to send this event to clients
+            return;
+        }
 
-		fireEvent(event);
-	}
+        fireEvent(event);
+    }
 
-	/**
-     * Enro 2015-03
-     * Workaround to continue having Legacy Events from Asterisk 13.
+    /**
+     * Enro 2015-03 Workaround to continue having Legacy Events from Asterisk
+     * 13.
      */
-    private void dispatchLegacyEventIfNeeded(ManagerEvent event) {
-		if (event instanceof DialBeginEvent){
-        	DialEvent legacyEvent = (new DialEvent((DialBeginEvent) event));
-        	dispatchEvent(legacyEvent);
-		}
-	}
+    private void dispatchLegacyEventIfNeeded(ManagerEvent event)
+    {
+        if (event instanceof DialBeginEvent)
+        {
+            DialEvent legacyEvent = (new DialEvent((DialBeginEvent) event));
+            dispatchEvent(legacyEvent);
+        }
+    }
 
-	/**
-	 * Notifies all {@link ManagerEventListener}s registered by users.
-	 * 
+    /**
+     * Notifies all {@link ManagerEventListener}s registered by users.
+     * 
      * @param event the event to propagate
-	 */
-	private void fireEvent(ManagerEvent event)
-	{
-		synchronized (eventListeners)
-		{
-			for (ManagerEventListener listener : eventListeners)
-			{
-				try
-				{
-					listener.onManagerEvent(event);
-				}
-				catch (RuntimeException e)
-				{
-					logger.warn("Unexpected exception in eventHandler " + listener.getClass().getName(), e);
-				}
-			}
-		}
-	}
+     */
+    private void fireEvent(ManagerEvent event)
+    {
+        synchronized (eventListeners)
+        {
+            for (ManagerEventListener listener : eventListeners)
+            {
+                try
+                {
+                    listener.onManagerEvent(event);
+                }
+                catch (RuntimeException e)
+                {
+                    logger.warn("Unexpected exception in eventHandler " + listener.getClass().getName(), e);
+                }
+            }
+        }
+    }
 
-	/**
-	 * This method is called when a {@link ProtocolIdentifierReceivedEvent} is
-	 * received from the reader. Having received a correct protocol identifier
-	 * is the precodition for logging in.
-	 * 
+    /**
+     * This method is called when a {@link ProtocolIdentifierReceivedEvent} is
+     * received from the reader. Having received a correct protocol identifier
+     * is the precodition for logging in.
+     * 
      * @param identifier the protocol version used by the Asterisk server.
-	 */
-	private void setProtocolIdentifier(final String identifier)
-	{
-		logger.info("Connected via " + identifier);
+     */
+    private void setProtocolIdentifier(final String identifier)
+    {
+        logger.info("Connected via " + identifier);
 
-		if (!"Asterisk Call Manager/1.0".equals(identifier)
-                && !"Asterisk Call Manager/1.1".equals(identifier) // Asterisk 1.6
-                && !"Asterisk Call Manager/1.2".equals(identifier) // bri stuffed
-                && !"Asterisk Call Manager/1.3".equals(identifier) // Asterisk 11
-                && !"Asterisk Call Manager/2.6.0".equals(identifier) // Asterisk 13
-                && !"Asterisk Call Manager/2.7.0".equals(identifier) // Asterisk 13.2
-                && !"OpenPBX Call Manager/1.0".equals(identifier)
-                && !"CallWeaver Call Manager/1.0".equals(identifier)
-				&& !(identifier != null && identifier.startsWith("Asterisk Call Manager Proxy/")))
-		{
-			logger.warn("Unsupported protocol version '" + identifier + "'. Use at your own risk.");
-		}
+        if (!"Asterisk Call Manager/1.0".equals(identifier)
+                && !"Asterisk Call Manager/1.1".equals(identifier) // Asterisk
+                                                                   // 1.6
+                && !"Asterisk Call Manager/1.2".equals(identifier) // bri
+                                                                   // stuffed
+                && !"Asterisk Call Manager/1.3".equals(identifier) // Asterisk
+                                                                   // 11
+                && !"Asterisk Call Manager/2.6.0".equals(identifier) // Asterisk
+                                                                     // 13
+                && !"Asterisk Call Manager/2.7.0".equals(identifier) // Asterisk
+                                                                     // 13.2
+                && !"OpenPBX Call Manager/1.0".equals(identifier) && !"CallWeaver Call Manager/1.0".equals(identifier)
+                && !(identifier != null && identifier.startsWith("Asterisk Call Manager Proxy/")))
+        {
+            logger.warn("Unsupported protocol version '" + identifier + "'. Use at your own risk.");
+        }
 
-		synchronized (protocolIdentifier)
-		{
-			protocolIdentifier.value = identifier;
-			protocolIdentifier.notifyAll();
-		}
-	}
+        synchronized (protocolIdentifier)
+        {
+            protocolIdentifier.value = identifier;
+            protocolIdentifier.notifyAll();
+        }
+    }
 
-	/**
-	 * Reconnects to the asterisk server when the connection is lost.
-     * <br>
-	 * While keepAlive is <code>true</code> we will try to reconnect.
-	 * Reconnection attempts will be stopped when the {@link #logoff()} method
-	 * is called or when the login after a successful reconnect results in an
-	 * {@link AuthenticationFailedException} suggesting that the manager
-	 * credentials have changed and keepAliveAfterAuthenticationFailure is not
-	 * set.
-     * <br>
-	 * This method is called when a {@link DisconnectEvent} is received from the
-	 * reader.
-	 */
-	private void reconnect()
-	{
-		int numTries;
+    /**
+     * Reconnects to the asterisk server when the connection is lost. <br>
+     * While keepAlive is <code>true</code> we will try to reconnect.
+     * Reconnection attempts will be stopped when the {@link #logoff()} method
+     * is called or when the login after a successful reconnect results in an
+     * {@link AuthenticationFailedException} suggesting that the manager
+     * credentials have changed and keepAliveAfterAuthenticationFailure is not
+     * set. <br>
+     * This method is called when a {@link DisconnectEvent} is received from the
+     * reader.
+     */
+    private void reconnect()
+    {
+        int numTries;
 
-		// try to reconnect
-		numTries = 0;
-		while (state == RECONNECTING)
-		{
-			try
-			{
-				if (numTries < 10)
-				{
-					// try to reconnect quite fast for the firt 10 times
-					// this succeeds if the server has just been restarted
-					Thread.sleep(RECONNECTION_INTERVAL_1);
-				}
-				else
-				{
-					// slow down after 10 unsuccessful attempts asuming a
-					// shutdown of the server
-					Thread.sleep(RECONNECTION_INTERVAL_2);
-				}
-			}
-			catch (InterruptedException e)
-			{
-				Thread.currentThread().interrupt();
-			}
+        // try to reconnect
+        numTries = 0;
+        while (state == RECONNECTING)
+        {
+            try
+            {
+                if (numTries < 10)
+                {
+                    // try to reconnect quite fast for the firt 10 times
+                    // this succeeds if the server has just been restarted
+                    Thread.sleep(RECONNECTION_INTERVAL_1);
+                }
+                else
+                {
+                    // slow down after 10 unsuccessful attempts asuming a
+                    // shutdown of the server
+                    Thread.sleep(RECONNECTION_INTERVAL_2);
+                }
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+            }
 
-			try
-			{
-				connect();
+            try
+            {
+                connect();
 
-				try
-				{
-					doLogin(defaultResponseTimeout, eventMask);
-					logger.info("Successfully reconnected.");
-					// everything is ok again, so we leave
-					// when successful doLogin set the state to CONNECTED so no
-					// need to adjust it
-					break;
-				}
-				catch (AuthenticationFailedException e1)
-				{
-					if (keepAliveAfterAuthenticationFailure)
-					{
-						logger.error("Unable to log in after reconnect: " + e1.getMessage());
-					}
-					else
-					{
-						logger.error("Unable to log in after reconnect: " + e1.getMessage() + ". Giving up.");
-						state = DISCONNECTED;
-					}
-				}
-				catch (TimeoutException e1)
-				{
-					// shouldn't happen - but happens!
-					logger.error("TimeoutException while trying to log in " + "after reconnect.");
-				}
-			}
-			catch (IOException e)
-			{
-				// server seems to be still down, just continue to attempt
-				// reconnection
-				logger.warn("Exception while trying to reconnect: " + e.getMessage());
-			}
-			numTries++;
-		}
-	}
+                try
+                {
+                    doLogin(defaultResponseTimeout, eventMask);
+                    logger.info("Successfully reconnected.");
+                    // everything is ok again, so we leave
+                    // when successful doLogin set the state to CONNECTED so no
+                    // need to adjust it
+                    break;
+                }
+                catch (AuthenticationFailedException e1)
+                {
+                    if (keepAliveAfterAuthenticationFailure)
+                    {
+                        logger.error("Unable to log in after reconnect: " + e1.getMessage());
+                    }
+                    else
+                    {
+                        logger.error("Unable to log in after reconnect: " + e1.getMessage() + ". Giving up.");
+                        state = DISCONNECTED;
+                    }
+                }
+                catch (TimeoutException e1)
+                {
+                    // shouldn't happen - but happens!
+                    logger.error("TimeoutException while trying to log in " + "after reconnect.");
+                }
+            }
+            catch (IOException e)
+            {
+                // server seems to be still down, just continue to attempt
+                // reconnection
+                logger.warn("Exception while trying to reconnect: " + e.getMessage());
+            }
+            numTries++;
+        }
+    }
 
-	private void cleanup()
-	{
-		disconnect();
-		this.readerThread = null;
-	}
+    private void cleanup()
+    {
+        disconnect();
+        this.readerThread = null;
+    }
 
-	@Override
-	public String toString()
-	{
-		StringBuffer sb;
+    @Override
+    public String toString()
+    {
+        StringBuffer sb;
 
-		sb = new StringBuffer("ManagerConnection[");
-		sb.append("id='").append(id).append("',");
-		sb.append("hostname='").append(hostname).append("',");
-		sb.append("port=").append(port).append(",");
-		sb.append("systemHashcode=").append(System.identityHashCode(this)).append("]");
+        sb = new StringBuffer("ManagerConnection[");
+        sb.append("id='").append(id).append("',");
+        sb.append("hostname='").append(hostname).append("',");
+        sb.append("port=").append(port).append(",");
+        sb.append("systemHashcode=").append(System.identityHashCode(this)).append("]");
 
-		return sb.toString();
-	}
+        return sb.toString();
+    }
 
-	/* Helper classes */
+    /* Helper classes */
 
-	/**
-	 * A simple data object to store a ManagerResult.
-	 */
-	private static class ResponseHandlerResult implements Serializable
-	{
-		/**
-		 * Serializable version identifier.
-		 */
-		private static final long serialVersionUID = 7831097958568769220L;
-		private ManagerResponse response;
+    /**
+     * A simple data object to store a ManagerResult.
+     */
+    private static class ResponseHandlerResult implements Serializable
+    {
+        /**
+         * Serializable version identifier.
+         */
+        private static final long serialVersionUID = 7831097958568769220L;
+        private ManagerResponse response;
 
-		public ResponseHandlerResult()
-		{
-		}
+        public ResponseHandlerResult()
+        {
+        }
 
-		public ManagerResponse getResponse()
-		{
-			return this.response;
-		}
+        public ManagerResponse getResponse()
+        {
+            return this.response;
+        }
 
-		public void setResponse(ManagerResponse response)
-		{
-			this.response = response;
-		}
-	}
+        public void setResponse(ManagerResponse response)
+        {
+            this.response = response;
+        }
+    }
 
-	/**
-	 * A simple response handler that stores the received response in a
-	 * ResponseHandlerResult for further processing.
-	 */
-	private static class DefaultSendActionCallback implements SendActionCallback, Serializable
-	{
-		/**
-		 * Serializable version identifier.
-		 */
-		private static final long serialVersionUID = 2926598671855316803L;
-		private final ResponseHandlerResult result;
+    /**
+     * A simple response handler that stores the received response in a
+     * ResponseHandlerResult for further processing.
+     */
+    private static class DefaultSendActionCallback implements SendActionCallback, Serializable
+    {
+        /**
+         * Serializable version identifier.
+         */
+        private static final long serialVersionUID = 2926598671855316803L;
+        private final ResponseHandlerResult result;
 
-		/**
-		 * Creates a new instance.
-		 * 
+        /**
+         * Creates a new instance.
+         * 
          * @param result the result to store the response in
-		 */
-		public DefaultSendActionCallback(ResponseHandlerResult result)
-		{
-			this.result = result;
-		}
+         */
+        public DefaultSendActionCallback(ResponseHandlerResult result)
+        {
+            this.result = result;
+        }
 
-		public void onResponse(ManagerResponse response)
-		{
-			synchronized (result)
-			{
-				result.setResponse(response);
-				result.notifyAll();
-			}
-		}
-	}
+        public void onResponse(ManagerResponse response)
+        {
+            synchronized (result)
+            {
+                result.setResponse(response);
+                result.notifyAll();
+            }
+        }
+    }
 
-	/**
-	 * A combinded event and response handler that adds received events and the
-	 * response to a ResponseEvents object.
-	 */
-	private static class ResponseEventHandler implements ManagerEventListener, SendActionCallback
-	{
-		private final ResponseEventsImpl events;
-		private final Class<?> actionCompleteEventClass;
+    /**
+     * A combinded event and response handler that adds received events and the
+     * response to a ResponseEvents object.
+     */
+    private static class ResponseEventHandler implements ManagerEventListener, SendActionCallback
+    {
+        private final ResponseEventsImpl events;
+        private final Class< ? > actionCompleteEventClass;
 
-		/**
-		 * Creates a new instance.
-		 * 
-         * @param events                   the ResponseEventsImpl to store the events in
+        /**
+         * Creates a new instance.
+         * 
+         * @param events the ResponseEventsImpl to store the events in
          * @param actionCompleteEventClass the type of event that indicates that
-         *                                 all events have been received
-		 */
-		public ResponseEventHandler(ResponseEventsImpl events, Class<?> actionCompleteEventClass)
-		{
-			this.events = events;
-			this.actionCompleteEventClass = actionCompleteEventClass;
-		}
+         *            all events have been received
+         */
+        public ResponseEventHandler(ResponseEventsImpl events, Class< ? > actionCompleteEventClass)
+        {
+            this.events = events;
+            this.actionCompleteEventClass = actionCompleteEventClass;
+        }
 
-		public void onManagerEvent(ManagerEvent event)
-		{
-			synchronized (events)
-			{
-				// should always be a ResponseEvent, anyway...
-				if (event instanceof ResponseEvent)
-				{
-					ResponseEvent responseEvent;
+        public void onManagerEvent(ManagerEvent event)
+        {
+            synchronized (events)
+            {
+                // should always be a ResponseEvent, anyway...
+                if (event instanceof ResponseEvent)
+                {
+                    ResponseEvent responseEvent;
 
-					responseEvent = (ResponseEvent) event;
-					events.addEvent(responseEvent);
-				}
+                    responseEvent = (ResponseEvent) event;
+                    events.addEvent(responseEvent);
+                }
 
-				// finished?
-				if (actionCompleteEventClass.isAssignableFrom(event.getClass()))
-				{
-					events.setComplete(true);
-					// notify if action complete event and response have been
-					// received
-					if (events.getResponse() != null)
-					{
-						events.notifyAll();
-					}
-				}
-			}
-		}
+                // finished?
+                if (actionCompleteEventClass.isAssignableFrom(event.getClass()))
+                {
+                    events.setComplete(true);
+                    // notify if action complete event and response have been
+                    // received
+                    if (events.getResponse() != null)
+                    {
+                        events.notifyAll();
+                    }
+                }
+            }
+        }
 
-		public void onResponse(ManagerResponse response)
-		{
-			synchronized (events)
-			{
-				events.setRepsonse(response);
-				if (response instanceof ManagerError)
-				{
-					events.setComplete(true);
-				}
+        public void onResponse(ManagerResponse response)
+        {
+            synchronized (events)
+            {
+                events.setRepsonse(response);
+                if (response instanceof ManagerError)
+                {
+                    events.setComplete(true);
+                }
 
-				// finished?
-				// notify if action complete event and response have been
-				// received
-				if (events.isComplete())
-				{
-					events.notifyAll();
-				}
-			}
-		}
-	}
+                // finished?
+                // notify if action complete event and response have been
+                // received
+                if (events.isComplete())
+                {
+                    events.notifyAll();
+                }
+            }
+        }
+    }
 
-	private static class ProtocolIdentifierWrapper
-	{
-		String value;
-	}
+    private static class ProtocolIdentifierWrapper
+    {
+        String value;
+    }
 }


### PR DESCRIPTION
So this is what I have at the moment - 
- Restructured ParkEvents and HoldEvents to better comply with Asterisk 12 AMI Spec 
- Removed properties and getters/setters that unnecessarily overrode ManagerEvent (don't think I caught them all, yet, though)
- Backward compatibility for DialBeginEvents by building fake legacy DialEvent
- Small NullPointer fix in MeetMeManager
- Plus the changes that were already included in the 1.1 release branch.

Do let me know if you have any questions...