### PR TITLE
Code quality fix -  Class variable fields should not have public accessibility.

### DIFF
--- a/src/main/java/org/asteriskjava/live/internal/AsteriskAgentImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskAgentImpl.java
@@ -27,9 +27,9 @@ import org.asteriskjava.live.AsteriskAgent;
  */
 public class AsteriskAgentImpl extends AbstractLiveObject implements AsteriskAgent
 {
-    public String name;
-    public String agentId;
-    public AgentState state;
+    private String name;
+    private String agentId;
+    private AgentState state;
 
     AsteriskAgentImpl(AsteriskServerImpl server, String name, String agentId, AgentState state)
     {

--- a/src/main/java/org/asteriskjava/manager/action/SetVarAction.java
+++ b/src/main/java/org/asteriskjava/manager/action/SetVarAction.java
@@ -34,17 +34,17 @@ public class SetVarAction extends AbstractManagerAction
     /**
      * The channel on which to set the variable.
      */
-    public String channel;
+    private String channel;
 
     /**
      * The name of the variable to set.
      */
-    public String variable;
+    private String variable;
 
     /**
      * The value to store.
      */
-    public String value;
+    private String value;
 
     /**
      * Creates a new empty SetVarAction.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck

Please let me know if you have any questions.

Faisal Hameed