### PR TITLE
Code quality fix - Collection.isEmpty() should be used to test for emptiness.

### DIFF
--- a/src/main/java/org/asteriskjava/fastagi/AbstractMappingStrategy.java
+++ b/src/main/java/org/asteriskjava/fastagi/AbstractMappingStrategy.java
@@ -90,7 +90,7 @@ public abstract class AbstractMappingStrategy implements MappingStrategy
                 }
             }
 
-            if (dirUrls.size() == 0)
+            if (dirUrls.isEmpty())
             {
                 return parentClassLoader;
             }

--- a/src/main/java/org/asteriskjava/fastagi/ScriptEngineMappingStrategy.java
+++ b/src/main/java/org/asteriskjava/fastagi/ScriptEngineMappingStrategy.java
@@ -226,7 +226,7 @@ public class ScriptEngineMappingStrategy implements MappingStrategy
             }
         }
 
-        if (jarFileUrls.size() == 0)
+        if (jarFileUrls.isEmpty())
         {
             return parentClassLoader;
         }

--- a/src/main/java/org/asteriskjava/live/internal/AsteriskServerImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskServerImpl.java
@@ -579,7 +579,7 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
                 final List<String> result;
 
                 result = ((CommandResponse) response).getResult();
-                if (result.size() > 0)
+                if (!result.isEmpty())
                 {
                     version = result.get(0);
                 }
@@ -739,7 +739,7 @@ public class AsteriskServerImpl implements AsteriskServer, ManagerEventListener
         }
 
         result = ((CommandResponse) response).getResult();
-        if (result == null || result.size() < 1)
+        if (result == null || result.isEmpty())
         {
             return voicemailboxes;
         }

--- a/src/main/java/org/asteriskjava/manager/internal/EventBuilderImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/EventBuilderImpl.java
@@ -304,7 +304,7 @@ class EventBuilderImpl extends AbstractBuilder implements EventBuilder
         if (attributes.get("event") instanceof List)
         {
             List< ? > eventNames = (List< ? >) attributes.get("event");
-            if (eventNames.size() > 0 && "PeerEntry".equals(eventNames.get(0)))
+            if (!eventNames.isEmpty() && "PeerEntry".equals(eventNames.get(0)))
             {
                 // List of PeerEntry events was received (AJ-329)
                 // Convert map of lists to list of maps - one map for each

--- a/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
@@ -657,7 +657,7 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
             }
 
             showVersionFilesResult = ((CommandResponse) showVersionFilesResponse).getResult();
-            if (showVersionFilesResult != null && showVersionFilesResult.size() > 0)
+            if (showVersionFilesResult != null && !showVersionFilesResult.isEmpty())
             {
                 final String line1 = showVersionFilesResult.get(0);
 
@@ -682,7 +682,7 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
                     {
                         final List<String> coreShowVersionResult = ((CommandResponse) coreShowVersionResponse).getResult();
 
-                        if (coreShowVersionResult != null && coreShowVersionResult.size() > 0)
+                        if (coreShowVersionResult != null && !coreShowVersionResult.isEmpty())
                         {
                             final String coreLine = coreShowVersionResult.get(0);
 
@@ -753,7 +753,7 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
             final List<String> showVersionResult;
 
             showVersionResult = ((CommandResponse) showVersionResponse).getResult();
-            if (showVersionResult != null && showVersionResult.size() > 0)
+            if (showVersionResult != null && !showVersionResult.isEmpty())
             {
                 return showVersionResult.get(0);
             }

--- a/src/main/java/org/asteriskjava/manager/internal/ManagerReaderImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/ManagerReaderImpl.java
@@ -273,7 +273,7 @@ public class ManagerReaderImpl implements ManagerReader
                     }
                     else
                     {
-                        if (buffer.size() > 0)
+                        if (!buffer.isEmpty())
                         {
                             logger.debug("Buffer contains neither response nor event");
                         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1155 - Collection.isEmpty() should be used to test for emptiness. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.

Faisal Hameed