### PR TITLE
ManagerEvent getters and setters final to prevent useless overrides

### DIFF
--- a/src/main/java/org/asteriskjava/manager/event/AbstractBridgeEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AbstractBridgeEvent.java
@@ -10,7 +10,6 @@ public abstract class AbstractBridgeEvent extends ManagerEvent
 	 */
 	private static final long serialVersionUID = 1L;
 	private String bridgeUniqueId;
-	private String privilege;
 	private String bridgeType;
 	private Integer bridgeNumChannels;
 	private String bridgeCreator;
@@ -30,18 +29,6 @@ public abstract class AbstractBridgeEvent extends ManagerEvent
 	public void setBridgeUniqueId(String bridgeUniqueId)
 	{
 		this.bridgeUniqueId = bridgeUniqueId;
-	}
-
-	@Override
-	public String getPrivilege()
-	{
-		return privilege;
-	}
-
-	@Override
-	public void setPrivilege(String privilege)
-	{
-		this.privilege = privilege;
 	}
 
 	public String getBridgeType()

--- a/src/main/java/org/asteriskjava/manager/event/AbstractChannelStateEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AbstractChannelStateEvent.java
@@ -32,77 +32,9 @@ public abstract class AbstractChannelStateEvent extends AbstractChannelEvent
      */
     static final long serialVersionUID = 0L;
 
-    private Integer channelState;
-    private String channelStateDesc;
-
     protected AbstractChannelStateEvent(Object source)
     {
         super(source);
-    }
-
-    /**
-     * Returns the new state of the channel.
-     * <p>
-     * For Asterisk versions prior to 1.6 (that do not send the numeric value)
-     * it is derived from the descriptive text.
-     *
-     * @return the new state of the channel.
-     * @since 1.0.0
-     */
-    @Override
-    public Integer getChannelState()
-    {
-        return channelState == null ? AstState.str2state(channelStateDesc) : channelState;
-    }
-
-    /**
-     * Sets the new state of the channel.
-     *
-     * @param channelState the new state of the channel.
-     * @since 1.0.0
-     */
-    @Override
-    public void setChannelState(Integer channelState)
-    {
-        this.channelState = channelState;
-    }
-
-    /**
-     * Returns the new state of the channel as a descriptive text.
-     * <p>
-     * The following states are used:
-     * <p>
-     * <ul>
-     * <li>Down</li>
-     * <li>Rsrvd</li>
-     * <li>OffHook</li>
-     * <li>Dialing</li>
-     * <li>Ring</li>
-     * <li>Ringing</li>
-     * <li>Up</li>
-     * <li>Busy</li>
-     * <li>Dialing Offhook (since Asterik 1.6)</li>
-     * <li>Pre-ring (since Asterik 1.6)</li>
-     * </ul>
-     *
-     * @return the new state of the channel as a descriptive text.
-     * @since 1.0.0
-     */
-    public String getChannelStateDesc()
-    {
-        return channelStateDesc;
-    }
-
-    /**
-     * Sets the new state of the channel as a descriptive text.
-     *
-     * @param channelStateDesc the new state of the channel as a descriptive
-     *            text.
-     * @since 1.0.0
-     */
-    public void setChannelStateDesc(String channelStateDesc)
-    {
-        this.channelStateDesc = channelStateDesc;
     }
 
     /**
@@ -117,7 +49,7 @@ public abstract class AbstractChannelStateEvent extends AbstractChannelEvent
     @Deprecated
     public String getState()
     {
-        return channelStateDesc;
+        return getChannelStateDesc();
     }
 
     /**
@@ -129,6 +61,6 @@ public abstract class AbstractChannelStateEvent extends AbstractChannelEvent
      */
     public void setState(String state)
     {
-        this.channelStateDesc = state;
+        setChannelStateDesc(state);
     }
 }

