### PR TITLE
Restore OSGi manifest headers

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,0 +1,16 @@
+Main-Class: org.asteriskjava.Cli
+
+Bundle-SymbolicName: org.asteriskjava
+Bundle-Name: ${project.name}
+Bundle-Description: ${project.description}
+Bundle-DocURL: ${project.url}
+Bundle-License: http://www.apache.org/licenses/LICENSE-2.0.txt
+
+-exportcontents: !*.internal.*, *
+
+Import-Package: \
+	javax.net,\
+	javax.net.ssl,\
+	javax.script,\
+	org.apache.log4j;resolution:=optional,\
+	org.slf4j;resolution:=optional

--- a/pom.xml
+++ b/pom.xml
@@ -107,12 +107,20 @@
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>2.5</version>
 				<configuration>
-					<archive>
-						<manifest>
-							<mainClass>org.asteriskjava.Cli</mainClass>
-						</manifest>
-					</archive>
+					<useDefaultManifestFile>true</useDefaultManifestFile>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<version>3.1.0</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>bnd-process</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -195,10 +203,7 @@
 		<profile>
 			<id>release</id>
 			<build>
-
 				<plugins>
-
-
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
This go around we're using the bnd-maven-plugin to do most of the heavy lifting for us. We're also letting bnd take care of the Main-Class header as well.