### PR TITLE
-- fixed https://github.com/asterisk-java/asterisk-java/issues/53

### DIFF
--- a/src/main/java/org/asteriskjava/manager/response/SipShowPeerResponse.java
+++ b/src/main/java/org/asteriskjava/manager/response/SipShowPeerResponse.java
@@ -77,6 +77,7 @@ public class SipShowPeerResponse extends ManagerResponse
 	private String sipForcerport;
 	private String sipRtpEngine;
 	private String sipComedia;
+	private String mohsuggest;
 	
 
 	private Map<String, String> chanVariable;
@@ -711,6 +712,15 @@ public class SipShowPeerResponse extends ManagerResponse
 	public void setSipComedia(String sipComedia) {
 		this.sipComedia = sipComedia;
 	}
+	
+
+	public String getMohsuggest() {
+		return mohsuggest;
+	}
+
+	public void setMohsuggest(String mohsuggest) {
+		this.mohsuggest = mohsuggest;
+	}
 
 	@Override
 	public String toString() {
@@ -841,6 +851,8 @@ public class SipShowPeerResponse extends ManagerResponse
 		builder.append(sipComedia);
 		builder.append(", chanVariable=");
 		builder.append(chanVariable);
+		builder.append(", mohSuggest=");
+		builder.append(mohsuggest);
 		builder.append("]");
 		return builder.toString();
 	}

--- a/src/test/java/org/asteriskjava/manager/response/SipShowPeerResponseTest.java
+++ b/src/test/java/org/asteriskjava/manager/response/SipShowPeerResponseTest.java
@@ -35,4 +35,13 @@ public class SipShowPeerResponseTest
         response.setQualifyFreq(": 60000 ms\nChanVariable:\n PHBX_ID,191");
         assertEquals("Incorrect qualifyFreq", 60000, (int) response.getQualifyFreq());
     }
+    
+    @Test
+    public void testSetMohsuggest()
+    {
+        response.setMohsuggest("default");
+        assertEquals("Incorrect mohsuggest", "default",response.getMohsuggest());
+    }
+    
+    
 }


### PR DESCRIPTION
Unable to set property 'mohsuggest' to 'default' on org.asteriskjava.manager.response.SipShowPeerResponse: no setter. Please report at http://jira.reucon.org/browse/AJ