### PR TITLE
Change sendPackets from Integer to Long

### DIFF
--- a/src/main/java/org/asteriskjava/manager/event/RtcpReceivedEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/RtcpReceivedEvent.java
@@ -71,7 +71,7 @@ public class RtcpReceivedEvent extends AbstractRtcpEvent
     private InetAddress toAddress;
     private Integer toPort;
     private String sentntp;
-    private Integer sentPackets;
+    private Long sentPackets;
     private Long sentrtp;
     private String accountCode;
     
@@ -429,12 +429,12 @@ public class RtcpReceivedEvent extends AbstractRtcpEvent
         this.linkedId = linkedId;
     }
 
-    public Integer getSentPackets()
+    public Long getSentPackets()
     {
         return sentPackets;
     }
 
-    public void setSentPackets(Integer sentPackets)
+    public void setSentPackets(Long sentPackets)
     {
         this.sentPackets = sentPackets;
     }


### PR DESCRIPTION
Hi.
I found a problem in the class **RtcpReceivedEvent** attribute **sentpackets**, the type used is Integer but should be Long. 
Follow the error.
```
2018-09-21 11:21:58.902 ERROR 5591 --- [Asterisk-Java ManagerConnection-0-Reader-0] o.a.manager.internal.EventBuilderImpl    : Unable to convert value: Called the constructor of class java.lang.Integer with value '4294967295' for the attribute 'sentpackets'
 of event type org.asteriskjava.manager.event.RtcpReceivedEvent with resulting error: null****

```
Thanks