### PR TITLE
Code quality fix - Declarations should use Java collection interfaces such as "List" rather than specific implementation.

### DIFF
--- a/src/main/java/org/asteriskjava/live/internal/AsteriskQueueImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskQueueImpl.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -77,11 +78,11 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
     /****/
 
     private Integer weight;
-    private final ArrayList<AsteriskQueueEntryImpl> entries;
+    private final List<AsteriskQueueEntryImpl> entries;
     private final Timer timer;
-    private final HashMap<String, AsteriskQueueMemberImpl> members;
+    private final Map<String, AsteriskQueueMemberImpl> members;
     private final List<AsteriskQueueListener> listeners;
-    private final HashMap<AsteriskQueueEntry, ServiceLevelTimerTask> serviceLevelTimerTasks;
+    private final Map<AsteriskQueueEntry, ServiceLevelTimerTask> serviceLevelTimerTasks;
 
     AsteriskQueueImpl(AsteriskServerImpl server, String name, Integer max,
                       String strategy, Integer serviceLevel, Integer weight,
@@ -575,7 +576,7 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
      */
     public Collection<AsteriskQueueMember> getMembers()
     {
-        ArrayList<AsteriskQueueMember> listOfMembers = new ArrayList<AsteriskQueueMember>(members.size());
+        List<AsteriskQueueMember> listOfMembers = new ArrayList<AsteriskQueueMember>(members.size());
         synchronized (members)
         {
             for (AsteriskQueueMemberImpl asteriskQueueMember : members.values())

--- a/src/main/java/org/asteriskjava/live/internal/ChannelManager.java
+++ b/src/main/java/org/asteriskjava/live/internal/ChannelManager.java
@@ -83,7 +83,7 @@ class ChannelManager
     /**
      * A map of all active channel by their unique id.
      */
-    final LinkedHashMap<String, AsteriskChannelImpl> channels = new LinkedHashMap<String, AsteriskChannelImpl>();
+    final Map<String, AsteriskChannelImpl> channels = new LinkedHashMap<String, AsteriskChannelImpl>();
 
     ScheduledThreadPoolExecutor traceScheduledExecutorService;
 

--- a/src/main/java/org/asteriskjava/live/internal/QueueManager.java
+++ b/src/main/java/org/asteriskjava/live/internal/QueueManager.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.asteriskjava.live.AsteriskQueue;
@@ -64,7 +65,7 @@ class QueueManager
      * A map of ACD queues by there name. 101119 OLB: Modified to act as a LRU
      * Cache to optimize updates
      */
-    private final LinkedHashMap<String, AsteriskQueueImpl> queuesLRU = new LinkedHashMap<String, AsteriskQueueImpl>();
+    private final Map<String, AsteriskQueueImpl> queuesLRU = new LinkedHashMap<String, AsteriskQueueImpl>();
 
     QueueManager(AsteriskServerImpl server, ChannelManager channelManager)
     {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319

Please let me know if you have any questions.

Faisal Hameed