### PR TITLE
Fix order of BridgeEvent in legacy support code.

### DIFF
--- a/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeState.java
+++ b/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeState.java
@@ -140,9 +140,9 @@ class BridgeState
      *
      * @param id1 1st Asterisk Unique ID, for example "1099015093.165".
      * @param id2 2nd Asterisk Unique ID, for example "1099015093.166".
-     * @return Return 0 if s1 == s2.
-     * Return less then 0 if s1 < s2.
-     * Return greater then 0 if s1 > s2.
+     * @return Return 0 if id1 == id2.
+     * Return less then 0 if id1 < id2.
+     * Return greater then 0 if id1 > id2.
      */
     private int compareUniqueId(String id1, String id2) {
         Pattern uniqueIdPattern = Pattern.compile("^([0-9]+)\\.([0-9]+)$");

--- a/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeState.java
+++ b/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeState.java
@@ -105,29 +105,26 @@ class BridgeState
     private BridgeEvent buildBridgeEvent(String bridgeState, List<BridgeEnterEvent> members)
     {
         BridgeEvent bridgeEvent = new BridgeEvent(this);
-
+        int index1, index2;
 
         if (this.compareUniqueId(members.get(0).getUniqueId(),
                                  members.get(1).getUniqueId()) < 0)
         {
-            bridgeEvent.setCallerId1(members.get(0).getCallerIdNum());
-            bridgeEvent.setUniqueId1(members.get(0).getUniqueId());
-            bridgeEvent.setChannel1(members.get(0).getChannel());
-
-            bridgeEvent.setCallerId2(members.get(1).getCallerIdNum());
-            bridgeEvent.setUniqueId2(members.get(1).getUniqueId());
-            bridgeEvent.setChannel2(members.get(1).getChannel());
+            index1 = 0;
+            index2 = 1;
         }
         else
         {
-            bridgeEvent.setCallerId1(members.get(1).getCallerIdNum());
-            bridgeEvent.setUniqueId1(members.get(1).getUniqueId());
-            bridgeEvent.setChannel1(members.get(1).getChannel());
-
-            bridgeEvent.setCallerId2(members.get(0).getCallerIdNum());
-            bridgeEvent.setUniqueId2(members.get(0).getUniqueId());
-            bridgeEvent.setChannel2(members.get(0).getChannel());
+            index1 = 1;
+            index2 = 0;
         }
+        bridgeEvent.setCallerId1(members.get(index1).getCallerIdNum());
+        bridgeEvent.setUniqueId1(members.get(index1).getUniqueId());
+        bridgeEvent.setChannel1(members.get(index1).getChannel());
+
+        bridgeEvent.setCallerId2(members.get(index2).getCallerIdNum());
+        bridgeEvent.setUniqueId2(members.get(index2).getUniqueId());
+        bridgeEvent.setChannel2(members.get(index2).getChannel());
 
         bridgeEvent.setBridgeState(bridgeState);
         bridgeEvent.setDateReceived(new Date());

--- a/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeState.java
+++ b/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeState.java
@@ -144,7 +144,8 @@ class BridgeState
      * Return less then 0 if id1 < id2.
      * Return greater then 0 if id1 > id2.
      */
-    private int compareUniqueId(String id1, String id2) {
+    private int compareUniqueId(String id1, String id2)
+    {
         Pattern uniqueIdPattern = Pattern.compile("^([0-9]+)\\.([0-9]+)$");
         Matcher uniqueId1Matcher = uniqueIdPattern.matcher(id1);
         Matcher uniqueId2Matcher = uniqueIdPattern.matcher(id2);
@@ -152,26 +153,33 @@ class BridgeState
         boolean find1 = uniqueId1Matcher.find();
         boolean find2 = uniqueId2Matcher.find();
 
-        if (find1 && find2) {
+        if (find1 && find2)
+        {
             // 1501234567.890 -> epochtime: 1501234567 | serial: 890
             int epochtime1 = Integer.valueOf(uniqueId1Matcher.group(1));
             int epochtime2 = Integer.valueOf(uniqueId2Matcher.group(1));
             int serial1 = Integer.valueOf(uniqueId1Matcher.group(2));
             int serial2 = Integer.valueOf(uniqueId2Matcher.group(2));
 
-            if (epochtime1 == epochtime2) {
+            if (epochtime1 == epochtime2)
+            {
                 return Integer.compare(serial1, serial2);
             }
 
             return Integer.compare(epochtime1, epochtime2);
 
-        } else if (!find1 && find2) {
+        }
+        else if (!find1 && find2)
+        {
             // id1 < id2
             return -1;
-        } else if (find1 && !find2) {
+        }
+        else if (find1 && !find2)
+        {
             // id1 > id2
             return 1;
         }
+	// Both of inputs are invalid value: id1 == id2
         return 0;
     }
 }

--- a/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeState.java
+++ b/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeState.java
@@ -104,13 +104,27 @@ class BridgeState
     {
         BridgeEvent bridgeEvent = new BridgeEvent(this);
 
-        bridgeEvent.setCallerId1(members.get(0).getCallerIdNum());
-        bridgeEvent.setUniqueId1(members.get(0).getUniqueId());
-        bridgeEvent.setChannel1(members.get(0).getChannel());
 
-        bridgeEvent.setCallerId2(members.get(1).getCallerIdNum());
-        bridgeEvent.setUniqueId2(members.get(1).getUniqueId());
-        bridgeEvent.setChannel2(members.get(1).getChannel());
+        if (new Integer(2).equals(members.get(0).getBridgeNumChannels()))
+        {
+            bridgeEvent.setCallerId1(members.get(0).getCallerIdNum());
+            bridgeEvent.setUniqueId1(members.get(0).getUniqueId());
+            bridgeEvent.setChannel1(members.get(0).getChannel());
+
+	    bridgeEvent.setCallerId2(members.get(1).getCallerIdNum());
+	    bridgeEvent.setUniqueId2(members.get(1).getUniqueId());
+	    bridgeEvent.setChannel2(members.get(1).getChannel());
+        }
+        else
+        {
+            bridgeEvent.setCallerId1(members.get(1).getCallerIdNum());
+            bridgeEvent.setUniqueId1(members.get(1).getUniqueId());
+            bridgeEvent.setChannel1(members.get(1).getChannel());
+
+	    bridgeEvent.setCallerId2(members.get(0).getCallerIdNum());
+	    bridgeEvent.setUniqueId2(members.get(0).getUniqueId());
+	    bridgeEvent.setChannel2(members.get(0).getChannel());
+        }
 
         bridgeEvent.setBridgeState(bridgeState);
         bridgeEvent.setDateReceived(new Date());

--- a/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeState.java
+++ b/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeState.java
@@ -111,9 +111,9 @@ class BridgeState
             bridgeEvent.setUniqueId1(members.get(0).getUniqueId());
             bridgeEvent.setChannel1(members.get(0).getChannel());
 
-	    bridgeEvent.setCallerId2(members.get(1).getCallerIdNum());
-	    bridgeEvent.setUniqueId2(members.get(1).getUniqueId());
-	    bridgeEvent.setChannel2(members.get(1).getChannel());
+            bridgeEvent.setCallerId2(members.get(1).getCallerIdNum());
+            bridgeEvent.setUniqueId2(members.get(1).getUniqueId());
+            bridgeEvent.setChannel2(members.get(1).getChannel());
         }
         else
         {
@@ -121,9 +121,9 @@ class BridgeState
             bridgeEvent.setUniqueId1(members.get(1).getUniqueId());
             bridgeEvent.setChannel1(members.get(1).getChannel());
 
-	    bridgeEvent.setCallerId2(members.get(0).getCallerIdNum());
-	    bridgeEvent.setUniqueId2(members.get(0).getUniqueId());
-	    bridgeEvent.setChannel2(members.get(0).getChannel());
+            bridgeEvent.setCallerId2(members.get(0).getCallerIdNum());
+            bridgeEvent.setUniqueId2(members.get(0).getUniqueId());
+            bridgeEvent.setChannel2(members.get(0).getChannel());
         }
 
         bridgeEvent.setBridgeState(bridgeState);


### PR DESCRIPTION
I using BridgeEvent class in my project with Asterisk 11 and 13.
BridgeEvent legacy support code helps me.  But sometimes make me confused.

```
Cite from output of BridgeEvent#toString().  "UniqueId2" newer then "UniqueId1"
uniqueid1='1503378525.2326',
uniqueid2='1503378525.2327',
```
UniqueID(and Channel) order fixed in Asterisk 11.
But Asterisk 13 with Asterisk-Java change order **in sometimes**.

```
BridgeEvent#toString() with Asterisk13(without this patch): Random order
uniqueid1='1503379966.2341',
uniqueid2='1503379966.2340',
(snip)
uniqueid1='1503380654.2346',
uniqueid2='1503380654.2347',
```

I suggest compare UniqueId of two BridgeEnterEvent and
sort order of two CallerId/UniqueId/Channel.