--- a/src/main/java/org/asteriskjava/manager/event/AbstractParkedCallEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AbstractParkedCallEvent.java
@@ -98,24 +98,6 @@ public abstract class AbstractParkedCallEvent extends ManagerEvent
     }
 
     /**
-     * Returns the Caller*ID number of the parked channel.
-     *
-     * @return the Caller*ID number of the parked channel.
-     * @since 1.0.0
-     */
-    @Override
-    public String getCallerIdNum()
-    {
-        return getParkeeCallerIDNum();
-    }
-
-    @Override
-    public void setCallerIdNum(String callerIdNum)
-    {
-        this.setParkeeCallerIDNum(callerIdNum);
-    }
-
-    /**
      * Returns the unique id of the parked channel.
      * <p>
      * Note: This property is not set properly by all versions of Asterisk, see
@@ -340,29 +322,5 @@ public abstract class AbstractParkedCallEvent extends ManagerEvent
     public void setCallerId(String callerId)
     {
         setParkeeCallerIDNum(callerId);
-    }
-
-    @Deprecated
-    public String getCallerIdName()
-    {
-        return getParkeeCallerIDName();
-    }
-
-    @Deprecated
-    public void setCallerIdName(String callerIdName)
-    {
-        setParkeeCallerIDName(callerIdName);
-    }
-
-    @Deprecated
-    public String getExten()
-    {
-        return getParkingSpace();
-    }
-
-    @Deprecated
-    public void setExten(String exten)
-    {
-        setParkingSpace(exten);
     }
 }

--- a/src/main/java/org/asteriskjava/manager/event/ConfbridgeListEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ConfbridgeListEvent.java
@@ -15,7 +15,6 @@ public class ConfbridgeListEvent extends ResponseEvent
 
     private String conference;
     private String callerIDnum;
-    private String callerIdName;
     private Boolean admin;
     private Boolean markedUser;
     private String channel;
@@ -63,26 +62,6 @@ public class ConfbridgeListEvent extends ResponseEvent
     public String getCallerIDnum()
     {
         return callerIDnum;
-    }
-
-    /**
-     * Sets the Caller*ID Name of the channel in the list of the conference.
-     *
-     * @param callerIdName the Caller*ID Name of the channel in the list of the conference.
-     */
-    public void setCallerIdName(String callerIdName)
-    {
-        this.callerIdName = callerIdName;
-    }
-
-    /**
-     * Returns the Caller*ID Name of the channel in the list of the conference.
-     *
-     * @return the Caller*ID Name of the channel in the list of the conference.
-     */
-    public String getCallerIdName()
-    {
-        return callerIdName;
     }
 
     /**

--- a/src/main/java/org/asteriskjava/manager/event/CoreShowChannelEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/CoreShowChannelEvent.java
@@ -34,12 +34,9 @@ public class CoreShowChannelEvent extends ResponseEvent
 
     private String uniqueid;
     private String channel;
-    private String context;
     private String extension;
-    private String channelstatedesc;
     private String application;
     private String applicationdata;
-    private String calleridnum;
     private String duration;
     private String accountcode;
     private String bridgedChannel;
@@ -133,21 +130,6 @@ public class CoreShowChannelEvent extends ResponseEvent
     }
 
     /**
-     * Returns the CallerID
-     *
-     * @return callerid
-     */
-    public String getCalleridnum()
-    {
-        return calleridnum;
-    }
-
-    public void setCalleridnum(String calleridnum)
-    {
-        this.calleridnum = calleridnum;
-    }
-
-    /**
      * Returns the Originate Channel name
      *
      * @return Channel name
@@ -160,36 +142,6 @@ public class CoreShowChannelEvent extends ResponseEvent
     public void setChannel(String channel)
     {
         this.channel = channel;
-    }
-
-    /**
-     * Returns the Channel state description (RING,...)
-     *
-     * @return description
-     */
-    public String getChannelstatedesc()
-    {
-        return channelstatedesc;
-    }
-
-    public void setChannelstatedesc(String channelstatedesc)
-    {
-        this.channelstatedesc = channelstatedesc;
-    }
-
-    /**
-     * Returns the Context the channel is
-     *
-     * @return context
-     */
-    public String getContext()
-    {
-        return context;
-    }
-
-    public void setContext(String context)
-    {
-        this.context = context;
     }
 
     /**

--- a/src/main/java/org/asteriskjava/manager/event/DahdiShowChannelsEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/DahdiShowChannelsEvent.java
@@ -34,7 +34,6 @@ public class DahdiShowChannelsEvent extends ResponseEvent
     private Integer Dahdichannel;
     private String signalling;
     private String signallingcode;
-    private String context;
     private Boolean dnd;
     private String alarm;
     private String uniqueid;
@@ -133,24 +132,6 @@ public class DahdiShowChannelsEvent extends ResponseEvent
     public void setSignalling(String signalling)
     {
         this.signalling = signalling;
-    }
-
-
-
-    /**
-     * Returns the context of this Dahdi channel as defined in <code>chan_Dahdi.conf</code>.
-     */
-    public String getContext()
-    {
-        return context;
-    }
-
-    /**
-     * Sets the context of this Dahdi channel.
-     */
-    public void setContext(String context)
-    {
-        this.context = context;
     }
 
     /**

--- a/src/main/java/org/asteriskjava/manager/event/DialEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/DialEvent.java
@@ -78,16 +78,6 @@ public class DialEvent extends ManagerEvent
     private String destCallerIdNum;
 
     /**
-     * The new Caller*ID.
-     */
-    private String callerIdNum;
-
-    /**
-     * The new Caller*ID Name.
-     */
-    private String callerIdName;
-
-    /**
      * The unique id of the source channel.
      */
     private String uniqueId;
@@ -234,17 +224,19 @@ public class DialEvent extends ManagerEvent
     @Deprecated
     public String getCallerId()
     {
-        return callerIdNum;
+        return getCallerIdNum();
     }
 
     /**
      * Sets the caller*ID.
      *
      * @param callerId the caller*ID.
+     * @deprecated as of 1.0.0, use {@link #setCallerIdNum()} instead.
      */
