### PR TITLE
ConfbridgeEvents mssing sometimes Conference element

### DIFF
--- a/src/main/java/org/asteriskjava/manager/event/AbstractConfbridgeEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AbstractConfbridgeEvent.java
@@ -9,6 +9,8 @@ public abstract class AbstractConfbridgeEvent extends AbstractChannelEvent
     private String bridgeTechnology;
     private String bridgeName;
     private String bridgeCreator;
+    private String conference;
+
     String admin;
 
     public AbstractConfbridgeEvent(Object source)
@@ -128,4 +130,24 @@ public abstract class AbstractConfbridgeEvent extends AbstractChannelEvent
         this.bridgeCreator = bridgeCreator;
     }
 
+    /**
+     * Sets the id of the conference the participant left.
+     *
+     * @param conference the id of the conference the participant left.
+     */
+    public final void setConference(String conference)
+    {
+        this.conference = conference;
+    }
+
+    /**
+     * Returns the id of the conference the participant left.
+     *
+     * @return the id of the conference the participant left.
+     */
+    public final String getConference()
+    {
+        return conference;
+    }
+    
 }

--- a/src/main/java/org/asteriskjava/manager/event/ConfbridgeEndEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ConfbridgeEndEvent.java
@@ -20,24 +20,4 @@ public class ConfbridgeEndEvent extends AbstractConfbridgeEvent
         super(source);
     }
 
-    /**
-     * Sets the id of the conference ended.
-     *
-     * @param conference the id of the conference ended.
-     */
-    public void setConference(String conference)
-    {
-        this.conference = conference;
-    }
-
-    /**
-     * Returns the id of the conference ended.
-     *
-     * @return the id of the conference ended.
-     */
-    public String getConference()
-    {
-        return conference;
-    }
-
 }

--- a/src/main/java/org/asteriskjava/manager/event/ConfbridgeJoinEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ConfbridgeJoinEvent.java
@@ -20,14 +20,4 @@ public class ConfbridgeJoinEvent extends AbstractConfbridgeEvent
         super(source);
     }
 
-    public String getConference()
-    {
-        return conference;
-    }
-
-    public void setConference(String conference)
-    {
-        this.conference = conference;
-    }
-
 }

--- a/src/main/java/org/asteriskjava/manager/event/ConfbridgeLeaveEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ConfbridgeLeaveEvent.java
@@ -18,23 +18,4 @@ public class ConfbridgeLeaveEvent extends AbstractConfbridgeEvent
         super(source);
     }
 
-    /**
-     * Sets the id of the conference the participant left.
-     *
-     * @param conference the id of the conference the participant left.
-     */
-    public void setConference(String conference)
-    {
-        this.conference = conference;
-    }
-
-    /**
-     * Returns the id of the conference the participant left.
-     *
-     * @return the id of the conference the participant left.
-     */
-    public String getConference()
-    {
-        return conference;
-    }
 }

--- a/src/main/java/org/asteriskjava/manager/event/ConfbridgeStartEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ConfbridgeStartEvent.java
@@ -20,23 +20,4 @@ public class ConfbridgeStartEvent extends AbstractConfbridgeEvent
         super(source);
     }
 
-    /**
-     * Sets the id of the conference started.
-     *
-     * @param conference the id of the conference started.
-     */
-    public void setConference(String conference)
-    {
-        this.conference = conference;
-    }
-
-    /**
-     * Returns the id of the conference started.
-     *
-     * @return the id of the conference started.
-     */
-    public String getConference()
-    {
-        return conference;
-    }
 }

--- a/src/main/java/org/asteriskjava/manager/event/ConfbridgeTalkingEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ConfbridgeTalkingEvent.java
@@ -14,7 +14,7 @@ public class ConfbridgeTalkingEvent extends AbstractConfbridgeEvent
     private static final long serialVersionUID = 1L;
 
     private Boolean talkingStatus;
-
+    
     public ConfbridgeTalkingEvent(Object source)
     {
         super(source);
@@ -40,4 +40,5 @@ public class ConfbridgeTalkingEvent extends AbstractConfbridgeEvent
     {
         return talkingStatus;
     }
+    
 }


### PR DESCRIPTION
According to digium docu all confbridge events contains a conference id element.
So i modified AbstraceConfbridgeEvent to contain the element and removed it in alle descendent classes where it was already implemented