### PR TITLE
Code quality fix - Methods named "equals" should override Object.equals(Object).

### DIFF
--- a/src/main/java/org/asteriskjava/live/internal/AsteriskQueueImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskQueueImpl.java
@@ -136,7 +136,7 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
      */
     boolean setMax(Integer max)
     {
-    	if(!AstUtil.equals(this.max, max)){
+    	if(!AstUtil.isEqual(this.max, max)){
     		this.max = max;
 			stampLastUpdate();
 			return true;
@@ -156,7 +156,7 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
      */
     boolean setServiceLevel(Integer serviceLevel)
     {
-    	if(!AstUtil.equals(this.serviceLevel, serviceLevel)){
+    	if(!AstUtil.isEqual(this.serviceLevel, serviceLevel)){
     		this.serviceLevel = serviceLevel;
 			stampLastUpdate();
 			return true;
@@ -176,7 +176,7 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
      * @return  true if value updated, false otherwise
      */
     boolean setCalls(Integer calls) {
-    	if(!AstUtil.equals(this.calls, calls)){
+    	if(!AstUtil.isEqual(this.calls, calls)){
     		this.calls = calls;
 			stampLastUpdate();
 			return true;
@@ -200,7 +200,7 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
      * @return true if value updated, false otherwise
      */
     boolean setHoldTime(Integer holdTime) {
-    	if(!AstUtil.equals(this.holdTime, holdTime)){
+    	if(!AstUtil.isEqual(this.holdTime, holdTime)){
     		this.holdTime = holdTime;
 			stampLastUpdate();
 			return true;
@@ -219,7 +219,7 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
      * @return true if value updated, false otherwise
      */
     boolean setTalkTime(Integer talkTime) {
-    	if(!AstUtil.equals(this.talkTime, talkTime)){
+    	if(!AstUtil.isEqual(this.talkTime, talkTime)){
     		this.talkTime = talkTime;
 			stampLastUpdate();
 			return true;
@@ -238,7 +238,7 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
      * @return  true if value updated, false otherwise
      */
     boolean setCompleted(Integer completed) {
-    	if(!AstUtil.equals(this.completed, completed)){
+    	if(!AstUtil.isEqual(this.completed, completed)){
     		this.completed = completed;
 			stampLastUpdate();
 			return true;
@@ -257,7 +257,7 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
      * @return true if value updated, false otherwise
      */
 	boolean setAbandoned(Integer abandoned) {
-		if(!AstUtil.equals(this.abandoned, abandoned)){
+		if(!AstUtil.isEqual(this.abandoned, abandoned)){
 			this.abandoned = abandoned;
 			stampLastUpdate();
 			return true;
@@ -277,7 +277,7 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
 	 * @return true if value updated, false otherwise
 	 */
 	boolean setServiceLevelPerf(Double serviceLevelPerf) {
-		if(!AstUtil.equals(this.serviceLevelPerf, serviceLevelPerf)){
+		if(!AstUtil.isEqual(this.serviceLevelPerf, serviceLevelPerf)){
 			this.serviceLevelPerf = serviceLevelPerf;
 			stampLastUpdate();
 			return true;
@@ -297,7 +297,7 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
      */
     boolean setWeight(Integer weight)
     {
-    	if(!AstUtil.equals(this.weight, weight)){
+    	if(!AstUtil.isEqual(this.weight, weight)){
     		this.weight = weight;
 			stampLastUpdate();
 			return true;

--- a/src/main/java/org/asteriskjava/live/internal/AsteriskQueueMemberImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskQueueMemberImpl.java
@@ -214,7 +214,7 @@ class AsteriskQueueMemberImpl extends AbstractLiveObject implements AsteriskQueu
 
     synchronized boolean stateChanged(QueueMemberState state)
     {
-        if (!AstUtil.equals(this.state, state))
+        if (!AstUtil.isEqual(this.state, state))
         {
             QueueMemberState oldState = this.state;
             this.state = state;
@@ -226,7 +226,7 @@ class AsteriskQueueMemberImpl extends AbstractLiveObject implements AsteriskQueu
 
     synchronized boolean penaltyChanged(Integer penalty)
     {
-        if (!AstUtil.equals(this.penalty, penalty))
+        if (!AstUtil.isEqual(this.penalty, penalty))
         {
             Integer oldPenalty = this.penalty;
             this.penalty = penalty;
@@ -239,7 +239,7 @@ class AsteriskQueueMemberImpl extends AbstractLiveObject implements AsteriskQueu
 
     synchronized boolean pausedChanged(boolean paused)
     {
-        if (!AstUtil.equals(this.paused, paused))
+        if (!AstUtil.isEqual(this.paused, paused))
         {
             boolean oldPaused = this.paused;
             this.paused = paused;
@@ -251,7 +251,7 @@ class AsteriskQueueMemberImpl extends AbstractLiveObject implements AsteriskQueu
 
     synchronized boolean callsTakenChanged(Integer callsTaken)
     {
-        if (!AstUtil.equals(this.callsTaken, callsTaken))
+        if (!AstUtil.isEqual(this.callsTaken, callsTaken))
         {
             Integer oldcallsTaken = this.callsTaken;
             this.callsTaken = callsTaken;
@@ -263,7 +263,7 @@ class AsteriskQueueMemberImpl extends AbstractLiveObject implements AsteriskQueu
 
     synchronized boolean lastCallChanged(Long lastCall)
     {
-        if (!AstUtil.equals(this.lastCall, lastCall))
+        if (!AstUtil.isEqual(this.lastCall, lastCall))
         {
             Long oldlastCall = this.lastCall;
             this.lastCall = lastCall;

--- a/src/main/java/org/asteriskjava/util/AstUtil.java
+++ b/src/main/java/org/asteriskjava/util/AstUtil.java
@@ -110,7 +110,7 @@ public class AstUtil
      * @return {@code true} if the arguments are equal to each other and
      *         {@code false} otherwise
      */
-    public static boolean equals(Object a, Object b)
+    public static boolean isEqual(Object a, Object b)
     {
         return a == b || a != null && a.equals(b);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1201 - Methods named "equals" should override Object.equals(Object).
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1201

Please let me know if you have any questions.

Faisal Hameed