### PR TITLE
Asterisk 13 changes rtt to a float in manager

### DIFF
--- a/src/main/java/org/asteriskjava/manager/event/AbstractRtcpEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AbstractRtcpEvent.java
@@ -92,6 +92,11 @@ public abstract class AbstractRtcpEvent extends ManagerEvent
         {
             return null;
         }
+        
+        //things like RTT can be float/double in the event message in newer asterisk versions
+        if(s.contains(".")) {
+            return secStringToDouble(s).longValue();
+        }
 
         if (s.endsWith("(sec)"))
         {

--- a/src/main/java/org/asteriskjava/manager/event/AbstractRtcpEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AbstractRtcpEvent.java
@@ -94,7 +94,8 @@ public abstract class AbstractRtcpEvent extends ManagerEvent
         }
         
         //things like RTT can be float/double in the event message in newer asterisk versions
-        if(s.contains(".")) {
+        if(s.contains("."))
+        {
             return secStringToDouble(s).longValue();
         }
 


### PR DESCRIPTION
When running against asterisk 13 and chan_sip instead of chan_pjsip I start getting failures to parse rtt.  It looks like the manager events now have a float value for rtt.  I updated the secStringToLong to parse things with a . as a double and then downcast them.

I made and tested the changes against the 1.1 branch and that is what I am running on my system now.  They should be equally valid against master.