### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/org/asteriskjava/manager/ManagerEventListenerProxy.java
+++ b/src/main/java/org/asteriskjava/manager/ManagerEventListenerProxy.java
@@ -67,6 +67,10 @@ public class ManagerEventListenerProxy implements ManagerEventListener {
     }
 
 		public static class Access {
+		    private Access() {
+		        
+		    }
+		    
 			public static int getThreadQueueSize (ManagerEventListenerProxy proxy) {
 				return proxy.executor.getQueue().size();
 			}

--- a/src/main/java/org/asteriskjava/manager/internal/ManagerUtil.java
+++ b/src/main/java/org/asteriskjava/manager/internal/ManagerUtil.java
@@ -37,6 +37,10 @@ public class ManagerUtil
      * The hex digits used to build a hex string representation of a byte array.
      */
     private static final char[] hexChar = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+    
+    private ManagerUtil() {
+        
+    }
 
     /**
      * Converts a byte array to a hex string representing it. The hex digits are

--- a/src/main/java/org/asteriskjava/util/Base64.java
+++ b/src/main/java/org/asteriskjava/util/Base64.java
@@ -15,6 +15,11 @@ package org.asteriskjava.util;
  * @author  Josh Bloch
  */
 public class Base64 {
+    
+    private Base64() {
+        
+    }
+    
     /**
      * Translates the specified byte array into a Base64 string as per
      * Preferences.put(byte[]).

--- a/src/main/java/org/asteriskjava/util/LogFactory.java
+++ b/src/main/java/org/asteriskjava/util/LogFactory.java
@@ -60,6 +60,10 @@ public final class LogFactory
     private static Boolean javaLoggingAvailable = null;
 
     private static ClassLoader classLoader = LogFactory.class.getClassLoader();
+    
+    private LogFactory() {
+        
+    }
 
     public static void setClassLoader(ClassLoader classLoader)
     {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed