### PR TITLE
Remove unnessecary fields, setters, getters from descedant events

### DIFF
--- a/src/main/java/org/asteriskjava/manager/event/AbstractChannelEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AbstractChannelEvent.java
@@ -29,7 +29,7 @@ public abstract class AbstractChannelEvent extends ManagerEvent
      */
     static final long serialVersionUID = 5906599407896179295L;
 
-    private String accountCode;
+    protected String accountCode;
 
     /**
      * The name of the channel.

--- a/src/main/java/org/asteriskjava/manager/event/HangupEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/HangupEvent.java
@@ -35,8 +35,6 @@ public class HangupEvent extends AbstractChannelStateEvent
     private String language;
     private String linkedId;
     private String connectedlinenum;
-
-    private String accountCode;
     
     public HangupEvent(Object source)
     {
@@ -95,16 +93,6 @@ public class HangupEvent extends AbstractChannelStateEvent
     {
         this.causeTxt = causeTxt;
     }
-
-	public String getAccountCode() 
-	{
-		return accountCode;
-	}
-
-	public void setAccountCode(String accountCode) 
-	{
-		this.accountCode = accountCode;
-	}
 
     public String getLinkedId()
     {

--- a/src/main/java/org/asteriskjava/manager/event/NewChannelEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/NewChannelEvent.java
@@ -30,8 +30,6 @@ public class NewChannelEvent extends AbstractChannelStateEvent
      * Serializable version identifier.
      */
     static final long serialVersionUID = 1L;
-
-    private String accountCode;
     private String language;
     private String linkedid;
 
@@ -48,30 +46,6 @@ public class NewChannelEvent extends AbstractChannelStateEvent
     public void setLanguage(String language)
     {
         this.language = language;
-    }
-
-    /**
-     * Returns the account code of the new channel.
-     * <p>
-     * This property is available since Asterisk 1.6.
-     *
-     * @return the account code of the new channel.
-     * @since 1.0.0
-     */
-    public String getAccountCode()
-    {
-        return accountCode;
-    }
-
-    /**
-     * Sets the account code of the new channel.
-     *
-     * @param accountCode the account code of the new channel.
-     * @since 1.0.0
-     */
-    public void setAccountCode(String accountCode)
-    {
-        this.accountCode = accountCode;
     }
 
     public String getLinkedid()


### PR DESCRIPTION
Removing unnecessary code, as it already exists in the ancestor org.asteriskjava.manager.event.AbstractChannelEvent.
Furthermore, this unnecessary code prevents transforming events (org.asteriskjava.manager.event.NewChannelEvent, for example) to JSON-representation, because of the duplicate fields across inheritance of classes.