### PR TITLE
Possible cast exception because in rare conditions a module version c…

### DIFF
--- a/src/main/java/org/asteriskjava/manager/response/ModuleCheckResponse.java
+++ b/src/main/java/org/asteriskjava/manager/response/ModuleCheckResponse.java
@@ -28,19 +28,19 @@ public class ModuleCheckResponse extends ManagerResponse
 {
     private static final long serialVersionUID = -7253724086340850957L;
 
-    private Integer version;
+    private String version;
 
     /**
      * Returns the version (svn revision) of the module.
      *
      * @return the version (svn revision) of the module.
      */
-    public Integer getVersion()
+    public String getVersion()
     {
         return version;
     }
 
-    public void setVersion(Integer version)
+    public void setVersion(String version)
     {
         this.version = version;
     }


### PR DESCRIPTION
#131 
…an contain textual information.

In this special case codec_silk