### PR TITLE
AsyncAgiEvent does not use UTF-8 encoding

### DIFF
--- a/src/main/java/org/asteriskjava/manager/event/AsyncAgiEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AsyncAgiEvent.java
@@ -203,13 +203,12 @@ public class AsyncAgiEvent extends ResponseEvent
 
         try
         {
-            final String decodedString = URLDecoder.decode(s, "ISO-8859-1");
+            final String decodedString = URLDecoder.decode(s, "UTF-8");
             result.addAll(Arrays.asList(decodedString.split("\n")));
         }
         catch (UnsupportedEncodingException e)
         {
-            // won't happen as JDK ships with ISO-8859-1
-            throw new RuntimeException("This JDK does not support ISO-8859-1 encoding", e);
+            throw new RuntimeException("This JDK does not support UTF-8 encoding", e);
         }
 
         return result;


### PR DESCRIPTION
In line 206 of AsyncAgiEvent, it uses ISO-8859-1 encoding scheme but according to [ Oracle Java 7 API specification](http://docs.oracle.com/javase/7/docs/api/java/net/URLDecoder.html#decode%28java.lang.String,%20java.lang.String%29), the World Wide Web Consortium Recommendation states that UTF-8 should be used. Not doing so may introduce incompatibilities. 
This pull request adds a fix by using UTF-8 encoding.