### PR TITLE
Code quality fix - Useless parentheses around expressions should be removed to prevent any misunderstanding.

### DIFF
--- a/src/main/java/org/asteriskjava/fastagi/internal/AgiReplyImpl.java
+++ b/src/main/java/org/asteriskjava/fastagi/internal/AgiReplyImpl.java
@@ -230,7 +230,7 @@ public class AgiReplyImpl implements AgiReply
                 inKey = false;
                 inQuotes = false;
             }
-            else if ((c == ' ' && !inKey && !inQuotes))
+            else if (c == ' ' && !inKey && !inQuotes)
             {
                 map.put(keyBuilder.toString().toLowerCase(Locale.ENGLISH), valueBuilder.toString());
                 keyBuilder.delete(0, keyBuilder.length());

--- a/src/main/java/org/asteriskjava/manager/internal/EventBuilderImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/EventBuilderImpl.java
@@ -423,7 +423,7 @@ class EventBuilderImpl extends AbstractBuilder implements EventBuilder
                 }
                 peerEntryEvents.add(peerEntryEvent);
             }
-            peersEvent.setActionId((peersEvent.getChildEvents().get(0).getActionId()));
+            peersEvent.setActionId(peersEvent.getChildEvents().get(0).getActionId());
         }
         else
         {

--- a/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
@@ -1038,7 +1038,7 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
             {
                 writer.sendAction(action, internalActionId);
                 // only wait if response has not yet arrived.
-                if ((responseEvents.getResponse() == null || !responseEvents.isComplete()))
+                if (responseEvents.getResponse() == null || !responseEvents.isComplete())
                 {
                     try
                     {
@@ -1053,7 +1053,7 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
             }
 
             // still no response or not all events received and timed out?
-            if ((responseEvents.getResponse() == null || !responseEvents.isComplete()))
+            if (responseEvents.getResponse() == null || !responseEvents.isComplete())
             {
                 throw new EventTimeoutException(
                         "Timeout waiting for response or response events to " + action.getAction()
@@ -1331,7 +1331,7 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
     {
         if (event instanceof DialBeginEvent)
         {
-            DialEvent legacyEvent = (new DialEvent((DialBeginEvent) event));
+            DialEvent legacyEvent = new DialEvent((DialBeginEvent) event);
             dispatchEvent(legacyEvent);
         }
     }

--- a/src/main/java/org/asteriskjava/util/Base64.java
+++ b/src/main/java/org/asteriskjava/util/Base64.java
@@ -39,7 +39,7 @@ public class Base64 {
         int numBytesInPartialGroup = aLen - 3*numFullGroups;
         int resultLen = 4*((aLen + 2)/3);
         StringBuffer result = new StringBuffer(resultLen);
-        char[] intToAlpha = (alternate ? intToAltBase64 : intToBase64);
+        char[] intToAlpha = alternate ? intToAltBase64 : intToBase64;
 
         // Translate all full groups from byte array elements to Base64
         int inCursor = 0;
@@ -125,7 +125,7 @@ public class Base64 {
     }
 
     private static byte[] base64ToByteArray(String s, boolean alternate) {
-        byte[] alphaToInt = (alternate ?  altBase64ToInt : base64ToInt);
+        byte[] alphaToInt = alternate ?  altBase64ToInt : base64ToInt;
         int sLen = s.length();
         int numGroups = sLen/4;
         if (4*numGroups != sLen)

--- a/src/main/java/org/asteriskjava/util/internal/Log4JLogger.java
+++ b/src/main/java/org/asteriskjava/util/internal/Log4JLogger.java
@@ -266,7 +266,7 @@ public class Log4JLogger implements Log, Serializable
         {
             logger = Logger.getLogger(name);
         }
-        return (this.logger);
+        return this.logger;
     }
 
     /**

--- a/src/main/java/org/asteriskjava/util/internal/Slf4JLogger.java
+++ b/src/main/java/org/asteriskjava/util/internal/Slf4JLogger.java
@@ -161,7 +161,7 @@ public class Slf4JLogger implements Log, Serializable
         {
             logger = LoggerFactory.getLogger(clazz);
         }
-        return (this.logger);
+        return this.logger;
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.

Faisal Hameed