### PR TITLE
Replaced slow Scanner by LineReader (own implementation)

### DIFF
--- a/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
@@ -670,7 +670,7 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
             if (Asterisk14outputPresent)
             {
                 List<String> outputList = Arrays
-                        .asList(showVersionFilesResponse.getOutput().split(SocketConnectionFacadeImpl.NL_PATTERN.pattern()));
+                        .asList(showVersionFilesResponse.getOutput().split(Pattern.quote(SocketConnectionFacadeImpl.NL_PATTERN)));
                 showVersionFilesResult = outputList;
             }
             else

--- a/src/main/java/org/asteriskjava/util/internal/LineReader.java
+++ b/src/main/java/org/asteriskjava/util/internal/LineReader.java
@@ -1,0 +1,161 @@
+package org.asteriskjava.util.internal;
+
+import java.io.IOException;
+import java.io.Reader;
+
+public class LineReader extends Reader
+{
+	private Reader in;
+	private char[] pattern;
+	private char[] cbuf;
+	private int off, len;
+
+	/**
+	 * @param pattern the pattern used as delimiter for line breaks in {@link #readLine()}
+	 */
+	public LineReader(Reader in, String pattern)
+	{
+		if (pattern.isEmpty())
+		{
+			throw new IllegalArgumentException("pattern must not be empty");
+		}
+		this.in = in;
+		this.pattern = pattern.toCharArray();
+		cbuf = new char[8192 + pattern.length()];
+	}
+
+	@Override
+	public void close() throws IOException
+	{
+		synchronized (lock)
+		{
+			if (in == null)
+			{
+				return;
+			}
+			try
+			{
+				in.close();
+			}
+			finally
+			{
+				// free memory
+				in = null;
+				pattern = null;
+				cbuf = null;
+
+				// disable reading
+				len = -1;
+			}
+		}
+	}
+
+	@Override
+	public int read(char[] cbuf, int off, int len) throws IOException
+	{
+		if (len <= 0)
+		{
+			return 0;
+		}
+		if (off < 0 || off + len >= cbuf.length)
+		{
+			throw new ArrayIndexOutOfBoundsException();
+		}
+		synchronized (lock)
+		{
+			// fill buffer from stream
+			if (this.len == 0)
+			{
+				this.off = 0;
+				this.len = in.read(this.cbuf);
+			}
+
+			// end of stream?
+			if (this.len < 0)
+			{
+				// free memory
+				pattern = null;
+				this.cbuf = null;
+				return -1;
+			}
+
+			// copy buffer to result
+			len = Math.min(len, this.len);
+			System.arraycopy(this.cbuf, this.off, cbuf, off, len);
+			this.off += len;
+			this.len -= len;
+			return len;
+		}
+	}
+
+	/**
+	 * Reads a line of text.
+	 * A line is considered to be terminated by {@link #pattern}.
+	 *
+	 * @return A String containing the contents of the line, not including the pattern {@link #pattern}, or null if the end of the stream has been reached
+	 * @exception IOException If an I/O error occurs
+	 * @see java.io.BufferedReader#readLine()
+	 */
+	public String readLine() throws IOException
+	{
+		synchronized (lock)
+		{
+			if (len < 0)
+			{
+				return null;
+			}
+
+			StringBuilder result = new StringBuilder(80);
+			while (true)
+			{
+				// search pattern in buffer
+				int matches = 0;
+				int limit = len - off;
+				for (int i = off; i < limit; )
+				{
+					if (cbuf[i++] == pattern[matches])
+					{
+						matches++;
+						if (matches == pattern.length)
+						{
+							int size = i - off;
+							result.append(cbuf, off, size - matches);
+							off += size;
+							len -= size;
+							return result.toString();
+						}
+					}
+					else
+					{
+						// backtrack
+						i -= matches;
+						matches = 0;
+					}
+				}
+
+				// copy buffer to result except for matched suffix
+				result.append(cbuf, off, len - matches);
+
+				// fill buffer from stream
+				// (leaving some space to prepend matched suffix later)
+				len = in.read(cbuf, matches, cbuf.length - matches);
+
+				// end of stream?
+				if (len < 0)
+				{
+					// append matched suffix
+					result.append(pattern, 0, matches);
+					// free memory
+					pattern = null;
+					cbuf = null;
+					return result.length() > 0 ? result.toString() : null;
+				}
+
+				// prepend previously matched suffix as new prefix (for search during next iteration)
+				System.arraycopy(pattern, 0, cbuf, 0, matches);
+				off = 0;
+				len += matches; // chars from stream + previously matched suffix
+			}
+		}
+	}
+}

