### PR TITLE
Refactor version detection support

### DIFF
--- a/src/main/java/org/asteriskjava/AsteriskVersion.java
+++ b/src/main/java/org/asteriskjava/AsteriskVersion.java
@@ -31,17 +31,11 @@ public class AsteriskVersion implements Comparable<AsteriskVersion>, Serializabl
     private static final String VERSION_PATTERN_15 = "^\\s*Asterisk (GIT-)?15[-. ].*";
     private static final String VERSION_PATTERN_14 = "^\\s*Asterisk (GIT-)?14[-. ].*";
     private static final String VERSION_PATTERN_13 = "^\\s*Asterisk ((SVN-branch|GIT)-)?13[-. ].*";
-    private static final String VERSION_PATTERN_12 = "^\\s*Asterisk ((SVN-branch|GIT)-)?12[-. ].*";
-    private static final String VERSION_PATTERN_11 = "^\\s*Asterisk ((SVN-branch|GIT)-)?11[-. ].*";
-    private static final String VERSION_PATTERN_10 = "^\\s*Asterisk ((SVN-branch|GIT)-)?10[-. ].*";
-    private static final String VERSION_PATTERN_1_8 = "^\\s*Asterisk ((SVN-branch|GIT)-)?1\\.8[-. ].*";
-    private static final String VERSION_PATTERN_1_6 = "^\\s*Asterisk ((SVN-branch|GIT)-)?1\\.6[-. ].*";
     private final int version;
     private final String versionString;
     private final Pattern patterns[];
 
     private static final String VERSION_PATTERN_CERTIFIED_13 = "^\\s*Asterisk certified/((SVN-branch|GIT)-)?13[-. ].*";
-    private static final String VERSION_PATTERN_CERTIFIED_11 = "^\\s*Asterisk certified/((SVN-branch|GIT)-)?11[-. ].*";
 
     /**
      * Represents the Asterisk 1.0 series.
@@ -65,36 +59,35 @@ public class AsteriskVersion implements Comparable<AsteriskVersion>, Serializabl
      *
      * @since 1.0.0
      */
-    public static final AsteriskVersion ASTERISK_1_6 = new AsteriskVersion(160, "Asterisk 1.6", VERSION_PATTERN_1_6);
+    public static final AsteriskVersion ASTERISK_1_6 = new AsteriskVersion(160, "Asterisk 1.6", new String[]{});
 
     /**
      * Represents the Asterisk 1.8 series.
      *
      * @since 1.0.0
      */
-    public static final AsteriskVersion ASTERISK_1_8 = new AsteriskVersion(180, "Asterisk 1.8", VERSION_PATTERN_1_8);
+    public static final AsteriskVersion ASTERISK_1_8 = new AsteriskVersion(180, "Asterisk 1.8", new String[]{});
 
     /**
      * Represents the Asterisk 10 series.
      *
      * @since 1.0.0
      */
-    public static final AsteriskVersion ASTERISK_10 = new AsteriskVersion(1000, "Asterisk 10", VERSION_PATTERN_10);
+    public static final AsteriskVersion ASTERISK_10 = new AsteriskVersion(1000, "Asterisk 10", new String[]{});
 
     /**
      * Represents the Asterisk 11 series.
      *
      * @since 1.0.0
      */
-    public static final AsteriskVersion ASTERISK_11 = new AsteriskVersion(1100, "Asterisk 11",
-            new String[]{VERSION_PATTERN_11, VERSION_PATTERN_CERTIFIED_11});
+    public static final AsteriskVersion ASTERISK_11 = new AsteriskVersion(1100, "Asterisk 11", new String[]{});
 
     /**
      * Represents the Asterisk 12 series.
      *
      * @since 1.0.0
      */
-    public static final AsteriskVersion ASTERISK_12 = new AsteriskVersion(1200, "Asterisk 12", VERSION_PATTERN_12);
+    public static final AsteriskVersion ASTERISK_12 = new AsteriskVersion(1200, "Asterisk 12", new String[]{});
 
     /**
      * Represents the Asterisk 13 series.
@@ -118,8 +111,10 @@ public class AsteriskVersion implements Comparable<AsteriskVersion>, Serializabl
      */
     public static final AsteriskVersion ASTERISK_15 = new AsteriskVersion(1500, "Asterisk 15", VERSION_PATTERN_15);
 
