### PR TITLE
Use ParkingSpace to set parkedAt on channel

### DIFF
--- a/src/main/java/org/asteriskjava/live/AsteriskChannel.java
+++ b/src/main/java/org/asteriskjava/live/AsteriskChannel.java
@@ -40,6 +40,7 @@ import org.asteriskjava.util.MixMonitorDirection;
  * <li>meetMeUser
  * <li>queueEntry
  * <li>parkedAt
+ * <li>parkingLot
  * <li>dtmfReceived
  * <li>dtmfSent
  * </ul>
@@ -61,6 +62,7 @@ public interface AsteriskChannel extends LiveObject
     String PROPERTY_MEET_ME_USER = "meetMeUser";
     String PROPERTY_QUEUE_ENTRY = "queueEntry";
     String PROPERTY_PARKED_AT = "parkedAt";
+    String PROPERTY_PARKING_LOT = "parkingLot";
     String PROPERTY_DTMF_RECEIVED = "dtmfReceived";
     String PROPERTY_DTMF_SENT = "dtmfSent";
     String PROPERTY_MONITORED = "monitored";
@@ -286,6 +288,13 @@ public interface AsteriskChannel extends LiveObject
      * @return the Extension to dial, <code>null</code> if not currently parked.
      */
     Extension getParkedAt();
+
+    /**
+     * Return the name of the parkinglot where the channel is currently parked.
+     *
+     * @return the name of the parkinglot used to park, <code>null</code> if not currently parked.
+     */
+    String getParkingLot();
 
     /**
      * Returns the channel variables as received by

--- a/src/main/java/org/asteriskjava/live/internal/AsteriskChannelImpl.java
+++ b/src/main/java/org/asteriskjava/live/internal/AsteriskChannelImpl.java
@@ -128,6 +128,11 @@ class AsteriskChannelImpl extends AbstractLiveObject implements AsteriskChannel
      */
     private Extension parkedAt;
     /**
+     * Parkinglot where the call is parked if it is parked, <code>null</code>
+     * otherwise.
+     */
+    private String parkingLot;
+    /**
      * Last dtmf digit recieved on this channel if any, <code>null</code>
      * otherwise.
      */
@@ -917,12 +922,20 @@ class AsteriskChannelImpl extends AbstractLiveObject implements AsteriskChannel
         return parkedAt;
     }
 
-    void setParkedAt(Extension parkedAt)
+    public String getParkingLot()
+    {
+        return this.parkingLot;
+    }
+
+    void setParkedAt(Extension parkedAt, String parkingLot)
     {
         final Extension oldParkedAt = this.parkedAt;
+        final String oldParkingLot = this.parkingLot;
 
         this.parkedAt = parkedAt;
+        this.parkingLot = parkingLot;
         firePropertyChange(PROPERTY_PARKED_AT, oldParkedAt, parkedAt);
+        firePropertyChange(PROPERTY_PARKING_LOT, oldParkingLot, parkingLot);
     }
 
     void updateVariable(String name, String value)

--- a/src/main/java/org/asteriskjava/live/internal/ChannelManager.java
+++ b/src/main/java/org/asteriskjava/live/internal/ChannelManager.java
@@ -821,6 +821,7 @@ class ChannelManager
 
     void handleParkedCallEvent(ParkedCallEvent event)
     {
+        logger.info("Trace - ChannelManager.java - handleParkedCallEvent: " + event);
         // Only bristuffed versions: AsteriskChannelImpl channel =
         // getChannelImplById(event.getUniqueId());
         AsteriskChannelImpl channel = getChannelImplByNameAndActive(event.getParkeeChannel());
@@ -833,12 +834,9 @@ class ChannelManager
 
         synchronized (channel)
         {
-            // todo The context should be "parkedcalls" or whatever has been
-            // configured in features.conf
-            // unfortunately we don't get the context in the ParkedCallEvent so
-            // for now we'll set it to null.
-            Extension ext = new Extension(null, event.getExten(), 1);
-            channel.setParkedAt(ext);
+            Extension ext = new Extension(null, (event.getParkingSpace() != null) ? event.getParkingSpace() : event.getExten(), 1);
+            String parkinglot = event.getParkingLot();
+            channel.setParkedAt(ext, parkinglot);
             logger.info("Channel " + channel.getName() + " is parked at " + channel.getParkedAt().getExtension());
         }
     }
@@ -865,7 +863,7 @@ class ChannelManager
 
         synchronized (channel)
         {
-            channel.setParkedAt(null);
+            channel.setParkedAt(null, null);
         }
         logger.info("Channel " + channel.getName() + " is unparked (GiveUp) from " + wasParkedAt.getExtension());
     }
@@ -892,7 +890,7 @@ class ChannelManager
 
         synchronized (channel)
         {
-            channel.setParkedAt(null);
+            channel.setParkedAt(null, null);
         }
         logger.info("Channel " + channel.getName() + " is unparked (Timeout) from " + wasParkedAt.getExtension());
     }
@@ -919,7 +917,7 @@ class ChannelManager
 
         synchronized (channel)
         {
-            channel.setParkedAt(null);
+            channel.setParkedAt(null, null);
         }
         logger.info("Channel " + channel.getName() + " is unparked (moved away) from " + wasParkedAt.getExtension());
     }


### PR DESCRIPTION
Addresses Issue Report #264 

Use ParkingSpace to set parkedAt on channel instead of 'Exten'. Falls back to
Exten if ParkingSpace is null for some reason (most likely because we are on
an older version of Asterisk).

Also, changes setParkedAt to include a parkinglot name. This can be retrieved
from the Asterisk channel with getParkingLot(). Between getParkedAt() and
getParkingLot() you can get all the arguments needed to use the ParkedCall
dialplan application on any parked call.