+    @Deprecated
     public void setCallerId(String callerId)
     {
-        this.callerIdNum = callerId;
+        setCallerIdNum(callerId);
     }
 
     /**

--- a/src/main/java/org/asteriskjava/manager/event/DongleDeviceEntryEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/DongleDeviceEntryEvent.java
@@ -13,8 +13,6 @@ public class DongleDeviceEntryEvent extends ResponseEvent
 	private String IMEISetting;
 	private String IMSISetting;
 	private String ChannelLanguage;
-	private String Context;
-	private String Exten;
 	private String Group;
 	private String RXGain;
 	private String TXGain;
@@ -130,26 +128,6 @@ public class DongleDeviceEntryEvent extends ResponseEvent
 	public void setChannelLanguage(String ChannelLanguage)
 	{
 		this.ChannelLanguage = ChannelLanguage;
-	}
-
-	public String getContext()
-	{
-		return Context;
-	}
-
-	public void setContext(String Context)
-	{
-		this.Context = Context;
-	}
-
-	public String getExten()
-	{
-		return Exten;
-	}
-
-	public void setExten(String Exten)
-	{
-		this.Exten = Exten;
 	}
 
 	public String getGroup()

--- a/src/main/java/org/asteriskjava/manager/event/ExtensionStatusEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ExtensionStatusEvent.java
@@ -65,8 +65,6 @@ public class ExtensionStatusEvent extends ManagerEvent
      */
     public static final int RINGING = 1 << 3;
 
-    private String exten;
-    private String context;
     private String hint;
     private Integer status;
     private String callerId;
@@ -74,38 +72,6 @@ public class ExtensionStatusEvent extends ManagerEvent
     public ExtensionStatusEvent(Object source)
     {
         super(source);
-    }
-
-    /**
-     * Returns the extension.
-     */
-    public String getExten()
-    {
-        return exten;
-    }
-
-    /**
-     * Sets the extension.
-     */
-    public void setExten(String exten)
-    {
-        this.exten = exten;
-    }
-
-    /**
-     * Returns the context of the extension.
-     */
-    public String getContext()
-    {
-        return context;
-    }
-
-    /**
-     * Sets the context of the extension.
-     */
-    public void setContext(String context)
-    {
-        this.context = context;
     }
 
     /**

--- a/src/main/java/org/asteriskjava/manager/event/FaxReceivedEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/FaxReceivedEvent.java
@@ -36,7 +36,6 @@ public class FaxReceivedEvent extends AbstractFaxEvent
      */
     private static final long serialVersionUID = 1L;
 
-    private String exten;
     private String callerId;
     private String remoteStationId;
     private String localStationId;
@@ -48,27 +47,6 @@ public class FaxReceivedEvent extends AbstractFaxEvent
     public FaxReceivedEvent(Object source)
     {
         super(source);
-    }
-
-    /**
-     * Returns the extension in Asterisk's dialplan the fax was received
-     * through.
-     * 
-     * @return the extension the fax was received through.
-     */
-    public String getExten()
-    {
-        return exten;
-    }
-
-    /**
-     * Sets the extension the fax was received through.
-     * 
-     * @param exten the extension the fax was received through.
-     */
-    public void setExten(String exten)
-    {
-        this.exten = exten;
     }
 
     /**

--- a/src/main/java/org/asteriskjava/manager/event/FaxStatusEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/FaxStatusEvent.java
@@ -52,12 +52,10 @@ public class FaxStatusEvent extends AbstractFaxEvent
     private Integer rtnCount;
     private Integer dcnCount;
     private String remoteStationId;
-    private String context;
     private String localStationId;
     private String callerId;
     private String status;
     private String operation;
-    private String exten;
 
     public FaxStatusEvent(Object source)
     {
@@ -514,22 +512,6 @@ public class FaxStatusEvent extends AbstractFaxEvent
     }
 
     /**
-     * @return the context
-     */
-    public String getContext()
-    {
-        return context;
-    }
-
-    /**
-     * @param context the context to set
-     */
-    public void setContext(String context)
-    {
-        this.context = context;
-    }
-
-    /**
      * @return the callerId
      */
     public String getCallerId()
@@ -576,22 +558,5 @@ public class FaxStatusEvent extends AbstractFaxEvent
     {
         this.operation = operation;
     }
-
-    /**
-     * @return the exten
-     */
-    public String getExten()
-    {
-        return exten;
-    }
-
-    /**
-     * @param exten the exten to set
-     */
-    public void setExten(String exten)
-    {
-        this.exten = exten;
-    }
-
 }
 

--- a/src/main/java/org/asteriskjava/manager/event/JoinEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/JoinEvent.java
@@ -63,49 +63,6 @@ public class JoinEvent extends QueueEvent
     }
 
     /**
-     * Returns the Caller*ID number of the channel that joined the queue if set.
-     * If the channel has no caller id set "unknown" is returned.
-     *
-     * @return the Caller*ID number of the channel that joined the queue
-     * @since 1.0.0
-     */
-    public String getCallerIdNum()
-    {
-        return callerIdNum;
-    }
-
-    /**
-     * Sets the Caller*ID number of the channel that joined the queue.
-     *
-     * @param callerIdNum the Caller*ID number of the channel that joined the queue.
-     */
-    public void setCallerIdNum(String callerIdNum)
-    {
-        this.callerIdNum = callerIdNum;
-    }
-
-    /**
-     * Returns the Caller*ID name of the channel that joined the queue if set.
-     * If the channel has no caller id set "unknown" is returned.
-     *
-     * @since 0.2
-     */
-    public String getCallerIdName()
-    {
-        return callerIdName;
-    }
-
-    /**
-     * Sets the Caller*ID name of the channel that joined the queue.
-     *
-     * @since 0.2
-     */
-    public void setCallerIdName(String callerIdName)
-    {
-        this.callerIdName = callerIdName;
-    }
-
-    /**
      * Returns the position of the joined channel in the queue.
      */
     public Integer getPosition()

