### PR TITLE
 Fixing BridgeEnterEvents order comparision (uniqueId can be prefixed)

### DIFF
--- a/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeEnterEventComparator.java
+++ b/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeEnterEventComparator.java
@@ -1,0 +1,38 @@
+package org.asteriskjava.manager.internal.backwardsCompatibility.bridge;
+
+import org.asteriskjava.manager.event.BridgeEnterEvent;
+
+import java.util.Comparator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class BridgeEnterEventComparator implements Comparator<BridgeEnterEvent> {
+
+	private static final String UNIQUE_ID_PATTERN = "([0-9]+)\\.([0-9]+)$";
+
+	@Override
+	public int compare(BridgeEnterEvent o1, BridgeEnterEvent o2) {
+		Pattern uniqueIdPattern = Pattern.compile(UNIQUE_ID_PATTERN);
+		Matcher uniqueId1Matcher = uniqueIdPattern.matcher(o1.getUniqueId());
+		Matcher uniqueId2Matcher = uniqueIdPattern.matcher(o2.getUniqueId());
+
+		boolean find1 = uniqueId1Matcher.find();
+		boolean find2 = uniqueId2Matcher.find();
+
+		if (find1 && find2) {
+			// 1501234567.890 -> epochtime: 1501234567 | serial: 890
+			long epochtime1 = Long.valueOf(uniqueId1Matcher.group(1));
+			long epochtime2 = Long.valueOf(uniqueId2Matcher.group(1));
+			int serial1 = Integer.valueOf(uniqueId1Matcher.group(2));
+			int serial2 = Integer.valueOf(uniqueId2Matcher.group(2));
+
+			return epochtime1 == epochtime2 ? Integer.compare(serial1, serial2) : Long.compare(epochtime1, epochtime2);
+		} else if (!find1 && !find2) {
+			// Both of inputs are invalid value: id1 == id2
+			return 0;
+		} else {
+			// id1 is valid ==> 1
+			return find1 ? 1 : -1;
+		}
+	}
+}

--- a/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeState.java
+++ b/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeState.java
@@ -1,12 +1,11 @@
 package org.asteriskjava.manager.internal.backwardsCompatibility.bridge;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.asteriskjava.manager.event.BridgeEnterEvent;
 import org.asteriskjava.manager.event.BridgeEvent;
@@ -18,15 +17,17 @@ import org.asteriskjava.util.LogFactory;
 /**
  * Track the current members of a bridge, emmitting BridgeEvents when 2 members
  * join or breakup
- * 
+ *
  * @author rsutton
  */
 class BridgeState
 {
-    final Log logger = LogFactory.getLog(getClass());
+	private final Log logger = LogFactory.getLog(getClass());
+
+	private static final BridgeEnterEventComparator BRIDGE_ENTER_EVENT_COMPARATOR = new BridgeEnterEventComparator();
 
     private final Map<String, BridgeEnterEvent> members = new HashMap<>();
-    
+
     ManagerEvent destroy()
     {
         synchronized (members) {
@@ -37,7 +38,7 @@ class BridgeState
 
     /**
      * if there are exactly 2 members in the bridge, return a BridgeEvent
-     * 
+     *
      * @param event
      * @return
      */
@@ -72,7 +73,7 @@ class BridgeState
 
     /**
      * If there are exactly 2 members in the bridge, return a BridgeEvent
-     * 
+     *
      * @param event
      * @return
      */
@@ -80,7 +81,7 @@ class BridgeState
     ManagerEvent removeMember(BridgeLeaveEvent event)
     {
         List<BridgeEnterEvent> remaining = null;
-        
+
         synchronized (members)
         {
             if (members.remove(event.getChannel()) != null
@@ -101,82 +102,23 @@ class BridgeState
                 BridgeEvent.BRIDGE_STATE_UNLINK,
                 remaining);
     }
-    
-    private BridgeEvent buildBridgeEvent(String bridgeState, List<BridgeEnterEvent> members)
-    {
-        BridgeEvent bridgeEvent = new BridgeEvent(this);
-        int index1, index2;
 
-        if (this.compareUniqueId(members.get(0).getUniqueId(),
-                                 members.get(1).getUniqueId()) < 0)
-        {
-            index1 = 0;
-            index2 = 1;
-        }
-        else
-        {
-            index1 = 1;
-            index2 = 0;
-        }
-        bridgeEvent.setCallerId1(members.get(index1).getCallerIdNum());
-        bridgeEvent.setUniqueId1(members.get(index1).getUniqueId());
-        bridgeEvent.setChannel1(members.get(index1).getChannel());
+	private BridgeEvent buildBridgeEvent(String bridgeState, List<BridgeEnterEvent> members) {
+		Collections.sort(members, BRIDGE_ENTER_EVENT_COMPARATOR);
 
-        bridgeEvent.setCallerId2(members.get(index2).getCallerIdNum());
-        bridgeEvent.setUniqueId2(members.get(index2).getUniqueId());
-        bridgeEvent.setChannel2(members.get(index2).getChannel());
+		BridgeEvent bridgeEvent = new BridgeEvent(this);
 
-        bridgeEvent.setBridgeState(bridgeState);
-        bridgeEvent.setDateReceived(new Date());
+		bridgeEvent.setCallerId1(members.get(0).getCallerIdNum());
+		bridgeEvent.setUniqueId1(members.get(0).getUniqueId());
+		bridgeEvent.setChannel1(members.get(0).getChannel());
 
-        return bridgeEvent;
-    }
+		bridgeEvent.setCallerId2(members.get(1).getCallerIdNum());
+		bridgeEvent.setUniqueId2(members.get(1).getUniqueId());
+		bridgeEvent.setChannel2(members.get(1).getChannel());
 
-    /**
-     * Compares two Asteirsk Unique ID.
-     *
-     * @param id1 1st Asterisk Unique ID, for example "1099015093.165".
-     * @param id2 2nd Asterisk Unique ID, for example "1099015093.166".
-     * @return Return 0 if id1 == id2.
-     * Return less then 0 if id1 < id2.
-     * Return greater then 0 if id1 > id2.
-     */
-    private int compareUniqueId(String id1, String id2)
-    {
-        Pattern uniqueIdPattern = Pattern.compile("^([0-9]+)\\.([0-9]+)$");
-        Matcher uniqueId1Matcher = uniqueIdPattern.matcher(id1);
-        Matcher uniqueId2Matcher = uniqueIdPattern.matcher(id2);
+		bridgeEvent.setBridgeState(bridgeState);
+		bridgeEvent.setDateReceived(new Date());
 
-        boolean find1 = uniqueId1Matcher.find();
-        boolean find2 = uniqueId2Matcher.find();
-
-        if (find1 && find2)
-        {
-            // 1501234567.890 -> epochtime: 1501234567 | serial: 890
-            long epochtime1 = Long.valueOf(uniqueId1Matcher.group(1));
-            long epochtime2 = Long.valueOf(uniqueId2Matcher.group(1));
-            int serial1 = Integer.valueOf(uniqueId1Matcher.group(2));
-            int serial2 = Integer.valueOf(uniqueId2Matcher.group(2));
-
-            if (epochtime1 == epochtime2)
-            {
-                return Integer.compare(serial1, serial2);
-            }
-
-            return Long.compare(epochtime1, epochtime2);
-
-        }
-        else if (!find1 && find2)
-        {
-            // id1 < id2
-            return -1;
-        }
-        else if (find1 && !find2)
-        {
-            // id1 > id2
-            return 1;
-        }
-        // Both of inputs are invalid value: id1 == id2
-        return 0;
-    }
+		return bridgeEvent;
+	}
 }

--- a/src/test/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeEnterEventComparatorTest.java
+++ b/src/test/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeEnterEventComparatorTest.java
@@ -1,0 +1,237 @@
+package org.asteriskjava.manager.internal.backwardsCompatibility.bridge;
+
+import org.asteriskjava.manager.event.BridgeEnterEvent;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BridgeEnterEventComparatorTest {
+
+	private BridgeEnterEventComparator bridgeEnterEventComparator = new BridgeEnterEventComparator();
+
+	@Test
+	public void withoutPrefix_shouldId2BeGreater() {
+		// given
+		BridgeEnterEvent bridgeEnterEvent1 = createBridgeEnterEvent("1515590350.29");
+		BridgeEnterEvent bridgeEnterEvent2 = createBridgeEnterEvent("1515590353.30");
+
+		// when
+		int compareResult = bridgeEnterEventComparator.compare(bridgeEnterEvent1, bridgeEnterEvent2);
+
+		// then
+		Assert.assertEquals(-1, compareResult);
+	}
+
+	@Test
+	public void withoutPrefix_shouldId1BeGreater() {
+		// given
+		BridgeEnterEvent bridgeEnterEvent1 = createBridgeEnterEvent("1515590353.30");
+		BridgeEnterEvent bridgeEnterEvent2 = createBridgeEnterEvent("1515590350.29");
+
+		// when
+		int compareResult = bridgeEnterEventComparator.compare(bridgeEnterEvent1, bridgeEnterEvent2);
+
+		// then
+		Assert.assertEquals(1, compareResult);
+	}
+
+	@Test
+	public void withoutPrefix_shouldId2BeGreaterForSameSerials() {
+		// given
+		BridgeEnterEvent bridgeEnterEvent1 = createBridgeEnterEvent("1515590350.30");
+		BridgeEnterEvent bridgeEnterEvent2 = createBridgeEnterEvent("1515590353.30");
+
+		// when
+		int compareResult = bridgeEnterEventComparator.compare(bridgeEnterEvent1, bridgeEnterEvent2);
+
+		// then
+		Assert.assertEquals(-1, compareResult);
+	}
+
+	@Test
+	public void withoutPrefix_shouldId1BeGreaterForSameSerials() {
+		// given
+		BridgeEnterEvent bridgeEnterEvent1 = createBridgeEnterEvent("1515590353.30");
+		BridgeEnterEvent bridgeEnterEvent2 = createBridgeEnterEvent("1515590350.30");
+
+		// when
+		int compareResult = bridgeEnterEventComparator.compare(bridgeEnterEvent1, bridgeEnterEvent2);
+
+		// then
+		Assert.assertEquals(1, compareResult);
+	}
+
+	@Test
+	public void withoutPrefix_shouldId2BeGreaterForSameEpoch() {
+		// given
+		BridgeEnterEvent bridgeEnterEvent1 = createBridgeEnterEvent("1515590353.29");
+		BridgeEnterEvent bridgeEnterEvent2 = createBridgeEnterEvent("1515590353.30");
+
+		// when
+		int compareResult = bridgeEnterEventComparator.compare(bridgeEnterEvent1, bridgeEnterEvent2);
+
+		// then
+		Assert.assertEquals(-1, compareResult);
+	}
+
+	@Test
+	public void withoutPrefix_shouldId1BeGreaterForSameEpoch() {
+		// given
+		BridgeEnterEvent bridgeEnterEvent1 = createBridgeEnterEvent("1515590353.30");
+		BridgeEnterEvent bridgeEnterEvent2 = createBridgeEnterEvent("1515590353.29");
+
+		// when
+		int compareResult = bridgeEnterEventComparator.compare(bridgeEnterEvent1, bridgeEnterEvent2);
+
+		// then
+		Assert.assertEquals(1, compareResult);
+	}
+
+	@Test
+	public void withoutPrefix_shouldIdsBeEqual() {
+		// given
+		BridgeEnterEvent bridgeEnterEvent1 = createBridgeEnterEvent("1515590353.30");
+		BridgeEnterEvent bridgeEnterEvent2 = createBridgeEnterEvent("1515590353.30");
+
+		// when
+		int compareResult = bridgeEnterEventComparator.compare(bridgeEnterEvent1, bridgeEnterEvent2);
+
+		// then
+		Assert.assertEquals(0, compareResult);
+	}
+
+	@Test
+	public void withPrefix_shouldId2BeGreater() {
+		// given
+		BridgeEnterEvent bridgeEnterEvent1 = createBridgeEnterEvent("some_prefix-1515590350.29");
+		BridgeEnterEvent bridgeEnterEvent2 = createBridgeEnterEvent("some_prefix-1515590353.30");
+
+		// when
+		int compareResult = bridgeEnterEventComparator.compare(bridgeEnterEvent1, bridgeEnterEvent2);
+
+		// then
+		Assert.assertEquals(-1, compareResult);
+	}
+
+	@Test
+	public void withPrefix_shouldId1BeGreater() {
+		// given
+		BridgeEnterEvent bridgeEnterEvent1 = createBridgeEnterEvent("some_prefix-1515590353.30");
+		BridgeEnterEvent bridgeEnterEvent2 = createBridgeEnterEvent("some_prefix-1515590350.29");
+
+		// when
+		int compareResult = bridgeEnterEventComparator.compare(bridgeEnterEvent1, bridgeEnterEvent2);
+
+		// then
+		Assert.assertEquals(1, compareResult);
+	}
+
+	@Test
+	public void withPrefix_shouldId2BeGreaterForSameSerials() {
+		// given
+		BridgeEnterEvent bridgeEnterEvent1 = createBridgeEnterEvent("some_prefix-1515590350.30");
+		BridgeEnterEvent bridgeEnterEvent2 = createBridgeEnterEvent("some_prefix-1515590353.30");
+
+		// when
+		int compareResult = bridgeEnterEventComparator.compare(bridgeEnterEvent1, bridgeEnterEvent2);
+
+		// then
+		Assert.assertEquals(-1, compareResult);
+	}
+
+	@Test
+	public void withPrefix_shouldId1BeGreaterForSameSerials() {
+		// given
+		BridgeEnterEvent bridgeEnterEvent1 = createBridgeEnterEvent("some_prefix-1515590353.30");
+		BridgeEnterEvent bridgeEnterEvent2 = createBridgeEnterEvent("some_prefix-1515590350.30");
+
+		// when
+		int compareResult = bridgeEnterEventComparator.compare(bridgeEnterEvent1, bridgeEnterEvent2);
+
+		// then
+		Assert.assertEquals(1, compareResult);
+	}
+
+	@Test
+	public void withPrefix_shouldId2BeGreaterForSameEpoch() {
+		// given
+		BridgeEnterEvent bridgeEnterEvent1 = createBridgeEnterEvent("some_prefix-1515590350.29");
+		BridgeEnterEvent bridgeEnterEvent2 = createBridgeEnterEvent("some_prefix-1515590350.30");
+
+		// when
+		int compareResult = bridgeEnterEventComparator.compare(bridgeEnterEvent1, bridgeEnterEvent2);
+
+		// then
+		Assert.assertEquals(-1, compareResult);
+	}
+
+	@Test
+	public void withPrefix_shouldId1BeGreaterForSameEpoch() {
+		// given
+		BridgeEnterEvent bridgeEnterEvent1 = createBridgeEnterEvent("some_prefix-1515590350.30");
+		BridgeEnterEvent bridgeEnterEvent2 = createBridgeEnterEvent("some_prefix-1515590350.29");
+
+		// when
+		int compareResult = bridgeEnterEventComparator.compare(bridgeEnterEvent1, bridgeEnterEvent2);
+
+		// then
+		Assert.assertEquals(1, compareResult);
+	}
+
+	@Test
+	public void withPrefix_shouldIdsBeEqual() {
+		// given
+		BridgeEnterEvent bridgeEnterEvent1 = createBridgeEnterEvent("some_prefix-1515590353.30");
+		BridgeEnterEvent bridgeEnterEvent2 = createBridgeEnterEvent("some_prefix-1515590353.30");
+
+		// when
+		int compareResult = bridgeEnterEventComparator.compare(bridgeEnterEvent1, bridgeEnterEvent2);
+
+		// then
+		Assert.assertEquals(0, compareResult);
+	}
+
+	@Test
+	public void shouldBothIdsDoesNotMatchPattern() {
+		// given
+		BridgeEnterEvent bridgeEnterEvent1 = createBridgeEnterEvent("some_id_1");
+		BridgeEnterEvent bridgeEnterEvent2 = createBridgeEnterEvent("some_id_2");
+
+		// when
+		int compareResult = bridgeEnterEventComparator.compare(bridgeEnterEvent1, bridgeEnterEvent2);
+
+		// then
+		Assert.assertEquals(0, compareResult);
+	}
+
+	@Test
+	public void shouldId1DoesNotMatchPattern() {
+		// given
+		BridgeEnterEvent bridgeEnterEvent1 = createBridgeEnterEvent("some_id_1");
+		BridgeEnterEvent bridgeEnterEvent2 = createBridgeEnterEvent("some_prefix-1515590353.30");
+
+		// when
+		int compareResult = bridgeEnterEventComparator.compare(bridgeEnterEvent1, bridgeEnterEvent2);
+
+		// then
+		Assert.assertEquals(-1, compareResult);
+	}
+
+	@Test
+	public void shouldId2DoesNotMatchPattern() {
+		// given
+		BridgeEnterEvent bridgeEnterEvent1 = createBridgeEnterEvent("some_prefix-1515590353.30");
+		BridgeEnterEvent bridgeEnterEvent2 = createBridgeEnterEvent("some_id_2");
+
+		// when
+		int compareResult = bridgeEnterEventComparator.compare(bridgeEnterEvent1, bridgeEnterEvent2);
+
+		// then
+		Assert.assertEquals(1, compareResult);
+	}
+
+	private static BridgeEnterEvent createBridgeEnterEvent(String uniqueId) {
+		BridgeEnterEvent bridgeEnterEvent = new BridgeEnterEvent(new Object());
+		bridgeEnterEvent.setUniqueId(uniqueId);
+		return bridgeEnterEvent;
+	}
+}


### PR DESCRIPTION
UniqueId field in BridgeEnterEvent can be prefixed. Prefix can be enabled by setting following properties in asterisk.conf file:
- systemname={prefix} ("Prefix uniqueid with a system name for Global uniqueness issues")
- autosystemname="yes" ("Automatically set systemname to hostname, uses 'localhost' on failure, or systemname if set")

If such prefix is used in Asterisk, previous comparison (uniquedId has to begin with epoch time) always fails. I have fixed that by removing "^" from beginning of pattern. Additionally, I have added some refactoring with tests.