### PR TITLE
Code quality fix - Classes and methods that rely on the default system encoding should not be used. 

### DIFF
--- a/src/main/java/org/asteriskjava/config/ConfigFileReader.java
+++ b/src/main/java/org/asteriskjava/config/ConfigFileReader.java
@@ -1,9 +1,12 @@
 package org.asteriskjava.config;
 
 import java.io.BufferedReader;
+import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -56,7 +59,7 @@ public class ConfigFileReader
         final ConfigFile result;
         final BufferedReader reader;
 
-        reader = new BufferedReader(new FileReader(configfile));
+        reader = new BufferedReader(new InputStreamReader(new FileInputStream(configfile), StandardCharsets.UTF_8));
         try
         {
             readFile(configfile, reader);

--- a/src/main/java/org/asteriskjava/fastagi/ScriptEngineMappingStrategy.java
+++ b/src/main/java/org/asteriskjava/fastagi/ScriptEngineMappingStrategy.java
@@ -27,6 +27,7 @@ import java.io.Reader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -350,7 +351,7 @@ public class ScriptEngineMappingStrategy implements MappingStrategy
     protected static Reader getReader(File file) throws FileNotFoundException
     {
         final InputStream is = new FileInputStream(file);
-        return new InputStreamReader(is);
+        return new InputStreamReader(is, StandardCharsets.UTF_8);
     }
 
     protected class ScriptEngineAgiScript implements NamedAgiScript

--- a/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
@@ -581,11 +581,11 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
             md = MessageDigest.getInstance("MD5");
             if (challenge != null)
             {
-                md.update(challenge.getBytes());
+                md.update(challenge.getBytes(StandardCharsets.UTF_8));
             }
             if (password != null)
             {
-                md.update(password.getBytes());
+                md.update(password.getBytes(StandardCharsets.UTF_8));
             }
             key = ManagerUtil.toHexString(md.digest());
         }

--- a/src/main/java/org/asteriskjava/tools/HtmlEventTracer.java
+++ b/src/main/java/org/asteriskjava/tools/HtmlEventTracer.java
@@ -3,8 +3,11 @@ package org.asteriskjava.tools;
 import java.beans.BeanInfo;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -67,7 +70,7 @@ public class HtmlEventTracer implements ManagerEventListener
 
         try
         {
-            writer = new PrintWriter(filename);
+            writer = new PrintWriter(new OutputStreamWriter(new FileOutputStream(filename), StandardCharsets.UTF_8));
         }
         catch (IOException e)
         {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1943 - Classes and methods that rely on the default system encoding should not be used. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1943
 
Please let me know if you have any questions.

Faisal Hameed