-    private static final AsteriskVersion knownVersions[] = new AsteriskVersion[]{ASTERISK_15, ASTERISK_14, ASTERISK_13,
-            ASTERISK_12, ASTERISK_11, ASTERISK_10, ASTERISK_1_8, ASTERISK_1_6};
+    private static final AsteriskVersion knownVersions[] = new AsteriskVersion[]{ASTERISK_15, ASTERISK_14, ASTERISK_13};
+
+    // current debian stable version, as of 03/07/2018
+    public static final AsteriskVersion DEFAULT_VERSION = ASTERISK_13;
 
     /**
      * Serial version identifier.
@@ -191,14 +186,14 @@ public class AsteriskVersion implements Comparable<AsteriskVersion>, Serializabl
         return versionString;
     }
 
-	/**
-	 * Determine the Asterisk version from the string returned by Asterisk.
-	 * The string should contain "Asterisk " followed by a version number.
-	 *
-	 * @param coreLine
-	 * @return the detected version, or null if unknown
-	 */
-	public static AsteriskVersion getDetermineVersionFromString(String coreLine)
+    /**
+     * Determine the Asterisk version from the string returned by Asterisk.
+     * The string should contain "Asterisk " followed by a version number.
+     *
+     * @param coreLine
+     * @return the detected version, or null if unknown
+     */
+    public static AsteriskVersion getDetermineVersionFromString(String coreLine)
     {
         for (AsteriskVersion version : knownVersions)
         {

--- a/src/main/java/org/asteriskjava/fastagi/internal/AgiChannelImpl.java
+++ b/src/main/java/org/asteriskjava/fastagi/internal/AgiChannelImpl.java
@@ -145,8 +145,8 @@ public class AgiChannelImpl implements AgiChannel
     {
         if (request == null)
         {
-            logger.warn("Request is null, I assume you're testing... returning AsteriskVersion 1.4");
-            return AsteriskVersion.ASTERISK_1_4;
+            logger.warn("Request is null, I assume you're testing...");
+            return AsteriskVersion.DEFAULT_VERSION;
         }
         if (asteriskVersion == null)
         {

--- a/src/main/java/org/asteriskjava/fastagi/internal/AgiRequestImpl.java
+++ b/src/main/java/org/asteriskjava/fastagi/internal/AgiRequestImpl.java
@@ -38,7 +38,7 @@ import org.asteriskjava.util.LogFactory;
 
 /**
  * Default implementation of the AGIRequest interface.
- *
+ * 
  * @author srt
  * @version $Id$
  */
@@ -107,7 +107,7 @@ public class AgiRequestImpl implements AgiRequest
      * prefix stripped) and the corresponding values.
      * <p>
      * Syntactically invalid and empty variables are skipped.
-     *
+     * 
      * @param lines the environment to transform.
      * @return a map with the variables set corresponding to the given
      *         environment.
@@ -169,7 +169,7 @@ public class AgiRequestImpl implements AgiRequest
 
     /**
      * Returns the name of the script to execute.
-     *
+     * 
      * @return the name of the script to execute.
      */
     public synchronized String getScript()
@@ -180,7 +180,7 @@ public class AgiRequestImpl implements AgiRequest
     /**
      * Returns the full URL of the request in the form
      * agi://host[:port][/script].
-     *
+     * 
      * @return the full URL of the request in the form
      *         agi://host[:port][/script].
      */
@@ -192,13 +192,13 @@ public class AgiRequestImpl implements AgiRequest
     @Override
     public AsteriskVersion getAsteriskVersion()
     {
-    	AsteriskVersion detected = AsteriskVersion.getDetermineVersionFromString("Asterisk " + request.get("version"));
-    	return detected != null ? detected : ManagerConnectionImpl.DEFAULT_ASTERISK_VERSION;
+        AsteriskVersion detected = AsteriskVersion.getDetermineVersionFromString("Asterisk " + request.get("version"));
+        return detected != null ? detected : AsteriskVersion.DEFAULT_VERSION;
     }
 
     /**
      * Returns the name of the channel.
-     *
+     * 
      * @return the name of the channel.
      */
     public String getChannel()
@@ -208,7 +208,7 @@ public class AgiRequestImpl implements AgiRequest
 
     /**
      * Returns the unqiue id of the channel.
-     *
+     * 
      * @return the unqiue id of the channel.
      */
     public String getUniqueId()
@@ -274,7 +274,7 @@ public class AgiRequestImpl implements AgiRequest
 
     /**
      * Returns the Caller*ID number using Asterisk 1.0 logic.
-     *
+     * 
      * @return the Caller*ID number
      */
     private synchronized String getCallerId10()
@@ -297,7 +297,7 @@ public class AgiRequestImpl implements AgiRequest
 
     /**
      * Returns the Caller*ID name using Asterisk 1.0 logic.
-     *
+     * 
      * @return the Caller*ID name
      */
     private synchronized String getCallerIdName10()
@@ -480,7 +480,7 @@ public class AgiRequestImpl implements AgiRequest
 
     /**
      * Parses the given parameter string and caches the result.
-     *
+     * 
      * @param s the parameter string to parse
      * @return a Map made up of parameter names their values
      */

--- a/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
@@ -83,9 +83,6 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
 
     private static final AtomicLong idCounter = new AtomicLong(0);
 
-    // current debian stable version, as of 03/07/2018
-    public static final AsteriskVersion DEFAULT_ASTERISK_VERSION = AsteriskVersion.ASTERISK_13;
-
     /**
      * Instance logger.
      */
@@ -644,8 +641,8 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
             } // NOPMD
         }
 
-        logger.error("Unable to determine asterisk version, assuming " + DEFAULT_ASTERISK_VERSION + "... you should expect problems to follow.");
-        return DEFAULT_ASTERISK_VERSION;
+        logger.error("Unable to determine asterisk version, assuming " + AsteriskVersion.DEFAULT_VERSION + "... you should expect problems to follow.");
+        return AsteriskVersion.DEFAULT_VERSION;
     }
 
     /**
@@ -789,7 +786,7 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
 
     /**
      * Implements synchronous sending of "simple" actions.
-     *
+     * 
      * @param timeout - in milliseconds
      */
     public ManagerResponse sendAction(ManagerAction action, long timeout)
