### PR TITLE
Code quality fix - "entrySet()" should be iterated when both the key and value are needed.

### DIFF
--- a/src/main/java/org/asteriskjava/live/internal/ChannelManager.java
+++ b/src/main/java/org/asteriskjava/live/internal/ChannelManager.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -288,9 +289,9 @@ class ChannelManager
             isNew = true;
             if (variables != null)
             {
-                for (String variable : variables.keySet())
+                for (Entry<String, String> variable : variables.entrySet())
                 {
-                    channel.updateVariable(variable, variables.get(variable));
+                    channel.updateVariable(variable.getKey(), variable.getValue());
                 }
             }
         }

--- a/src/main/java/org/asteriskjava/manager/response/GetConfigResponse.java
+++ b/src/main/java/org/asteriskjava/manager/response/GetConfigResponse.java
@@ -20,6 +20,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.Map.Entry;
 
 /**
  * Response that is received when sending a GetConfigAction.
@@ -55,9 +56,9 @@ public class GetConfigResponse extends ManagerResponse
         }
 
         Map<String, Object> responseMap = super.getAttributes();
-        Set<String> responseKeys = responseMap.keySet();
-        for (String key : responseKeys)
+        for (Entry<String, Object> response : responseMap.entrySet())
         {
+            String key = response.getKey();
             if (key.toLowerCase(Locale.US).contains("category"))
             {
                 String[] keyParts = key.split("-");
@@ -77,7 +78,7 @@ public class GetConfigResponse extends ManagerResponse
                     continue;
                 }
 
-                categories.put(categoryNumber, (String) responseMap.get(key));
+                categories.put(categoryNumber, (String) response.getValue());
             }
         }
 
@@ -99,9 +100,9 @@ public class GetConfigResponse extends ManagerResponse
         }
 
         Map<String, Object> responseMap = super.getAttributes();
-        Set<String> responseKeys = responseMap.keySet();
-        for (String key : responseKeys)
+        for (Entry<String, Object> response : responseMap.entrySet())
         {
+            String key = response.getKey();
             if (key.toLowerCase(Locale.US).contains("line"))
             {
                 String[] keyParts = key.split("-");
@@ -142,7 +143,7 @@ public class GetConfigResponse extends ManagerResponse
                 }
 
                 // put the line we just parsed into the line map for this category
-                linesForCategory.put(potentialLineNumber, (String) responseMap.get(key));
+                linesForCategory.put(potentialLineNumber, (String) response.getValue());
                 if (!lines.containsKey(potentialCategoryNumber))
                 {
                     lines.put(potentialCategoryNumber, linesForCategory);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864

Please let me know if you have any questions.

Faisal Hameed