### PR TITLE
Only sign archives if we want to upload archives, fixes #177

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ artifacts {
 }
 
 signing {
+    required { gradle.taskGraph.hasTask("uploadArchives") }
     sign configurations.archives
 }
 


### PR DESCRIPTION
Gradle signing plugin is now only invoked if we actually want to upload archives.
This allows us to use automated build services like jitpack.io, see #177 