--- a/src/main/java/org/asteriskjava/manager/event/ListDialplanEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ListDialplanEvent.java
@@ -18,10 +18,8 @@ public class ListDialplanEvent extends ResponseEvent
 
     private static final String PRIORITY_HINT = "hint";
 
-    private String context;
     private String extension;
     private String extensionLabel;
-    private Integer priority;
     private boolean hint = false;
     private String application;
     private String appData;
@@ -30,21 +28,6 @@ public class ListDialplanEvent extends ResponseEvent
     public ListDialplanEvent(Object source)
     {
         super(source);
-    }
-
-    /**
-     * Returns the context.
-     *
-     * @return the context.
-     */
-    public String getContext()
-    {
-        return context;
-    }
-
-    public void setContext(String context)
-    {
-        this.context = context;
     }
 
     /**
@@ -74,16 +57,6 @@ public class ListDialplanEvent extends ResponseEvent
     public void setExtensionLabel(String extensionLabel)
     {
         this.extensionLabel = extensionLabel;
-    }
-
-    /**
-     * Returns the priority.
-     *
-     * @return the priority or <code>null</code> if this is a hint.
-     */
-    public Integer getPriority()
-    {
-        return priority;
     }
 
     /**

--- a/src/main/java/org/asteriskjava/manager/event/ManagerEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ManagerEvent.java
@@ -56,42 +56,42 @@ public abstract class ManagerEvent extends EventObject
      * @since 0.2
      */
 
-    public final String getCallerIdName()
+    public String getCallerIdName()
     {
         return callerIdName;
     }
 
-    public final void setCallerIdName(String callerIdName)
+    public void setCallerIdName(String callerIdName)
     {
         this.callerIdName = callerIdName;
     }
 
-    public final String getConnectedLineNum()
+    public String getConnectedLineNum()
     {
         return connectedLineNum;
     }
 
-    public final void setConnectedLineNum(String connectedLineNum)
+    public void setConnectedLineNum(String connectedLineNum)
     {
         this.connectedLineNum = connectedLineNum;
     }
 
-    public final String getConnectedLineName()
+    public String getConnectedLineName()
     {
         return connectedLineName;
     }
 
-    public final void setConnectedLineName(String connectedLineName)
+    public void setConnectedLineName(String connectedLineName)
     {
         this.connectedLineName = connectedLineName;
     }
 
-    public final Integer getPriority()
+    public Integer getPriority()
     {
         return priority;
     }
 
-    public final void setPriority(Integer priority)
+    public void setPriority(Integer priority)
     {
         this.priority = priority;
     }
@@ -101,47 +101,47 @@ public abstract class ManagerEvent extends EventObject
         return channelState == null ? AstState.str2state(channelStateDesc) : channelState;
     }
 
-    public final void setChannelState(Integer channelState)
+    public void setChannelState(Integer channelState)
     {
         this.channelState = channelState;
     }
 
-    public final String getChannelStateDesc()
+    public String getChannelStateDesc()
     {
         return channelStateDesc;
     }
 
-    public final void setChannelStateDesc(String channelStateDesc)
+    public void setChannelStateDesc(String channelStateDesc)
     {
         this.channelStateDesc = channelStateDesc;
     }
 
-    public final String getExten()
+    public String getExten()
     {
         return exten;
     }
 
-    public final void setExten(String exten)
+    public void setExten(String exten)
     {
         this.exten = exten;
     }
 
-    public final String getCallerIdNum()
+    public String getCallerIdNum()
     {
         return callerIdNum;
     }
 
-    public final void setCallerIdNum(String callerIdNum)
+    public void setCallerIdNum(String callerIdNum)
     {
         this.callerIdNum = callerIdNum;
     }
 
-    public final String getContext()
+    public String getContext()
     {
         return context;
     }
 
-    public final void setContext(String context)
+    public void setContext(String context)
     {
         this.context = context;
     }
@@ -187,7 +187,7 @@ public abstract class ManagerEvent extends EventObject
      * (for example ConnectEvent and DisconnectEvent) may return
      * <code>null</code>.
      */
-    public final Date getDateReceived()
+    public Date getDateReceived()
     {
         return dateReceived;
     }
@@ -195,7 +195,7 @@ public abstract class ManagerEvent extends EventObject
     /**
      * Sets the point in time this event was received from the asterisk server.
      */
-    public final void setDateReceived(Date dateReceived)
+    public void setDateReceived(Date dateReceived)
     {
         this.dateReceived = dateReceived;
     }
@@ -208,7 +208,7 @@ public abstract class ManagerEvent extends EventObject
      *
      * @since 0.2
      */
-    public final String getPrivilege()
+    public String getPrivilege()
     {
         return privilege;
     }
@@ -218,7 +218,7 @@ public abstract class ManagerEvent extends EventObject
      *
      * @since 0.2
      */
-    public final void setPrivilege(String privilege)
+    public void setPrivilege(String privilege)
     {
         this.privilege = privilege;
     }
@@ -277,12 +277,12 @@ public abstract class ManagerEvent extends EventObject
         this.server = server;
     }
 
-    public final String getSystemName()
+    public String getSystemName()
     {
         return systemName;
     }
 
