### PR TITLE
General code quality fix-2

### DIFF
--- a/src/main/java/org/asteriskjava/config/ConfigParseException.java
+++ b/src/main/java/org/asteriskjava/config/ConfigParseException.java
@@ -6,8 +6,8 @@ package org.asteriskjava.config;
 public class ConfigParseException extends Exception
 {
     private static final long serialVersionUID = 4346366210261425734L;
-    private String filename;
-    private int lineno;
+    private final String filename;
+    private final int lineno;
 
     public ConfigParseException(String filename, int lineno, String message)
     {

--- a/src/main/java/org/asteriskjava/util/LogFactory.java
+++ b/src/main/java/org/asteriskjava/util/LogFactory.java
@@ -72,7 +72,7 @@ public final class LogFactory
      * @param clazz the class to create the logger for.
      * @return the created logger.
      */
-    public static Log getLog(Class< ? > clazz)
+    public synchronized static Log getLog(Class< ? > clazz)
     {
         if (slf4jLoggingAvailable == null)
         {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2444 - Lazy initialization of "static" fields should be "synchronized". 
squid:S1165 - Exception classes should be immutable. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2444
https://dev.eclipse.org/sonar/rules/show/squid:S1165

Please let me know if you have any questions.

Faisal Hameed