@@ -1308,13 +1305,9 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
     {
         logger.info("Connected via " + identifier);
 
-        if (!"Asterisk Call Manager/1.0".equals(identifier) && !"Asterisk Call Manager/1.1".equals(identifier) // Asterisk
-                                                                                                               // 1.6
-                && !"Asterisk Call Manager/1.2".equals(identifier) // bri
-                                                                   // stuffed
-                && !"Asterisk Call Manager/1.3".equals(identifier) // Asterisk
-                                                                   // 11
-                && !"Asterisk Call Manager/2.6.0".equals(identifier) // Asterisk
+        // NOTE: value is AMI_VERSION, defined in include/asterisk/manager.h
+
+        if (!"Asterisk Call Manager/2.6.0".equals(identifier) // Asterisk
                                                                      // 13
                 && !"Asterisk Call Manager/2.7.0".equals(identifier) // Asterisk
                                                                      // 13.2
@@ -1332,6 +1325,7 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
                 && !"Asterisk Call Manager/4.0.0".equals(identifier) // since Asterisk 15
                 && !"Asterisk Call Manager/4.0.1".equals(identifier) // since Asterisk 15.1
                 && !"Asterisk Call Manager/4.0.2".equals(identifier) // since Asterisk 15.2
+                && !"Asterisk Call Manager/4.0.3".equals(identifier) // since Asterisk 15.3
 
                 && !"OpenPBX Call Manager/1.0".equals(identifier) && !"CallWeaver Call Manager/1.0".equals(identifier)
                 && !(identifier != null && identifier.startsWith("Asterisk Call Manager Proxy/")))

--- a/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
@@ -32,14 +32,12 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.asteriskjava.AsteriskVersion;
@@ -52,13 +50,7 @@ import org.asteriskjava.manager.ManagerEventListener;
 import org.asteriskjava.manager.ResponseEvents;
 import org.asteriskjava.manager.SendActionCallback;
 import org.asteriskjava.manager.TimeoutException;
-import org.asteriskjava.manager.action.ChallengeAction;
-import org.asteriskjava.manager.action.CommandAction;
-import org.asteriskjava.manager.action.EventGeneratingAction;
-import org.asteriskjava.manager.action.LoginAction;
-import org.asteriskjava.manager.action.LogoffAction;
-import org.asteriskjava.manager.action.ManagerAction;
-import org.asteriskjava.manager.action.UserEventAction;
+import org.asteriskjava.manager.action.*;
 import org.asteriskjava.manager.event.ConnectEvent;
 import org.asteriskjava.manager.event.DialBeginEvent;
 import org.asteriskjava.manager.event.DialEvent;
@@ -66,10 +58,7 @@ import org.asteriskjava.manager.event.DisconnectEvent;
 import org.asteriskjava.manager.event.ManagerEvent;
 import org.asteriskjava.manager.event.ProtocolIdentifierReceivedEvent;
 import org.asteriskjava.manager.event.ResponseEvent;
-import org.asteriskjava.manager.response.ChallengeResponse;
-import org.asteriskjava.manager.response.CommandResponse;
-import org.asteriskjava.manager.response.ManagerError;
-import org.asteriskjava.manager.response.ManagerResponse;
+import org.asteriskjava.manager.response.*;
 import org.asteriskjava.util.DateUtil;
 import org.asteriskjava.util.Log;
 import org.asteriskjava.util.LogFactory;
@@ -91,7 +80,7 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
     private static final int DEFAULT_PORT = 5038;
     private static final int RECONNECTION_VERSION_INTERVAL = 500;
     private static final int MAX_VERSION_ATTEMPTS = 4;
-    private static final Pattern SHOW_VERSION_PATTERN = Pattern.compile("^(core )?show version.*");
+    private static final String CMD_SHOW_VERSION = "core show version";
 
     private static final Pattern VERSION_PATTERN_1_6 = Pattern.compile("^\\s*Asterisk ((SVN-branch|GIT)-)?1\\.6[-. ].*");
     private static final Pattern VERSION_PATTERN_1_8 = Pattern.compile("^\\s*Asterisk ((SVN-branch|GIT)-)?1\\.8[-. ].*");
@@ -107,6 +96,9 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
     private static final Pattern VERSION_PATTERN_15 = Pattern.compile("^\\s*Asterisk (GIT-)?15[-. ].*");
 
     private static final AtomicLong idCounter = new AtomicLong(0);
+
+    // current debian stable version, as of 03/07/2018
+    private static final AsteriskVersion DEFAULT_ASTERISK_VERSION = AsteriskVersion.ASTERISK_13;
 
     /**
      * Instance logger.
@@ -640,166 +632,129 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
     {
         int attempts = 0;
 
-        // if ("Asterisk Call Manager/1.1".equals(protocolIdentifier.value))
-        // {
-        // return AsteriskVersion.ASTERISK_1_6;
-        // }
+        logger.info("Got asterisk protocol identifier version " + protocolIdentifier.getValue());
 
         while (attempts++ < MAX_VERSION_ATTEMPTS)
         {
-            final ManagerResponse showVersionFilesResponse;
-            final List<String> showVersionFilesResult;
-            boolean Asterisk14outputPresent = false;
-            // increase timeout as output is quite large
-            showVersionFilesResponse = sendAction(new CommandAction("show version files pbx.c"), defaultResponseTimeout * 2);
-            if (!(showVersionFilesResponse instanceof CommandResponse))
-            {
-                // return early in case of permission problems
-                // org.asteriskjava.manager.response.ManagerError:
-                // actionId='null'; message='Permission denied';
-                // response='Error';
-                // uniqueId='null'; systemHashcode=15231583
-                if (showVersionFilesResponse.getOutput() != null)
-                {
-                    Asterisk14outputPresent = true;
-                }
-                else
-                {
-                    break;
-                }
+            try {
+                AsteriskVersion version = determineVersionByCoreSettings();
+                if (version != null) return version;
+            } catch (Exception e) {
             }
-            if (Asterisk14outputPresent)
-            {
-                List<String> outputList = Arrays
-                        .asList(showVersionFilesResponse.getOutput().split(SocketConnectionFacadeImpl.NL_PATTERN.pattern()));
-                showVersionFilesResult = outputList;
+
+            try {
+                AsteriskVersion version = determineVersionByCoreShowVersion();
+                if (version != null) return version;
+            } catch (Exception e) {
             }
-            else
+
+            try
             {
-                showVersionFilesResult = ((CommandResponse) showVersionFilesResponse).getResult();
+                Thread.sleep(RECONNECTION_VERSION_INTERVAL);
             }
-            if (showVersionFilesResult != null && !showVersionFilesResult.isEmpty())
+            catch (Exception ex)
             {
-                final String line1 = showVersionFilesResult.get(0);
-
-                if (line1 != null && line1.startsWith("File"))
-                {
-                    final String rawVersion;
-
-                    rawVersion = getRawVersion();
-                    if (rawVersion != null && rawVersion.startsWith("Asterisk 1.4"))
-                    {
-                        return AsteriskVersion.ASTERISK_1_4;
-                    }
-                    return AsteriskVersion.ASTERISK_1_2;
-                }
-                else if (line1 != null && line1.contains("No such command"))
-                {
-
-                    final ManagerResponse coreShowVersionResponse = sendAction(new CommandAction("core show version"),
-                            defaultResponseTimeout * 2);
-
-                    if (coreShowVersionResponse != null && coreShowVersionResponse instanceof CommandResponse)
-                    {
-                        final List<String> coreShowVersionResult = ((CommandResponse) coreShowVersionResponse).getResult();
-
-                        if (coreShowVersionResult != null && !coreShowVersionResult.isEmpty())
-                        {
-                            final String coreLine = coreShowVersionResult.get(0);
-
-                            if (VERSION_PATTERN_1_6.matcher(coreLine).matches())
-                            {
-                                return AsteriskVersion.ASTERISK_1_6;
-                            }
-                            else if (VERSION_PATTERN_1_8.matcher(coreLine).matches())
-                            {
-                                return AsteriskVersion.ASTERISK_1_8;
-                            }
-                            else if (VERSION_PATTERN_10.matcher(coreLine).matches())
-                            {
-                                return AsteriskVersion.ASTERISK_10;
-                            }
-                            else if (VERSION_PATTERN_11.matcher(coreLine).matches())
-                            {
-                                return AsteriskVersion.ASTERISK_11;
-                            }
-                            else if (VERSION_PATTERN_CERTIFIED_11.matcher(coreLine).matches())
-                            {
-                                return AsteriskVersion.ASTERISK_11;
-                            }
-                            else if (VERSION_PATTERN_12.matcher(coreLine).matches())
-                            {
-                                return AsteriskVersion.ASTERISK_12;
-                            }
-                            else if (VERSION_PATTERN_13.matcher(coreLine).matches())
-                            {
-                                return AsteriskVersion.ASTERISK_13;
-                            }
-                            else if (VERSION_PATTERN_CERTIFIED_13.matcher(coreLine).matches())
-                            {
-                                return AsteriskVersion.ASTERISK_13;
-                            }
-                            else if (VERSION_PATTERN_14.matcher(coreLine).matches())
-                            {
-                                return AsteriskVersion.ASTERISK_14;
-                            }
-                            else if (VERSION_PATTERN_15.matcher(coreLine).matches())
-                            {
-                                return AsteriskVersion.ASTERISK_15;
-                            }
-                        }
-                    }
-
-                    try
-                    {
-                        Thread.sleep(RECONNECTION_VERSION_INTERVAL);
-                    }
-                    catch (Exception ex)
-                    {
-                        // ingnore
-                    } // NOPMD
-                }
-                else
-                {
-                    // if it isn't the "no such command", break and return the
-                    // lowest version immediately
-                    break;
-                }
-            }
+                // ignore
+            } // NOPMD
         }
 
-        // TODO: add retry logic; in a reconnect scenario the version fails to
-        // be identified leading to errors
-
-        // as a fallback assume 1.6
-        logger.error("Unable to determine asterisk version, assuming 1.6... you should expect problems to follow.");
-        return AsteriskVersion.ASTERISK_1_6;
+        logger.error("Unable to determine asterisk version, assuming " + DEFAULT_ASTERISK_VERSION + "... you should expect problems to follow.");
+        return DEFAULT_ASTERISK_VERSION;
     }
 
-    protected String getRawVersion()
-    {
-        final ManagerResponse showVersionResponse;
+    /**
+     * Get asterisk version by 'core settings' actions.
+     * This is supported from Asterisk 1.6 onwards.
+     *
+     * @return
+     * @throws Exception
+     */
+    protected AsteriskVersion determineVersionByCoreSettings() throws Exception {
 
-        try
-        {
-            showVersionResponse = sendAction(new CommandAction("show version"), defaultResponseTimeout * 2);
-        }
-        catch (Exception e)
-        {
+        ManagerResponse response = sendAction(new CoreSettingsAction());
+        if (!(response instanceof CoreSettingsResponse)) {
+            // NOTE: you need system or reporting permissions
+            logger.info("Could not get core settings, do we have the necessary permissions?");
             return null;
         }
 
-        if (showVersionResponse instanceof CommandResponse)
-        {
-            final List<String> showVersionResult;
+        String ver = ((CoreSettingsResponse)response).getAsteriskVersion();
+        return parseVersionString("Asterisk " + ver);
+    }
 
-            showVersionResult = ((CommandResponse) showVersionResponse).getResult();
-            if (showVersionResult != null && !showVersionResult.isEmpty())
-            {
-                return showVersionResult.get(0);
-            }
+    /**
+     * Determine version by the 'core show version' command.
+     * This needs 'command' permissions.
+     *
+     * @return
+     * @throws Exception
+     */
+    protected AsteriskVersion determineVersionByCoreShowVersion() throws Exception {
+        final ManagerResponse coreShowVersionResponse = sendAction(new CommandAction(CMD_SHOW_VERSION));
+
+        if (coreShowVersionResponse == null || !(coreShowVersionResponse instanceof CommandResponse)) {
+            // this needs 'command' permissions
+            logger.info("Could not get response for 'core show version'");
+            return null;
         }
 
+        final List<String> coreShowVersionResult = ((CommandResponse) coreShowVersionResponse).getResult();
+        if (coreShowVersionResult == null || coreShowVersionResult.isEmpty()) {
+            logger.warn("Got empty response for 'core show version'");
+            return null;
+        }
+
+        final String coreLine = coreShowVersionResult.get(0);
+        return parseVersionString(coreLine);
+    }
+
+    /**
+     * Parse a version identifier coming from ast_get_version.
+     * @param versionString
+     * @return
+     */
+    protected AsteriskVersion parseVersionString(String versionString) {
+
+        if (VERSION_PATTERN_1_6.matcher(versionString).matches())
+        {
+            return AsteriskVersion.ASTERISK_1_6;
+        }
+        else if (VERSION_PATTERN_1_8.matcher(versionString).matches())
+        {
+            return AsteriskVersion.ASTERISK_1_8;
+        }
+        else if (VERSION_PATTERN_10.matcher(versionString).matches())
+        {
+            return AsteriskVersion.ASTERISK_10;
+        }
+        else if (VERSION_PATTERN_11.matcher(versionString).matches())
+        {
+            return AsteriskVersion.ASTERISK_11;
+        }
+        else if (VERSION_PATTERN_CERTIFIED_11.matcher(versionString).matches())
+        {
+            return AsteriskVersion.ASTERISK_11;
+        }
+        else if (VERSION_PATTERN_12.matcher(versionString).matches())
+        {
+            return AsteriskVersion.ASTERISK_12;
+        }
+        else if (VERSION_PATTERN_13.matcher(versionString).matches())
+        {
+            return AsteriskVersion.ASTERISK_13;
+        }
+        else if (VERSION_PATTERN_CERTIFIED_13.matcher(versionString).matches())
+        {
+            return AsteriskVersion.ASTERISK_13;
+        }
+        else if (VERSION_PATTERN_14.matcher(versionString).matches())
+        {
+            return AsteriskVersion.ASTERISK_14;
+        }
+        else if (VERSION_PATTERN_15.matcher(versionString).matches())
+        {
+            return AsteriskVersion.ASTERISK_15;
+        }
         return null;
     }
 
@@ -995,12 +950,15 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
 
     boolean isShowVersionCommandAction(ManagerAction action)
     {
-        if (!(action instanceof CommandAction))
-        {
-            return false;
+        if (action instanceof CoreSettingsAction)
+            return true;
+
+        if (action instanceof CommandAction) {
+            String cmd = ((CommandAction) action).getCommand();
+            return CMD_SHOW_VERSION.equals(cmd);
         }
-        final Matcher showVersionMatcher = SHOW_VERSION_PATTERN.matcher(((CommandAction) action).getCommand());
-        return showVersionMatcher.matches();
+
+        return false;
     }
 
     private Class< ? extends ManagerResponse> getExpectedResponseClass(Class< ? extends ManagerAction> actionClass)
@@ -1430,6 +1388,12 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
 
                 && !"Asterisk Call Manager/3.1.0".equals(identifier) // Asterisk
                                                                      // =14.3.0
+
+                && !"Asterisk Call Manager/3.2.0".equals(identifier) // since Asterisk 14.4.0
+
+                && !"Asterisk Call Manager/4.0.0".equals(identifier) // since Asterisk 15
+                && !"Asterisk Call Manager/4.0.1".equals(identifier) // since Asterisk 15.1
+                && !"Asterisk Call Manager/4.0.2".equals(identifier) // since Asterisk 15.2
 
                 && !"OpenPBX Call Manager/1.0".equals(identifier) && !"CallWeaver Call Manager/1.0".equals(identifier)
                 && !(identifier != null && identifier.startsWith("Asterisk Call Manager Proxy/")))

--- a/src/test/java/org/asteriskjava/AsteriskVersionTest.java
+++ b/src/test/java/org/asteriskjava/AsteriskVersionTest.java
@@ -13,37 +13,7 @@ public class AsteriskVersionTest
     {
         assertNull(AsteriskVersion.getDetermineVersionFromString(""));
     }
-
-    @Test
-    public void test1_6()
-    {
-        assertTrue(AsteriskVersion.getDetermineVersionFromString("Asterisk 1.6.0").equals(AsteriskVersion.ASTERISK_1_6));
-    }
-
-    @Test
-    public void test1_8()
-    {
-        assertTrue(AsteriskVersion.getDetermineVersionFromString("Asterisk 1.8.0").equals(AsteriskVersion.ASTERISK_1_8));
-    }
-
-    @Test
-    public void test10()
-    {
-        assertTrue(AsteriskVersion.getDetermineVersionFromString("Asterisk 10.1.0").equals(AsteriskVersion.ASTERISK_10));
-    }
-
-    @Test
-    public void test11()
-    {
-        assertTrue(AsteriskVersion.getDetermineVersionFromString("Asterisk 11.1.0").equals(AsteriskVersion.ASTERISK_11));
-    }
-
-    @Test
-    public void test12()
-    {
-        assertTrue(AsteriskVersion.getDetermineVersionFromString("Asterisk 12.1.0").equals(AsteriskVersion.ASTERISK_12));
-    }
-
+    
     @Test
     public void test13()
     {

--- a/src/test/java/org/asteriskjava/manager/internal/ManagerConnectionImplTest.java
+++ b/src/test/java/org/asteriskjava/manager/internal/ManagerConnectionImplTest.java
@@ -616,7 +616,7 @@ public class ManagerConnectionImplTest
     public void testIsShowVersionCommandAction()
     {
         assertTrue(mc.isShowVersionCommandAction(new CoreSettingsAction()));
-		assertTrue(mc.isShowVersionCommandAction(new CommandAction("core show version")));
+        assertTrue(mc.isShowVersionCommandAction(new CommandAction("core show version")));
         assertFalse(mc.isShowVersionCommandAction(new PingAction()));
     }
 


### PR DESCRIPTION
Adds proper support for Asterisk 15 up to 15.2.

Removes support for < 1.6 versions, using the 'show file version' method.

Relates to #174 