-    public final void setSystemName(String systemName)
+    public void setSystemName(String systemName)
     {
         this.systemName = systemName;
     }
@@ -303,12 +303,12 @@ public abstract class ManagerEvent extends EventObject
      * @see #getLine()
      * @since 1.0.0
      */
-    public final String getFile()
+    public String getFile()
     {
         return file;
     }
 
-    public final void setFile(String file)
+    public void setFile(String file)
     {
         this.file = file;
     }
@@ -329,12 +329,12 @@ public abstract class ManagerEvent extends EventObject
      * @see #getFunc()
      * @since 1.0.0
      */
-    public final Integer getLine()
+    public Integer getLine()
     {
         return line;
     }
 
-    public final void setLine(Integer line)
+    public void setLine(Integer line)
     {
         this.line = line;
     }
@@ -355,12 +355,12 @@ public abstract class ManagerEvent extends EventObject
      * @see #getLine()
      * @since 1.0.0
      */
-    public final String getFunc()
+    public String getFunc()
     {
         return func;
     }
 
-    public final void setFunc(String func)
+    public void setFunc(String func)
     {
         this.func = func;
     }
@@ -381,12 +381,12 @@ public abstract class ManagerEvent extends EventObject
      * @see #getLine()
      * @since 1.0.0
      */
-    public final Integer getSequenceNumber()
+    public Integer getSequenceNumber()
     {
         return sequenceNumber;
     }
 
-    public final void setSequenceNumber(Integer sequenceNumber)
+    public void setSequenceNumber(Integer sequenceNumber)
     {
         this.sequenceNumber = sequenceNumber;
     }
@@ -429,7 +429,7 @@ public abstract class ManagerEvent extends EventObject
         return sb.toString();
     }
 
-    protected final void appendPropertyIfNotNull(StringBuilder sb, String property, Object value)
+    protected void appendPropertyIfNotNull(StringBuilder sb, String property, Object value)
     {
         if (value != null)
         {

--- a/src/main/java/org/asteriskjava/manager/event/ManagerEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ManagerEvent.java
@@ -55,92 +55,92 @@ public abstract class ManagerEvent extends EventObject
      * @since 0.2
      */
 
-    public String getCallerIdName()
+    public final String getCallerIdName()
     {
         return callerIdName;
     }
 
-    public void setCallerIdName(String callerIdName)
+    public final void setCallerIdName(String callerIdName)
     {
         this.callerIdName = callerIdName;
     }
 
-    public String getConnectedLineNum()
+    public final String getConnectedLineNum()
     {
         return connectedLineNum;
     }
 
-    public void setConnectedLineNum(String connectedLineNum)
+    public final void setConnectedLineNum(String connectedLineNum)
     {
         this.connectedLineNum = connectedLineNum;
     }
 
-    public String getConnectedLineName()
+    public final String getConnectedLineName()
     {
         return connectedLineName;
     }
 
-    public void setConnectedLineName(String connectedLineName)
+    public final void setConnectedLineName(String connectedLineName)
     {
         this.connectedLineName = connectedLineName;
     }
 
-    public Integer getPriority()
+    public final Integer getPriority()
     {
         return priority;
     }
 
-    public void setPriority(Integer priority)
+    public final void setPriority(Integer priority)
     {
         this.priority = priority;
     }
 
-    public Integer getChannelState()
+    public final Integer getChannelState()
     {
         return channelState;
     }
 
-    public void setChannelState(Integer channelState)
+    public final void setChannelState(Integer channelState)
     {
         this.channelState = channelState;
     }
 
-    public String getChannelStateDesc()
+    public final String getChannelStateDesc()
     {
         return channelStateDesc;
     }
 
-    public void setChannelStateDesc(String channelStateDesc)
+    public final void setChannelStateDesc(String channelStateDesc)
     {
         this.channelStateDesc = channelStateDesc;
     }
 
-    public String getExten()
+    public final String getExten()
     {
         return exten;
     }
 
-    public void setExten(String exten)
+    public final void setExten(String exten)
     {
         this.exten = exten;
     }
 
-    public String getCallerIdNum()
+    public final String getCallerIdNum()
     {
         return callerIdNum;
     }
 
-    public void setCallerIdNum(String callerIdNum)
+    public final void setCallerIdNum(String callerIdNum)
     {
         this.callerIdNum = callerIdNum;
     }
 
-    public String getContext()
+    public final String getContext()
     {
         return context;
     }
 
-    public void setContext(String context)
+    public final void setContext(String context)
     {
         this.context = context;
     }
@@ -186,7 +186,7 @@ public abstract class ManagerEvent extends EventObject
      * (for example ConnectEvent and DisconnectEvent) may return
      * <code>null</code>.
      */
-    public Date getDateReceived()
+    public final Date getDateReceived()
     {
         return dateReceived;
     }
@@ -194,7 +194,7 @@ public abstract class ManagerEvent extends EventObject
     /**
      * Sets the point in time this event was received from the asterisk server.
      */
-    public void setDateReceived(Date dateReceived)
+    public final void setDateReceived(Date dateReceived)
     {
         this.dateReceived = dateReceived;
     }
@@ -207,7 +207,7 @@ public abstract class ManagerEvent extends EventObject
      *
      * @since 0.2
      */
-    public String getPrivilege()
+    public final String getPrivilege()
     {
         return privilege;
     }
@@ -217,7 +217,7 @@ public abstract class ManagerEvent extends EventObject
      *
      * @since 0.2
      */
-    public void setPrivilege(String privilege)
+    public final void setPrivilege(String privilege)
     {
         this.privilege = privilege;
     }
@@ -276,12 +276,12 @@ public abstract class ManagerEvent extends EventObject
         this.server = server;
     }
 
-    public String getSystemName()
+    public final String getSystemName()
     {
         return systemName;
     }
 
-    public void setSystemName(String systemName)
+    public final void setSystemName(String systemName)
     {
         this.systemName = systemName;
     }
@@ -302,12 +302,12 @@ public abstract class ManagerEvent extends EventObject
      * @see #getLine()
      * @since 1.0.0
      */
-    public String getFile()
+    public final String getFile()
     {
         return file;
     }
 
-    public void setFile(String file)
+    public final void setFile(String file)
     {
         this.file = file;
     }
@@ -328,12 +328,12 @@ public abstract class ManagerEvent extends EventObject
      * @see #getFunc()
      * @since 1.0.0
      */
-    public Integer getLine()
+    public final Integer getLine()
     {
         return line;
     }
 
-    public void setLine(Integer line)
+    public final void setLine(Integer line)
     {
         this.line = line;
     }
@@ -354,12 +354,12 @@ public abstract class ManagerEvent extends EventObject
      * @see #getLine()
      * @since 1.0.0
      */
-    public String getFunc()
+    public final String getFunc()
     {
         return func;
     }
 
-    public void setFunc(String func)
+    public final void setFunc(String func)
     {
         this.func = func;
     }
@@ -380,12 +380,12 @@ public abstract class ManagerEvent extends EventObject
      * @see #getLine()
      * @since 1.0.0
      */
-    public Integer getSequenceNumber()
+    public final Integer getSequenceNumber()
     {
         return sequenceNumber;
     }
 
-    public void setSequenceNumber(Integer sequenceNumber)
+    public final void setSequenceNumber(Integer sequenceNumber)
     {
         this.sequenceNumber = sequenceNumber;
     }
@@ -428,7 +428,7 @@ public abstract class ManagerEvent extends EventObject
         return sb.toString();
     }
 
