### PR TITLE
MuteFlagException

### DIFF
--- a/src/main/java/org/asteriskjava/live/MuteFlagException.java
+++ b/src/main/java/org/asteriskjava/live/MuteFlagException.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright 2005-2006 Stefan Reuter
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.asteriskjava.live;
+
+/**
+ * Indicates that the mute flag cannot be applied for this channel. Most probably because channel is not monitored (recorded)
+ * 
+ * @author videanuadrian
+ * @version $Id$
+ */
+public class MuteFlagException extends LiveException
+{
+    /**
+     * Serial version identifier.
+     */
+    
+	private static final long serialVersionUID = 7804327171239361017L;
+
+	/**
+     * Creates a new instance with the given message.
+     * 
+     * @param message the message
+     */
+    public MuteFlagException(String message)
+    {
+        super(message);
+    }
+}

--- a/src/main/java/org/asteriskjava/live/RecordingException.java
+++ b/src/main/java/org/asteriskjava/live/RecordingException.java
@@ -17,12 +17,12 @@
 package org.asteriskjava.live;
 
 /**
- * Indicates that the mute flag cannot be applied for this channel. Most probably because channel is not monitored (recorded)
+ * Indicates that a record related issue has occured,
  * 
  * @author videanuadrian
  * @version $Id$
  */
-public class MuteFlagException extends LiveException
+public class RecordingException extends LiveException
 {
     /**
      * Serial version identifier.
@@ -35,7 +35,7 @@ public class MuteFlagException extends LiveException
      * 
      * @param message the message
      */
-    public MuteFlagException(String message)
+    public RecordingException(String message)
     {
         super(message);
     }

--- a/src/main/java/org/asteriskjava/live/internal/AsteriskChannelImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskChannelImpl.java
@@ -31,7 +31,7 @@ import org.asteriskjava.live.HangupCause;
 import org.asteriskjava.live.LinkedChannelHistoryEntry;
 import org.asteriskjava.live.LiveException;
 import org.asteriskjava.live.ManagerCommunicationException;
-import org.asteriskjava.live.MuteFlagException;
+import org.asteriskjava.live.RecordingException;
 import org.asteriskjava.live.NoSuchChannelException;
 import org.asteriskjava.manager.action.AbsoluteTimeoutAction;
 import org.asteriskjava.manager.action.ChangeMonitorAction;
@@ -875,24 +875,24 @@ class AsteriskChannelImpl extends AbstractLiveObject implements AsteriskChannel
     }
 
     
-    public void pauseMixMonitor(MixMonitorDirection direction) throws ManagerCommunicationException, NoSuchChannelException, MuteFlagException
+    public void pauseMixMonitor(MixMonitorDirection direction) throws ManagerCommunicationException, NoSuchChannelException, RecordingException
     {
         ManagerResponse response;
         response = server.sendAction(new PauseMixMonitorAction(this.name,1,direction.getStateName()));
         if (response instanceof ManagerError) {
         	if (response.getMessage().equals("Cannot set mute flag"))        	
-        		throw new MuteFlagException(response.getMessage()+" on channel: '" + name);        	
+        		throw new RecordingException(response.getMessage()+" on channel: '" + name);        	
         }
     }
 
     
-    public void unPauseMixMonitor(MixMonitorDirection direction) throws ManagerCommunicationException, NoSuchChannelException, MuteFlagException
+    public void unPauseMixMonitor(MixMonitorDirection direction) throws ManagerCommunicationException, NoSuchChannelException, RecordingException
     {
         ManagerResponse response;
         response = server.sendAction(new PauseMixMonitorAction(this.name,0,direction.getStateName()));        
         if (response instanceof ManagerError) {
         	if (response.getMessage().equals("Cannot set mute flag"))        	
-        		throw new MuteFlagException(response.getMessage()+" on channel: '" + name);        	
+        		throw new RecordingException(response.getMessage()+" on channel: '" + name);        	
         }
     }
     

--- a/src/main/java/org/asteriskjava/live/internal/AsteriskChannelImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskChannelImpl.java
@@ -29,7 +29,9 @@ import org.asteriskjava.live.Extension;
 import org.asteriskjava.live.ExtensionHistoryEntry;
 import org.asteriskjava.live.HangupCause;
 import org.asteriskjava.live.LinkedChannelHistoryEntry;
+import org.asteriskjava.live.LiveException;
 import org.asteriskjava.live.ManagerCommunicationException;
+import org.asteriskjava.live.MuteFlagException;
 import org.asteriskjava.live.NoSuchChannelException;
 import org.asteriskjava.manager.action.AbsoluteTimeoutAction;
 import org.asteriskjava.manager.action.ChangeMonitorAction;
@@ -873,27 +875,26 @@ class AsteriskChannelImpl extends AbstractLiveObject implements AsteriskChannel
     }
 
     
-    public void pauseMixMonitor(MixMonitorDirection direction) throws ManagerCommunicationException, NoSuchChannelException
+    public void pauseMixMonitor(MixMonitorDirection direction) throws ManagerCommunicationException, NoSuchChannelException, MuteFlagException
     {
         ManagerResponse response;
         response = server.sendAction(new PauseMixMonitorAction(this.name,1,direction.getStateName()));
         if (response instanceof ManagerError) {
-            throw new NoSuchChannelException("Channel '" + name + "' is not available: " + response.getMessage());
+        	if (response.getMessage().equals("Cannot set mute flag"))        	
+        		throw new MuteFlagException(response.getMessage()+" on channel: '" + name);        	
         }
     }
 
     
-    public void unPauseMixMonitor(MixMonitorDirection direction) throws ManagerCommunicationException, NoSuchChannelException
+    public void unPauseMixMonitor(MixMonitorDirection direction) throws ManagerCommunicationException, NoSuchChannelException, MuteFlagException
     {
         ManagerResponse response;
         response = server.sendAction(new PauseMixMonitorAction(this.name,0,direction.getStateName()));        
         if (response instanceof ManagerError) {
-            throw new NoSuchChannelException("Channel '" + name + "' is not available: " + response.getMessage());
+        	if (response.getMessage().equals("Cannot set mute flag"))        	
+        		throw new MuteFlagException(response.getMessage()+" on channel: '" + name);        	
         }
     }
-    
-    
-    
     
     
     public Extension getParkedAt()


### PR DESCRIPTION
-- added a new LiveException that is raised when you try to pause a
record for a call that has not been monitored (recorded). Previously the
pauseMixMonitor() threw NoSuchChannelException which was not suitable in
this case, more than that it was misleading.