### PR TITLE
RtcpReceivedEvent does not catch NumberFormatException

### DIFF
--- a/src/main/java/org/asteriskjava/manager/event/RtcpReceivedEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/RtcpReceivedEvent.java
@@ -147,13 +147,20 @@ public class RtcpReceivedEvent extends AbstractRtcpEvent
             return;
         }
 
-        if (ptString.indexOf('(') > 0)
+        try
         {
-            this.pt = Long.parseLong(ptString.substring(0, ptString.indexOf('(')));
-        }
-        else
+            if (ptString.indexOf('(') > 0)
+            {
+                this.pt = Long.parseLong(ptString.substring(0, ptString.indexOf('(')));
+            }
+            else
+            {
+                this.pt = Long.parseLong(ptString);
+            }
+
+        } catch (NumberFormatException e)
         {
-            this.pt = Long.parseLong(ptString);
+            throw new NumberFormatException(String.format("Input string [%s] is not a parsable long", ptString));
         }
     }
 


### PR DESCRIPTION
`RtcpReceivedEvent.java` calls `java.lang.long.parseLong` without first checking whether the argument parses. This lead to an uncaught `NumberFormatException`: [Oracle Java 7 API specification](http://docs.oracle.com/javase/7/docs/api/java/lang/Long.html#parseLong%28java.lang.String,%20int%29).

This pull request adds a check with a  more helpful exception message. Kindly let me know if you want me to change the message. 