-    protected void appendPropertyIfNotNull(StringBuilder sb, String property, Object value)
+    protected final void appendPropertyIfNotNull(StringBuilder sb, String property, Object value)
     {
         if (value != null)
         {

--- a/src/main/java/org/asteriskjava/manager/event/ManagerEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ManagerEvent.java
@@ -19,6 +19,7 @@ package org.asteriskjava.manager.event;
 import java.lang.reflect.Method;
 import java.util.*;
 
+import org.asteriskjava.util.AstState;
 import org.asteriskjava.util.ReflectionUtil;
 
 /**
@@ -95,9 +96,9 @@ public abstract class ManagerEvent extends EventObject
         this.priority = priority;
     }
 
-    public final Integer getChannelState()
+    public Integer getChannelState()
     {
-        return channelState;
+        return channelState == null ? AstState.str2state(channelStateDesc) : channelState;
     }
 
     public final void setChannelState(Integer channelState)

--- a/src/main/java/org/asteriskjava/manager/event/NewExtenEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/NewExtenEvent.java
@@ -31,11 +31,9 @@ public class NewExtenEvent extends ManagerEvent
     static final long serialVersionUID = -467486409866099387L;
 
     private String uniqueId;
-    private String context;
     private String extension;
     private String application;
     private String appData;
-    private Integer priority;
     private String channel;
     private String language;
 
@@ -123,22 +121,6 @@ public class NewExtenEvent extends ManagerEvent
     }
 
     /**
-     * Returns the name of the context of the connected extension.
-     */
-    public String getContext()
-    {
-        return context;
-    }
-
-    /**
-     * Sets the name of the context of the connected extension.
-     */
-    public void setContext(String context)
-    {
-        this.context = context;
-    }
-
-    /**
      * Returns the extension.
      */
     public String getExtension()
@@ -152,21 +134,5 @@ public class NewExtenEvent extends ManagerEvent
     public void setExtension(String extension)
     {
         this.extension = extension;
-    }
-
-    /**
-     * Returns the priority.
-     */
-    public Integer getPriority()
-    {
-        return priority;
-    }
-
-    /**
-     * Sets the priority.
-     */
-    public void setPriority(Integer priority)
-    {
-        this.priority = priority;
     }
 }

--- a/src/main/java/org/asteriskjava/manager/event/OriginateResponseEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/OriginateResponseEvent.java
@@ -33,7 +33,6 @@ public class OriginateResponseEvent extends ResponseEvent
     private String channel;
     private String uniqueId;
     private Integer reason;
-    private String callerIdNum;
 
     /**
      * @param source
@@ -113,9 +112,9 @@ public class OriginateResponseEvent extends ResponseEvent
     // for backward compatibility only
     public void setCallerId(String callerId)
     {
-        if (this.callerIdNum == null)
+        if (getCallerIdNum() == null)
         {
-            this.callerIdNum = callerId;
+            setCallerIdNum(callerId);
         }
     }
 }

--- a/src/main/java/org/asteriskjava/manager/event/OriginateResponseEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/OriginateResponseEvent.java
@@ -31,12 +31,9 @@ public class OriginateResponseEvent extends ResponseEvent
     private static final long serialVersionUID = 910724860608259687L;
     private String response;
     private String channel;
-    private String context;
-    private String exten;
     private String uniqueId;
     private Integer reason;
     private String callerIdNum;
-    private String callerIdName;
 
     /**
      * @param source
@@ -87,38 +84,6 @@ public class OriginateResponseEvent extends ResponseEvent
         this.channel = channel;
     }
 
-    /**
-     * Returns the name of the context of the extension to connect to.
-     */
-    public String getContext()
-    {
-        return context;
-    }
-
-    /**
-     * Sets the name of the context of the extension to connect to.
-     */
-    public void setContext(String context)
-    {
-        this.context = context;
-    }
-
-    /**
-     * Returns the the extension to connect to.
-     */
-    public String getExten()
-    {
-        return exten;
-    }
-
-    /**
-     * Sets the the extension to connect to.
-     */
-    public void setExten(String exten)
-    {
-        this.exten = exten;
-    }
-
     public Integer getReason()
     {
         return reason;
@@ -145,24 +110,6 @@ public class OriginateResponseEvent extends ResponseEvent
         this.uniqueId = uniqueId;
     }
 
-    /**
-     * Returns the Caller*ID Number of the originated channel.
-     * <p>
-     * Available sind Asterisk 1.4.
-     * 
-     * @return the Caller*ID Number of the originated channel or <code>null</code> if none was set.
-     * @since 0.3
-     */
-    public String getCallerIdNum()
-    {
-        return callerIdNum;
-    }
-
-    public void setCallerIdNum(String callerId)
-    {
-        this.callerIdNum = callerId;
-    }
-
     // for backward compatibility only
     public void setCallerId(String callerId)
     {
@@ -170,22 +117,5 @@ public class OriginateResponseEvent extends ResponseEvent
         {
             this.callerIdNum = callerId;
         }
-    }
-
-    /**
-     * Returns the Caller*ID Name of the originated channel.
-     * <p>
-     * Available sind Asterisk 1.4.
-     * 
-     * @return the Caller*ID Name of the originated channel or <code>null</code> if none was set.
-     */
-    public String getCallerIdName()
-    {
-        return callerIdName;
-    }
-
-    public void setCallerIdName(String callerIdName)
-    {
-        this.callerIdName = callerIdName;
     }
 }

