### PR TITLE
Code quality fix - super.finalize() should be called at the end of Object.finalize() implementations.

### DIFF
--- a/src/main/java/org/asteriskjava/fastagi/AbstractAgiServer.java
+++ b/src/main/java/org/asteriskjava/fastagi/AbstractAgiServer.java
@@ -205,13 +205,13 @@ public abstract class AbstractAgiServer
     @Override
     protected void finalize() throws Throwable
     {
-        super.finalize();
-
         this.die = true;
         if (pool != null)
         {
             pool.shutdown();
         }
+
+        super.finalize();
     }
 
     /**

--- a/src/main/java/org/asteriskjava/fastagi/DefaultAgiServer.java
+++ b/src/main/java/org/asteriskjava/fastagi/DefaultAgiServer.java
@@ -401,7 +401,6 @@ public class DefaultAgiServer extends AbstractAgiServer implements AgiServer
     @Override
     protected void finalize() throws Throwable
     {
-        super.finalize();
 
         if (serverSocket != null)
         {
@@ -414,6 +413,8 @@ public class DefaultAgiServer extends AbstractAgiServer implements AgiServer
                 // swallow
             }
         }
+
+        super.finalize();
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:ObjectFinalizeOverridenCallsSuperFinalizeCheck - super.finalize() should be called at the end of Object.finalize() implementations.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:ObjectFinalizeOverridenCallsSuperFinalizeCheck

Please let me know if you have any questions.

Faisal Hameed