### PR TITLE
Code quality fix - Array designators "[]" should be on the type, not the variable.

### DIFF
--- a/src/main/java/org/asteriskjava/fastagi/command/GosubCommand.java
+++ b/src/main/java/org/asteriskjava/fastagi/command/GosubCommand.java
@@ -33,7 +33,7 @@ public class GosubCommand extends AbstractAgiCommand
      * an optional list of arguments to be passed to the subroutine.
      * They will accessible in the form of ${ARG1}, ${ARG2}, etc in the subroutine body.
      */
-    private String arguments[];
+    private String[] arguments;
 
     /**
      * Creates a new GosubCommand.

--- a/src/main/java/org/asteriskjava/util/Base64.java
+++ b/src/main/java/org/asteriskjava/util/Base64.java
@@ -78,7 +78,7 @@ public class Base64 {
      * index values into their "Base64 Alphabet" equivalents as specified
      * in Table 1 of RFC 2045.
      */
-    private static final char intToBase64[] = {
+    private static final char[] intToBase64 = {
         'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
         'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
         'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
@@ -93,7 +93,7 @@ public class Base64 {
      * This alternate alphabet does not use the capital letters.  It is
      * designed for use in environments where "case folding" occurs.
      */
-    private static final char intToAltBase64[] = {
+    private static final char[] intToAltBase64 = {
         '!', '"', '#', '$', '%', '&', '\'', '(', ')', ',', '-', '.', ':',
         ';', '<', '>', '@', '[', ']', '^',  '`', '_', '{', '|', '}', '~',
         'a', 'b', 'c', 'd', 'e', 'f', 'g',  'h', 'i', 'j', 'k', 'l', 'm',
@@ -192,7 +192,7 @@ public class Base64 {
      * are not in the Base64 alphabet but fall within the bounds of the
      * array are translated to -1.
      */
-    private static final byte base64ToInt[] = {
+    private static final byte[] base64ToInt = {
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63, 52, 53, 54,
@@ -206,7 +206,7 @@ public class Base64 {
      * This array is the analogue of base64ToInt, but for the nonstandard
      * variant that avoids the use of uppercase alphabetic characters.
      */
-    private static final byte altBase64ToInt[] = {
+    private static final byte[] altBase64ToInt = {
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1,
         2, 3, 4, 5, 6, 7, 8, -1, 62, 9, 10, 11, -1 , 52, 53, 54, 55, 56, 57,

--- a/src/main/java/org/asteriskjava/util/internal/JavaLoggingLog.java
+++ b/src/main/java/org/asteriskjava/util/internal/JavaLoggingLog.java
@@ -134,7 +134,7 @@ public class JavaLoggingLog implements Log
 
     private StackTraceElement getInvokerSTE()
     {
-        StackTraceElement stack[] = (new Throwable()).getStackTrace();
+        StackTraceElement[] stack = (new Throwable()).getStackTrace();
 
         if (stack.length > 2)
         {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1197 - Array designators "[]" should be on the type, not the variable.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1197

Please let me know if you have any questions.

Faisal Hameed