### PR TITLE
Removed dependency to commons-lang3.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,12 +227,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.1</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.9</version>

--- a/src/main/java/org/asteriskjava/live/internal/AsteriskQueueImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskQueueImpl.java
@@ -24,11 +24,11 @@ import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.asteriskjava.live.AsteriskQueue;
 import org.asteriskjava.live.AsteriskQueueEntry;
 import org.asteriskjava.live.AsteriskQueueListener;
 import org.asteriskjava.live.AsteriskQueueMember;
+import org.asteriskjava.util.AstUtil;
 import org.asteriskjava.util.Log;
 import org.asteriskjava.util.LogFactory;
 
@@ -136,7 +136,7 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
      */
     boolean setMax(Integer max)
     {
-    	if(!ObjectUtils.equals(this.max, max)){
+    	if(!AstUtil.equals(this.max, max)){
     		this.max = max;
 			stampLastUpdate();
 			return true;
@@ -156,7 +156,7 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
      */
     boolean setServiceLevel(Integer serviceLevel)
     {
-    	if(!ObjectUtils.equals(this.serviceLevel, serviceLevel)){
+    	if(!AstUtil.equals(this.serviceLevel, serviceLevel)){
     		this.serviceLevel = serviceLevel;
 			stampLastUpdate();
 			return true;
@@ -176,7 +176,7 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
      * @return  true if value updated, false otherwise
      */
     boolean setCalls(Integer calls) {
-    	if(!ObjectUtils.equals(this.calls, calls)){
+    	if(!AstUtil.equals(this.calls, calls)){
     		this.calls = calls;
 			stampLastUpdate();
 			return true;
@@ -200,7 +200,7 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
      * @return true if value updated, false otherwise
      */
     boolean setHoldTime(Integer holdTime) {
-    	if(!ObjectUtils.equals(this.holdTime, holdTime)){
+    	if(!AstUtil.equals(this.holdTime, holdTime)){
     		this.holdTime = holdTime;
 			stampLastUpdate();
 			return true;
@@ -219,7 +219,7 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
      * @return true if value updated, false otherwise
      */
     boolean setTalkTime(Integer talkTime) {
-    	if(!ObjectUtils.equals(this.talkTime, talkTime)){
+    	if(!AstUtil.equals(this.talkTime, talkTime)){
     		this.talkTime = talkTime;
 			stampLastUpdate();
 			return true;
@@ -238,7 +238,7 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
      * @return  true if value updated, false otherwise
      */
     boolean setCompleted(Integer completed) {
-    	if(!ObjectUtils.equals(this.completed, completed)){
+    	if(!AstUtil.equals(this.completed, completed)){
     		this.completed = completed;
 			stampLastUpdate();
 			return true;
@@ -257,7 +257,7 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
      * @return true if value updated, false otherwise
      */
 	boolean setAbandoned(Integer abandoned) {
-		if(!ObjectUtils.equals(this.abandoned, abandoned)){
+		if(!AstUtil.equals(this.abandoned, abandoned)){
 			this.abandoned = abandoned;
 			stampLastUpdate();
 			return true;
@@ -277,7 +277,7 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
 	 * @return true if value updated, false otherwise
 	 */
 	boolean setServiceLevelPerf(Double serviceLevelPerf) {
-		if(!ObjectUtils.equals(this.serviceLevelPerf, serviceLevelPerf)){
+		if(!AstUtil.equals(this.serviceLevelPerf, serviceLevelPerf)){
 			this.serviceLevelPerf = serviceLevelPerf;
 			stampLastUpdate();
 			return true;
@@ -297,7 +297,7 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
      */
     boolean setWeight(Integer weight)
     {
-    	if(!ObjectUtils.equals(this.weight, weight)){
+    	if(!AstUtil.equals(this.weight, weight)){
     		this.weight = weight;
 			stampLastUpdate();
 			return true;

--- a/src/main/java/org/asteriskjava/live/internal/AsteriskQueueMemberImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskQueueMemberImpl.java
@@ -16,7 +16,6 @@
  */
 package org.asteriskjava.live.internal;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.asteriskjava.live.AsteriskQueue;
 import org.asteriskjava.live.AsteriskQueueMember;
 import org.asteriskjava.live.InvalidPenaltyException;
@@ -27,6 +26,7 @@ import org.asteriskjava.manager.action.QueuePauseAction;
 import org.asteriskjava.manager.action.QueuePenaltyAction;
 import org.asteriskjava.manager.response.ManagerError;
 import org.asteriskjava.manager.response.ManagerResponse;
+import org.asteriskjava.util.AstUtil;
 
 /**
  * Default implementation of a queue member.
@@ -214,7 +214,7 @@ class AsteriskQueueMemberImpl extends AbstractLiveObject implements AsteriskQueu
 
     synchronized boolean stateChanged(QueueMemberState state)
     {
-        if(!ObjectUtils.equals(this.state, state)){
+        if(!AstUtil.equals(this.state, state)){
     		QueueMemberState oldState = this.state;
         	this.state = state;
         	firePropertyChange(PROPERTY_STATE, oldState, state);
@@ -225,7 +225,7 @@ class AsteriskQueueMemberImpl extends AbstractLiveObject implements AsteriskQueu
 
     synchronized boolean penaltyChanged(Integer penalty)
     {
-        if(!ObjectUtils.equals(this.penalty, penalty)){
+        if(!AstUtil.equals(this.penalty, penalty)){
         	Integer oldPenalty = this.penalty;
         	this.penalty = penalty;
         	firePropertyChange(PROPERTY_PENALTY, oldPenalty, penalty);
@@ -237,7 +237,7 @@ class AsteriskQueueMemberImpl extends AbstractLiveObject implements AsteriskQueu
 
     synchronized boolean pausedChanged(boolean paused)
     {
-    	if(!ObjectUtils.equals(this.paused, paused)){
+    	if(!AstUtil.equals(this.paused, paused)){
     		boolean oldPaused = this.paused;
     		this.paused = paused;
     		firePropertyChange(PROPERTY_PAUSED, oldPaused, paused);
@@ -247,7 +247,7 @@ class AsteriskQueueMemberImpl extends AbstractLiveObject implements AsteriskQueu
     }
 
     synchronized boolean callsTakenChanged(Integer callsTaken){
-    	if(!ObjectUtils.equals(this.callsTaken, callsTaken)){
+    	if(!AstUtil.equals(this.callsTaken, callsTaken)){
         	Integer oldcallsTaken = this.callsTaken;
         	this.callsTaken = callsTaken;
         	firePropertyChange(PROPERTY_CALLSTAKEN, oldcallsTaken, callsTaken);
@@ -257,7 +257,7 @@ class AsteriskQueueMemberImpl extends AbstractLiveObject implements AsteriskQueu
     }
 
     synchronized boolean lastCallChanged(Long lastCall){
-    	if(!ObjectUtils.equals(this.lastCall, lastCall)){
+    	if(!AstUtil.equals(this.lastCall, lastCall)){
         	Long oldlastCall = this.lastCall;
         	this.lastCall = lastCall;
         	firePropertyChange(PROPERTY_LASTCALL, oldlastCall, lastCall);

--- a/src/main/java/org/asteriskjava/util/AstUtil.java
+++ b/src/main/java/org/asteriskjava/util/AstUtil.java
@@ -105,6 +105,17 @@ public class AstUtil
     }
 
     /**
+     * @param a an object
+     * @param b an object to be compared with {@code a} for equality
+     * @return {@code true} if the arguments are equal to each other
+     * and {@code false} otherwise
+     */
+    public static boolean equals(Object a, Object b)
+    {
+        return a == b || a != null && a.equals(b);
+    }
+
+    /**
      * Parses a string for caller id information.
      * <br>
      * The caller id string should be in the form <code>"Some Name" &lt;1234&gt;</code>.


### PR DESCRIPTION
asterisk-java doesn't need the dependency to commons-lang3. The only method used from that library was ObjectUtils.equals(..) and that can be easily provided.
Since asterisk-java is a library for other projects it makes sense to have as little external dependencies as possible.