### PR TITLE
 WARN [Asterisk-Java ManagerConnection-0-Reader-0]

### DIFF
--- a/src/main/java/org/asteriskjava/manager/event/QueueMemberStatusEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/QueueMemberStatusEvent.java
@@ -29,8 +29,9 @@ public class QueueMemberStatusEvent extends QueueMemberEvent
      */
     private static final long serialVersionUID = -2293926744791895763L;
 
-    String ringinuse;
-    String iface;
+    private String ringinuse;
+    private String iface;
+    private Integer incall;
 
     /**
      * @param source
@@ -65,4 +66,16 @@ public class QueueMemberStatusEvent extends QueueMemberEvent
     {
         this.ringinuse = ringinuse;
     }
+
+    public Integer getIncall()
+    {
+        return incall;
+    }
+
+    public void setIncall(Integer incall)
+    {
+        this.incall = incall;
+    }
+    
+    
 }


### PR DESCRIPTION
(AbstractBuilder.java:83) - Unable to set property 'incall' to '0' on
org.asteriskjava.manager.event.QueueMemberStatusEvent: no setter. Please
report at https://github.com/asterisk-java/asterisk-java/issues]]