### PR TITLE
Readds log4j with provided scope instead of compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,12 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+			<version>1.2.17</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
 			<version>1.1.2</version>


### PR DESCRIPTION
This fixes a total brain fart on my part, which actually left the project unable to compile.

https://github.com/asterisk-java/asterisk-java/pull/244 removed log4j, as it caused issues to have log4j specified when using the default slf4j. But there are a few hardcoded references to log4j in this project, so it did not compile anymore (Even though I said it did - brain fart no. 2). 

This readds log4j with provided scope instead so it won't be added to builds automatically.