--- a/src/main/java/org/asteriskjava/manager/event/ReceiveFaxEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ReceiveFaxEvent.java
@@ -7,8 +7,6 @@ public class ReceiveFaxEvent extends ManagerEvent
 {
     private static final long serialVersionUID = 0L;
     private String channel;
-    private String context;
-    private String exten;
     private String callerId;
     private String remoteStationId;
     private String localStationId;
@@ -30,26 +28,6 @@ public class ReceiveFaxEvent extends ManagerEvent
     public void setChannel(String channel)
     {
         this.channel = channel;
-    }
-
-    public String getContext()
-    {
-        return context;
-    }
-
-    public void setContext(String context)
-    {
-        this.context = context;
-    }
-
-    public String getExten()
-    {
-        return exten;
-    }
-
-    public void setExten(String exten)
-    {
-        this.exten = exten;
     }
 
     public String getCallerId()

--- a/src/main/java/org/asteriskjava/manager/event/SendFaxEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/SendFaxEvent.java
@@ -25,8 +25,6 @@ public class SendFaxEvent extends AbstractFaxEvent
      * Serial version identifier.
      */
     private static final long serialVersionUID = -1L;
-    private String context;
-    private String exten;
     private String callerId;
     private String localStationId;
     private String remoteStationId;
@@ -39,42 +37,6 @@ public class SendFaxEvent extends AbstractFaxEvent
     public SendFaxEvent(Object source)
     {
         super(source);
-    }
-
-
-    /**
-     * @return the context
-     */
-    public String getContext()
-    {
-        return context;
-    }
-
-
-    /**
-     * @param context the context to set
-     */
-    public void setContext(String context)
-    {
-        this.context = context;
-    }
-
-
-    /**
-     * @return the exten
-     */
-    public String getExten()
-    {
-        return exten;
-    }
-
-
-    /**
-     * @param exten the exten to set
-     */
-    public void setExten(String exten)
-    {
-        this.exten = exten;
     }
 
 

--- a/src/main/java/org/asteriskjava/manager/event/SendFaxStatusEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/SendFaxStatusEvent.java
@@ -25,8 +25,6 @@ public class SendFaxStatusEvent extends AbstractFaxEvent
      * Serial version identifier.
      */
     private static final long serialVersionUID = -1L;
-    private String context;
-    private String exten;
     private String status;
     private String callerId;
     private String localStationId;
@@ -36,42 +34,6 @@ public class SendFaxStatusEvent extends AbstractFaxEvent
     public SendFaxStatusEvent(Object source)
     {
         super(source);
-    }
-
-
-    /**
-     * @return the context
-     */
-    public String getContext()
-    {
-        return context;
-    }
-
-
-    /**
-     * @param context the context to set
-     */
-    public void setContext(String context)
-    {
-        this.context = context;
-    }
-
-
-    /**
-     * @return the exten
-     */
-    public String getExten()
-    {
-        return exten;
-    }
-
-
-    /**
-     * @param exten the exten to set
-     */
-    public void setExten(String exten)
-    {
-        this.exten = exten;
     }
 
 

--- a/src/main/java/org/asteriskjava/manager/event/SkypeLicenseEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/SkypeLicenseEvent.java
@@ -31,7 +31,6 @@ public class SkypeLicenseEvent extends ResponseEvent
      * Serial version identifier.
      */
     private static final long serialVersionUID = 1L;
-    private String file;
     private String key;
     private String expires;
     private String hostId;
@@ -41,26 +40,6 @@ public class SkypeLicenseEvent extends ResponseEvent
     public SkypeLicenseEvent(Object source)
     {
         super(source);
-    }
-
-    /**
-     * Returns the name of the file this license is stored in.
-     *
-     * @return the name of the file this license is stored in.
-     */
-    public String getFile()
-    {
-        return file;
-    }
-
-    /**
-     * Sets the name of the file this license is stored in.
-     *
-     * @param file the name of the file this license is stored in.
-     */
-    public void setFile(String file)
-    {
-        this.file = file;
     }
 
     /**

--- a/src/main/java/org/asteriskjava/manager/event/StatusEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/StatusEvent.java
@@ -16,8 +16,6 @@
  */
 package org.asteriskjava.manager.event;
 
-import org.asteriskjava.util.AstState;
-
 import java.util.Map;
 
 /**
@@ -36,7 +34,6 @@ public class StatusEvent extends ResponseEvent
     private static final long serialVersionUID = -3619197512835308812L;
     private String channel;
     private String accountCode;
-    private Integer channelState;
     private Integer seconds;
     private String bridgedChannel;
     private String bridgedUniqueId;
@@ -97,50 +94,6 @@ public class StatusEvent extends ResponseEvent
     }
 
     /**
-     * Returns the Caller*ID Number of this channel.
-     *
-     * @return the Caller*ID Number of this channel or <code>null</code> if none
-     *         is available.
-     * @since 0.3
-     */
-    public String getCallerIdNum()
-    {
-        return callerIdNum;
-    }
-
-    /**
-     * Sets the Caller*ID Number of this channel.
-     *
-     * @param callerIdNum the Caller*ID Number to set.
-     * @since 0.3
-     */
-    public void setCallerIdNum(String callerIdNum)
-    {
-        this.callerIdNum = callerIdNum;
-    }
-
-    /**
-     * Returns the Caller*ID Name of this channel.
-     *
-     * @return the Caller*ID Name of this channel or <code>null</code> if none
-     *         is available.
-     */
-    public String getCallerIdName()
-    {
-        return callerIdName;
-    }
-
-    /**
-     * Sets the Caller*ID Name of this channel.
-     *
-     * @param callerIdName the Caller*ID Name of this channel.
-     */
-    public void setCallerIdName(String callerIdName)
-    {
-        this.callerIdName = callerIdName;
-    }
-
-    /**
      * Returns the account code of this channel.
      *
      * @return the account code of this channel.
@@ -185,47 +138,6 @@ public class StatusEvent extends ResponseEvent
     public void setAccount(String account)
     {
         this.accountCode = account;
-    }
-
-    /**
-     * Returns the state of the channel.
-     * <p>
-     * For Asterisk versions prior to 1.6 (that do not send the numeric value)
-     * it is derived from the descriptive text.
-     *
-     * @return the state of the channel.
-     * @since 1.0.0
-     */
-    public Integer getChannelState()
-    {
-        return channelState == null ? AstState.str2state(channelStateDesc) : channelState;
-    }
-
-    /**
-     * Sets the state of the channel.
-     *
-     * @param channelState the state of the channel.
-     * @since 1.0.0
-     */
-    public void setChannelState(Integer channelState)
-    {
-        this.channelState = channelState;
-    }
-
-    /**
-     * Returns the state of the channel as a descriptive text.
-     *
-     * @return the state of the channel as a descriptive text.
-     * @since 1.0.0
-     */
-    public String getChannelStateDesc()
-    {
-        return channelStateDesc;
-    }
-
-    public void setChannelStateDesc(String channelStateDesc)
-    {
-        this.channelStateDesc = channelStateDesc;
     }
 
     /**

--- a/src/main/java/org/asteriskjava/manager/event/ZapShowChannelsEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ZapShowChannelsEvent.java
@@ -104,22 +104,6 @@ public class ZapShowChannelsEvent extends ResponseEvent
     }
 
     /**
-     * Returns the context of this zap channel as defined in <code>zapata.conf</code>.
-     */
-    public String getContext()
-    {
-        return context;
-    }
-
-    /**
-     * Sets the context of this zap channel.
-     */
-    public void setContext(String context)
-    {
-        this.context = context;
-    }
-
-    /**
      * Returns whether dnd (do not disturb) is enabled for this zap channel.
      * 
      * @return Boolean.TRUE if dnd is enabled, Boolean.FALSE if it is disabled,


### PR DESCRIPTION
There probably still are redundant fields left in the ManagerEvent class hierarchy but I started cleaning up a bit by removing useless overrides in subclasses.