### PR TITLE
Update EventBuilderImpl.java

### DIFF
--- a/src/main/java/org/asteriskjava/manager/internal/EventBuilderImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/EventBuilderImpl.java
@@ -165,6 +165,8 @@ class EventBuilderImpl extends AbstractBuilder implements EventBuilder
         registerEventClass(PickupEvent.class);
         registerEventClass(PriEventEvent.class);
         registerEventClass(QueueCallerAbandonEvent.class);
+        registerEventClass(QueueCallerJoinEvent.class);
+        registerEventClass(QueueCallerLeaveEvent.class);
         registerEventClass(QueueEntryEvent.class);
         registerEventClass(QueueMemberAddedEvent.class);
         registerEventClass(QueueMemberEvent.class);


### PR DESCRIPTION
Good afternoon,
I noticed that there is not in the package the classes for QueueCallerJoin and QueueCallerLeave events then based on class QueueCallerAbandonEvent created their classes these events and added to my project and it worked, and it was necessary to change this file also to generate the objects of events.

I will add the classes in maneger.events package.
If interesting to add here that this change.

Thank you