### PR TITLE
Support delimiter variants other than ': '

### DIFF
--- a/src/main/java/org/asteriskjava/manager/internal/ManagerReaderImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/ManagerReaderImpl.java
@@ -190,35 +190,23 @@ public class ManagerReaderImpl implements ManagerReader
 
                 if (line.length() > 0)
                 {
-                    int delimiterIndex;
-                    int delimiterLength;
-
                     // begin of workaround for Astersik bug 13319
                     // see AJ-77
                     // Use this workaround only when line starts from "From "
                     // and "To "
-                    int isFromAtStart, isToAtStart;
-                    isFromAtStart = line.indexOf("From ");
-                    isToAtStart = line.indexOf("To ");
-                    if (isFromAtStart == 0 || isToAtStart == 0)
-                    {
-                        delimiterIndex = line.indexOf(" ");
-                        delimiterLength = 1;
-                    }
-                    else
-                    {
-                        delimiterIndex = line.indexOf(": ");
-                        delimiterLength = 2;
-                    }
+                    int isFromAtStart = line.indexOf("From ");
+                    int isToAtStart = line.indexOf("To ");
+
+                    int delimiterIndex = isFromAtStart == 0 || isToAtStart == 0
+                        ? line.indexOf(" ") : line.indexOf(":");
                     // end of workaround for Astersik bug 13319
+
+                    int delimiterLength = 1;
 
                     if (delimiterIndex > 0 && line.length() > delimiterIndex + delimiterLength)
                     {
-                        String name;
-                        String value;
-
-                        name = line.substring(0, delimiterIndex).toLowerCase(Locale.ENGLISH);
-                        value = line.substring(delimiterIndex + delimiterLength);
+                        String name = line.substring(0, delimiterIndex).toLowerCase(Locale.ENGLISH).trim();
+                        String value = line.substring(delimiterIndex + delimiterLength).trim();
 
                         addToBuffer(buffer, name, value);
                         // TODO tracing


### PR DESCRIPTION
Current implementations support [UserEvent](http://www.voip-info.org/wiki/view/Asterisk+cmd+UserEvent) with
properties delimited by **": "** (colon + space). `UserEvent(NAME,key1:value1,key2:value2)` will not work. RP add support for all variants.
