### PR TITLE
Code quality fix - Parsing should be used to convert "Strings" to primitives.

### DIFF
--- a/src/main/java/org/asteriskjava/fastagi/SpeechRecognitionResult.java
+++ b/src/main/java/org/asteriskjava/fastagi/SpeechRecognitionResult.java
@@ -81,7 +81,7 @@ public class SpeechRecognitionResult implements Serializable
      */
     public int getEndpos()
     {
-        return Integer.valueOf(agiReply.getAttribute("endpos"));
+        return Integer.parseInt(agiReply.getAttribute("endpos"));
     }
 
     /**
@@ -93,7 +93,7 @@ public class SpeechRecognitionResult implements Serializable
     public int getScore()
     {
         final String score0 = agiReply.getAttribute("score0");
-        return score0 == null ? 0 : Integer.valueOf(score0);
+        return score0 == null ? 0 : Integer.parseInt(score0);
     }
 
     /**
@@ -125,7 +125,7 @@ public class SpeechRecognitionResult implements Serializable
     public int getNumberOfResults()
     {
         final String numberOfResults = agiReply.getAttribute("results");
-        return numberOfResults == null ? 0 : Integer.valueOf(numberOfResults);
+        return numberOfResults == null ? 0 : Integer.parseInt(numberOfResults);
     }
 
     public List<SpeechResult> getAllResults()
@@ -136,7 +136,7 @@ public class SpeechRecognitionResult implements Serializable
         for (int i = 0; i < numberOfResults; i++)
         {
             SpeechResult result = new SpeechResult(
-                    Integer.valueOf(agiReply.getAttribute("score" + i)),
+                    Integer.parseInt(agiReply.getAttribute("score" + i)),
                     agiReply.getAttribute("text" + i),
                     agiReply.getAttribute("grammar" + i)
             );

--- a/src/main/java/org/asteriskjava/fastagi/internal/AgiRequestImpl.java
+++ b/src/main/java/org/asteriskjava/fastagi/internal/AgiRequestImpl.java
@@ -567,7 +567,7 @@ public class AgiRequestImpl implements AgiRequest
                 continue;
             }
 
-            int index = Integer.valueOf(entry.getKey().substring(4));
+            int index = Integer.parseInt(entry.getKey().substring(4));
             if (index > maxIndex)
             {
                 maxIndex = index;

--- a/src/main/java/org/asteriskjava/manager/internal/EventBuilderImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/EventBuilderImpl.java
@@ -310,7 +310,7 @@ class EventBuilderImpl extends AbstractBuilder implements EventBuilder
                 // Convert map of lists to list of maps - one map for each
                 // PeerEntry event
                 int peersAmount = attributes.get("listitems") != null
-                        ? Integer.valueOf((String) attributes.get("listitems"))
+                        ? Integer.parseInt((String) attributes.get("listitems"))
                         : eventNames.size() - 1; // Last event is
                                                  // PeerlistComplete
                 List<Map<String, Object>> peersAttributes = new ArrayList<Map<String, Object>>();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2130 - Parsing should be used to convert "Strings" to primitives.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2130

Please let me know if you have any questions.

Faisal Hameed