### PR TITLE
Remove dead code from AbstractBuilder.setAttributes()

### DIFF
--- a/src/main/java/org/asteriskjava/manager/internal/AbstractBuilder.java
+++ b/src/main/java/org/asteriskjava/manager/internal/AbstractBuilder.java
@@ -54,15 +54,6 @@ abstract class AbstractBuilder
                 setterName = "clazz";
             }
 
-            /*
-             * The class property needs to be renamed. It is used in
-             * MusicOnHoldEvent.
-             */
-            if ("class".equals(setterName))
-            {
-                setterName = "classname";
-            }
-
             setter = setters.get(setterName);
 
             if (setter == null && !setterName.endsWith("s")) // no exact match


### PR DESCRIPTION
The lines above this already change 'class' -> 'clazz' so this block
can never be executed.

Signed-off-by: Sean Bright <sean@callshaper.com>