### PR TITLE
Code quality fix - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.

### DIFF
--- a/src/main/java/org/asteriskjava/fastagi/command/AbstractAgiCommand.java
+++ b/src/main/java/org/asteriskjava/fastagi/command/AbstractAgiCommand.java
@@ -80,9 +80,9 @@ public abstract class AbstractAgiCommand implements Serializable, AgiCommand
     @Override
     public String toString()
     {
-        StringBuffer sb;
+        StringBuilder sb;
 
-        sb = new StringBuffer(getClass().getName()).append("[");
+        sb = new StringBuilder(getClass().getName()).append("[");
         sb.append("command='").append(buildCommand()).append("', ");
         sb.append("systemHashcode=").append(System.identityHashCode(this)).append("]");
 

--- a/src/main/java/org/asteriskjava/fastagi/command/ControlStreamFileCommand.java
+++ b/src/main/java/org/asteriskjava/fastagi/command/ControlStreamFileCommand.java
@@ -256,9 +256,9 @@ public class ControlStreamFileCommand extends AbstractAgiCommand
     @Override
    public String buildCommand()
     {
-        StringBuffer sb;
+    	StringBuilder sb;
 
-        sb = new StringBuffer("CONTROL STREAM FILE ");
+        sb = new StringBuilder("CONTROL STREAM FILE ");
         sb.append(escapeAndQuote(file));
         sb.append(" ");
         sb.append(escapeAndQuote(escapeDigits));

--- a/src/main/java/org/asteriskjava/fastagi/command/GetFullVariableCommand.java
+++ b/src/main/java/org/asteriskjava/fastagi/command/GetFullVariableCommand.java
@@ -114,9 +114,9 @@ public class GetFullVariableCommand extends AbstractAgiCommand
     @Override
    public String buildCommand()
     {
-        StringBuffer sb;
+    	StringBuilder sb;
 
-        sb = new StringBuffer("GET FULL VARIABLE ");
+        sb = new StringBuilder("GET FULL VARIABLE ");
         sb.append(escapeAndQuote(variable));
 
         if (channel != null)

--- a/src/main/java/org/asteriskjava/fastagi/command/SayDateTimeCommand.java
+++ b/src/main/java/org/asteriskjava/fastagi/command/SayDateTimeCommand.java
@@ -205,9 +205,9 @@ public class SayDateTimeCommand extends AbstractAgiCommand
     @Override
    public String buildCommand()
     {
-        StringBuffer sb;
+    	StringBuilder sb;
 
-        sb = new StringBuffer("SAY DATETIME ");
+        sb = new StringBuilder("SAY DATETIME ");
         sb.append(time);
         sb.append(" ");
         sb.append(escapeAndQuote(escapeDigits));

--- a/src/main/java/org/asteriskjava/fastagi/internal/AgiRequestImpl.java
+++ b/src/main/java/org/asteriskjava/fastagi/internal/AgiRequestImpl.java
@@ -627,9 +627,9 @@ public class AgiRequestImpl implements AgiRequest
     @Override
     public String toString()
     {
-        StringBuffer sb;
+    	StringBuilder sb;
 
-        sb = new StringBuffer("AgiRequest[");
+        sb = new StringBuilder("AgiRequest[");
         sb.append("script='").append(getScript()).append("',");
         sb.append("requestURL='").append(getRequestURL()).append("',");
         sb.append("channel='").append(getChannel()).append("',");

--- a/src/main/java/org/asteriskjava/live/Extension.java
+++ b/src/main/java/org/asteriskjava/live/Extension.java
@@ -85,9 +85,9 @@ public class Extension implements Serializable
     @Override
     public String toString()
     {
-        StringBuffer sb;
+    	StringBuilder sb;
 
-        sb = new StringBuffer("Extension[");
+        sb = new StringBuilder("Extension[");
         sb.append("context='").append(getContext()).append("',");
         sb.append("extension='").append(getExtension()).append("',");
         sb.append("priority='").append(getPriority()).append("',");

--- a/src/main/java/org/asteriskjava/live/Voicemailbox.java
+++ b/src/main/java/org/asteriskjava/live/Voicemailbox.java
@@ -124,9 +124,9 @@ public class Voicemailbox implements Serializable
     @Override
    public String toString()
     {
-        StringBuffer sb;
+    	StringBuilder sb;
 
-        sb = new StringBuffer(100);
+        sb = new StringBuilder(100);
         sb.append("Voicemailbox[");
         sb.append("mailbox='").append(getMailbox()).append("',");
         sb.append("context='").append(getContext()).append("',");

--- a/src/main/java/org/asteriskjava/live/internal/AsteriskAgentImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskAgentImpl.java
@@ -68,9 +68,9 @@ public class AsteriskAgentImpl extends AbstractLiveObject implements AsteriskAge
     @Override
     public String toString()
     {
-        final StringBuffer sb;
+        final StringBuilder sb;
 
-        sb = new StringBuffer("AsteriskAgent[");
+        sb = new StringBuilder("AsteriskAgent[");
         sb.append("agentId='").append(getAgentId()).append("',");
         sb.append("name='").append(getName()).append("',");
         sb.append("state=").append(getState()).append(",");

--- a/src/main/java/org/asteriskjava/live/internal/AsteriskChannelImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskChannelImpl.java
@@ -998,12 +998,12 @@ class AsteriskChannelImpl extends AbstractLiveObject implements AsteriskChannel
     @Override
     public String toString()
     {
-        final StringBuffer sb;
+        final StringBuilder sb;
         final List<AsteriskChannel> dialedChannels;
         final List<AsteriskChannel> dialingChannel;
         final List<AsteriskChannel> linkedChannel;
 
-        sb = new StringBuffer("AsteriskChannel[");
+        sb = new StringBuilder("AsteriskChannel[");
 
         synchronized (this)
         {

--- a/src/main/java/org/asteriskjava/live/internal/AsteriskQueueEntryImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskQueueEntryImpl.java
@@ -133,10 +133,10 @@ class AsteriskQueueEntryImpl extends AbstractLiveObject implements AsteriskQueue
     @Override
     public String toString()
     {
-        StringBuffer sb;
+    	StringBuilder sb;
         int systemHashcode;
 
-        sb = new StringBuffer("AsteriskQueueEntry[");
+        sb = new StringBuilder("AsteriskQueueEntry[");
 
         synchronized (this)
         {

--- a/src/main/java/org/asteriskjava/live/internal/AsteriskQueueImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskQueueImpl.java
@@ -432,9 +432,9 @@ class AsteriskQueueImpl extends AbstractLiveObject implements AsteriskQueue
     @Override
     public String toString()
     {
-        final StringBuffer sb;
+        final StringBuilder sb;
 
-        sb = new StringBuffer("AsteriskQueue[");
+        sb = new StringBuilder("AsteriskQueue[");
         sb.append("name='").append(getName()).append("',");
         sb.append("max='").append(getMax()).append("',");
         sb.append("strategy='").append(getStrategy()).append("',");

--- a/src/main/java/org/asteriskjava/live/internal/AsteriskQueueMemberImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskQueueMemberImpl.java
@@ -196,9 +196,9 @@ class AsteriskQueueMemberImpl extends AbstractLiveObject implements AsteriskQueu
     @Override
     public String toString()
     {
-        final StringBuffer sb;
+        final StringBuilder sb;
 
-        sb = new StringBuffer("AsteriskQueueMember[");
+        sb = new StringBuilder("AsteriskQueueMember[");
         sb.append("location='").append(location).append("'");
         sb.append("state='").append(state).append("'");
         sb.append("paused='").append(paused).append("'");

--- a/src/main/java/org/asteriskjava/live/internal/MeetMeRoomImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/MeetMeRoomImpl.java
@@ -116,7 +116,7 @@ class MeetMeRoomImpl extends AbstractLiveObject implements MeetMeRoom
 
     private void sendMeetMeCommand(String command) throws ManagerCommunicationException
     {
-        final StringBuffer sb = new StringBuffer();
+        final StringBuilder sb = new StringBuilder();
         sb.append(COMMAND_PREFIX);
         sb.append(" ");
         sb.append(command);
@@ -129,10 +129,10 @@ class MeetMeRoomImpl extends AbstractLiveObject implements MeetMeRoom
     @Override
    public String toString()
     {
-        StringBuffer sb;
+    	StringBuilder sb;
         int systemHashcode;
 
-        sb = new StringBuffer("MeetMeRoom[");
+        sb = new StringBuilder("MeetMeRoom[");
 
         synchronized (this)
         {

--- a/src/main/java/org/asteriskjava/live/internal/MeetMeUserImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/MeetMeUserImpl.java
@@ -141,7 +141,7 @@ class MeetMeUserImpl extends AbstractLiveObject implements MeetMeUser
 
     private void sendMeetMeUserCommand(String command) throws ManagerCommunicationException
     {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append(COMMAND_PREFIX);
         sb.append(" ");
         sb.append(command);
@@ -156,10 +156,10 @@ class MeetMeUserImpl extends AbstractLiveObject implements MeetMeUser
     @Override
    public String toString()
     {
-        StringBuffer sb;
+    	StringBuilder sb;
         int systemHashcode;
 
-        sb = new StringBuffer("MeetMeUser[");
+        sb = new StringBuilder("MeetMeUser[");
 
         synchronized (this)
         {

--- a/src/main/java/org/asteriskjava/manager/action/AbstractManagerAction.java
+++ b/src/main/java/org/asteriskjava/manager/action/AbstractManagerAction.java
@@ -53,10 +53,10 @@ public abstract class AbstractManagerAction implements ManagerAction
     @Override
     public String toString()
     {
-        StringBuffer sb;
+    	StringBuilder sb;
         Map<String, Method> getters;
 
-        sb = new StringBuffer(getClass().getName() + "[");
+        sb = new StringBuilder(getClass().getName() + "[");
         sb.append("action='").append(getAction()).append("',");
         getters = ReflectionUtil.getGetters(getClass());
         for (Map.Entry<String, Method> entry : getters.entrySet())

--- a/src/main/java/org/asteriskjava/manager/action/OriginateAction.java
+++ b/src/main/java/org/asteriskjava/manager/action/OriginateAction.java
@@ -446,7 +446,7 @@ public class OriginateAction extends AbstractManagerAction implements EventGener
         }
 
         Iterator<String> iter = codecs.iterator();
-        StringBuffer buffer = new StringBuffer(iter.next());
+        StringBuilder buffer = new StringBuilder(iter.next());
         while (iter.hasNext())
         {
             buffer.append(",").append(iter.next());

--- a/src/main/java/org/asteriskjava/manager/action/StatusAction.java
+++ b/src/main/java/org/asteriskjava/manager/action/StatusAction.java
@@ -136,7 +136,7 @@ public class StatusAction extends AbstractManagerAction implements EventGenerati
         }
 
         Iterator<String> iter = variables.iterator();
-        StringBuffer buffer = new StringBuffer(iter.next());
+        StringBuilder buffer = new StringBuilder(iter.next());
         while (iter.hasNext())
         {
             buffer.append(",").append(iter.next());

--- a/src/main/java/org/asteriskjava/manager/internal/ActionBuilderImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/ActionBuilderImpl.java
@@ -71,7 +71,7 @@ class ActionBuilderImpl implements ActionBuilder
     @SuppressWarnings("unchecked")
     public String buildAction(final ManagerAction action, final String internalActionId)
     {
-        StringBuffer sb = new StringBuffer();
+    	StringBuilder sb = new StringBuilder();
 
         sb.append("action: ");
         sb.append(action.getAction());
@@ -147,7 +147,7 @@ class ActionBuilderImpl implements ActionBuilder
         return sb.toString();
     }
 
-    private void appendMap(StringBuffer sb, String key, Map<String, String> values)
+    private void appendMap(StringBuilder sb, String key, Map<String, String> values)
     {
         String singularKey;
 
@@ -171,7 +171,7 @@ class ActionBuilderImpl implements ActionBuilder
         }
     }
 
-    private void appendMap10(StringBuffer sb, String singularKey, Map<String, String> values)
+    private void appendMap10(StringBuilder sb, String singularKey, Map<String, String> values)
     {
         Iterator<Map.Entry<String, String>> entryIterator;
 
@@ -198,7 +198,7 @@ class ActionBuilderImpl implements ActionBuilder
         sb.append(LINE_SEPARATOR);
     }
 
-    private void appendMap12(StringBuffer sb, String singularKey, Map<String, String> values)
+    private void appendMap12(StringBuilder sb, String singularKey, Map<String, String> values)
     {
         for (Map.Entry<String, String> entry : values.entrySet())
         {
@@ -215,7 +215,7 @@ class ActionBuilderImpl implements ActionBuilder
         }
     }
 
-    private void appendString(StringBuffer sb, String key, String value)
+    private void appendString(StringBuilder sb, String key, String value)
     {
         sb.append(key);
         sb.append(": ");
@@ -223,7 +223,7 @@ class ActionBuilderImpl implements ActionBuilder
         sb.append(LINE_SEPARATOR);
     }
 
-    private void appendUserEvent(StringBuffer sb, UserEvent event)
+    private void appendUserEvent(StringBuilder sb, UserEvent event)
     {
         Class<?> clazz = event.getClass();
 
@@ -239,7 +239,7 @@ class ActionBuilderImpl implements ActionBuilder
     }
 
     @SuppressWarnings("unchecked")
-    private void appendGetters(StringBuffer sb, Object action, Set<String> membersToIgnore)
+    private void appendGetters(StringBuilder sb, Object action, Set<String> membersToIgnore)
     {
         Map<String, Method> getters = ReflectionUtil.getGetters(action.getClass());
         for (Map.Entry<String, Method> entry : getters.entrySet())

--- a/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
@@ -1094,9 +1094,9 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
      */
     private String createInternalActionId()
     {
-        final StringBuffer sb;
+        final StringBuilder sb;
 
-        sb = new StringBuffer();
+        sb = new StringBuilder();
         sb.append(this.hashCode());
         sb.append("_");
         sb.append(actionIdCounter.getAndIncrement());
@@ -1488,9 +1488,9 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
     @Override
     public String toString()
     {
-        StringBuffer sb;
+    	StringBuilder sb;
 
-        sb = new StringBuffer("ManagerConnection[");
+        sb = new StringBuilder("ManagerConnection[");
         sb.append("id='").append(id).append("',");
         sb.append("hostname='").append(hostname).append("',");
         sb.append("port=").append(port).append(",");

--- a/src/main/java/org/asteriskjava/manager/response/ExtensionStateResponse.java
+++ b/src/main/java/org/asteriskjava/manager/response/ExtensionStateResponse.java
@@ -74,9 +74,9 @@ public class ExtensionStateResponse extends ManagerResponse
     @Override
     public String toString()
     {
-        StringBuffer sb;
+    	StringBuilder sb;
 
-        sb = new StringBuffer(getClass().getName() + ": ");
+        sb = new StringBuilder(getClass().getName() + ": ");
         sb.append("actionId='").append(getActionId()).append("'; ");
         sb.append("message='").append(getMessage()).append("'; ");
         sb.append("response='").append(getResponse()).append("'; ");

--- a/src/main/java/org/asteriskjava/manager/response/ManagerResponse.java
+++ b/src/main/java/org/asteriskjava/manager/response/ManagerResponse.java
@@ -280,9 +280,9 @@ public class ManagerResponse implements Serializable
     @Override
     public String toString()
     {
-        StringBuffer sb;
+    	StringBuilder sb;
 
-        sb = new StringBuffer(100);
+        sb = new StringBuilder(100);
         sb.append(getClass().getName()).append(": ");
         sb.append("actionId='").append(getActionId()).append("'; ");
         sb.append("message='").append(getMessage()).append("'; ");

--- a/src/main/java/org/asteriskjava/util/Base64.java
+++ b/src/main/java/org/asteriskjava/util/Base64.java
@@ -43,7 +43,7 @@ public class Base64 {
         int numFullGroups = aLen/3;
         int numBytesInPartialGroup = aLen - 3*numFullGroups;
         int resultLen = 4*((aLen + 2)/3);
-        StringBuffer result = new StringBuffer(resultLen);
+        StringBuilder result = new StringBuilder(resultLen);
         char[] intToAlpha = alternate ? intToAltBase64 : intToBase64;
 
         // Translate all full groups from byte array elements to Base64

--- a/src/main/java/org/asteriskjava/util/ReflectionUtil.java
+++ b/src/main/java/org/asteriskjava/util/ReflectionUtil.java
@@ -135,7 +135,7 @@ public class ReflectionUtil
     {
         char c;
         boolean needsStrip = false;
-        StringBuffer sb;
+        StringBuilder sb;
 
         if (s == null)
         {
@@ -165,7 +165,7 @@ public class ReflectionUtil
             return s;
         }
 
-        sb = new StringBuffer(s.length());
+        sb = new StringBuilder(s.length());
         for (int i = 0; i < s.length(); i++)
         {
             c = s.charAt(i);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149

Please let me know if you have any questions.

Faisal Hameed