### PR TITLE
Fix assembly plugin error on Windows

### DIFF
--- a/src/main/assembly/bin.xml
+++ b/src/main/assembly/bin.xml
@@ -15,11 +15,11 @@
         </fileSet>
         <fileSet>
             <directory>dist</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory>./</outputDirectory>
         </fileSet>
         <fileSet>
             <directory>target</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory>./</outputDirectory>
             <includes>
                 <include>*.jar</include>
             </includes>


### PR DESCRIPTION
`[ERROR] OS=Windows and the assembly descriptor contains a *nix-specific root-relative-reference (starting with slash) /`