--- a/src/test/java/org/asteriskjava/util/internal/LineReaderTest.java
+++ b/src/test/java/org/asteriskjava/util/internal/LineReaderTest.java
@@ -1,0 +1,91 @@
+package org.asteriskjava.util.internal;
+
+import java.io.BufferedWriter;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.NoSuchElementException;
+import java.util.Scanner;
+import java.util.regex.Pattern;
+
+/**
+ * @author sere
+ * @since 2018-01-30
+ */
+public class LineReaderTest {
+	public static void main(String[] args) throws Exception {
+		final byte[] bytes = new byte[1000_000_000];
+		byte[] str = "Hallo hello: one line with text!\r\n".getBytes(StandardCharsets.US_ASCII);
+		for (int i = 0; i < bytes.length; i += str.length) {
+			System.arraycopy(str, 0, bytes, i, str.length);
+		}
+
+		for (int i = 10; i-- > 0; ) {
+			System.out.print(i + ":\t");
+
+			InputStream inputStream = new ByteArrayInputStream(bytes);
+
+			LineReader reader = new LineReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8), "\r\n");
+			Scanner scanner = new Scanner(reader);
+			scanner.useDelimiter(Pattern.compile("\r\n"));
+
+			long start = System.currentTimeMillis();
+			try {
+				while (reader.readLine() != null) {
+				}
+			} catch (NoSuchElementException e) {
+			}
+			System.out.println((System.currentTimeMillis() - start));
+		}
+	}
+
+	public static void main2(String[] args) throws IOException {
+		Charset charset = StandardCharsets.UTF_8;
+		PipedOutputStream out = new PipedOutputStream();
+		final BufferedWriter w = new BufferedWriter(new OutputStreamWriter(out, charset));
+		LineReader r = new LineReader(new InputStreamReader(new PipedInputStream(out), charset), "123");
+
+		new Thread() {
+			@Override
+			public void run() {
+				try {
+					write("ab");
+					write("12");
+					write("3");
+					write("ab");
+					write("12");
+					write("ab");
+					write("121");
+					write("2");
+					write("3");
+					write("321");
+					write("2312");
+
+					System.out.println("--");
+					w.close();
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+
+			private void write(String s) throws Exception {
+				System.out.println("<< " + s);
+				w.write(s);
+				w.flush();
+				Thread.sleep(1000);
+			}
+		}.start();
+
+		System.out.println("1: " + r.readLine());
+		System.out.println("2: " + r.readLine());
+		System.out.println("3: " + r.readLine());
+		System.out.println("4: " + r.readLine());
+		System.out.println("5: " + r.readLine());
+	}
+}


### PR DESCRIPTION
When we did a test with heavy load (and tons of events), it turned out that the `Scanner` used in `SocketConnectionFacadeImpl` is slow and burns CPU.

I first removed the `Scanner` and used the underlaying `BufferedReader`, but this broke the detection of line endings.
So I ended up with replacing the combination of `BufferedReader` and `Scanner` by an own implementation called `LineReader`. It behaves like a `BufferedReader` except for a custom pattern for line endings.

BTW: for the implementation, I also had to migrate the patterns from regex to string

I did some benchmarks of how long it takes to slice 1GB of text into lines (see `LineReaderTest`):
13140ms	BufferedReader+Scanner
1768ms	LineReader
1678ms	BufferedReader
