### PR TITLE
Allow configuration of SO_TIMEOUT in AgiServer

### DIFF
--- a/src/main/java/org/asteriskjava/fastagi/AgiServer.java
+++ b/src/main/java/org/asteriskjava/fastagi/AgiServer.java
@@ -73,4 +73,14 @@ public interface AgiServer
      *             has not yet been started.
      */
     void shutdown() throws IllegalStateException;
+
+    /**
+     * Connection is dropped if it stales on read longer than the timeout.
+     *
+     * @param socketReadTimeout the read timeout value to be used in
+     *            milliseconds.
+     * @see java.net.Socket#setSoTimeout(int)
+     * @since 3.0.0
+     */
+    public void setSocketReadTimeout(int socketReadTimeout);
 }

--- a/src/main/java/org/asteriskjava/fastagi/DefaultAgiServer.java
+++ b/src/main/java/org/asteriskjava/fastagi/DefaultAgiServer.java
@@ -31,6 +31,7 @@ import org.asteriskjava.util.ReflectionUtil;
 import org.asteriskjava.util.ServerSocketFacade;
 import org.asteriskjava.util.SocketConnectionFacade;
 import org.asteriskjava.util.internal.ServerSocketFacadeImpl;
+import org.asteriskjava.util.internal.SocketConnectionFacadeImpl;
 
 /**
  * Default implementation of the {@link org.asteriskjava.fastagi.AgiServer}
@@ -61,6 +62,14 @@ public class DefaultAgiServer extends AbstractAgiServer implements AgiServer
     private String configResourceBundleName = DEFAULT_CONFIG_RESOURCE_BUNDLE_NAME;
     private int port = DEFAULT_BIND_PORT;
     private InetAddress address = null;
+
+    /**
+     * Closes the connection if no input has been read for the
+     * given amount of milliseconds.
+     *
+     * @see Socket#setSoTimeout(int)
+     */
+    private int socketReadTimeout = SocketConnectionFacadeImpl.MAX_SOCKET_READ_TIMEOUT_MILLIS;
 
     /**
      * Creates a new DefaultAgiServer.
@@ -295,9 +304,16 @@ public class DefaultAgiServer extends AbstractAgiServer implements AgiServer
         }
     }
 
+    public void setSocketReadTimeout(int socketReadTimeout)
+    {
+        this.socketReadTimeout = socketReadTimeout;
+    }
+
     protected ServerSocketFacade createServerSocket() throws IOException
     {
-        return new ServerSocketFacadeImpl(port, BACKLOG, address);
+        ServerSocketFacade serverSocketFacade = new ServerSocketFacadeImpl(port, BACKLOG, address);
+        serverSocketFacade.setSocketReadTimeout(socketReadTimeout);
+        return serverSocketFacade;
     }
 
     public void startup() throws IOException, IllegalStateException

--- a/src/main/java/org/asteriskjava/util/ServerSocketFacade.java
+++ b/src/main/java/org/asteriskjava/util/ServerSocketFacade.java
@@ -43,4 +43,14 @@ public interface ServerSocketFacade
      * @throws IOException if the server socket cannot be closed.
      */
     void close() throws IOException;
+
+    /**
+     * Connection is dropped if it stales on read longer than the timeout.
+     *
+     * @param socketReadTimeout the read timeout value to be used in
+     *            milliseconds.
+     * @see java.net.Socket#setSoTimeout(int)
+     * @since 3.0.0
+     */
+    public void setSocketReadTimeout(int socketReadTimeout);
 }

--- a/src/main/java/org/asteriskjava/util/internal/ServerSocketFacadeImpl.java
+++ b/src/main/java/org/asteriskjava/util/internal/ServerSocketFacadeImpl.java
@@ -28,13 +28,15 @@ import org.asteriskjava.util.SocketConnectionFacade;
 /**
  * Default implementation of the ServerSocketFacade interface using standard
  * java.io classes (ServerSocket in this case).
- * 
+ *
  * @author srt
  * @version $Id$
  */
 public class ServerSocketFacadeImpl implements ServerSocketFacade
 {
     private ServerSocket serverSocket;
+
+    private int socketReadTimeout = SocketConnectionFacadeImpl.MAX_SOCKET_READ_TIMEOUT_MILLIS;
 
     public ServerSocketFacadeImpl(int port, int backlog, InetAddress bindAddress)
             throws IOException
@@ -48,11 +50,16 @@ public class ServerSocketFacadeImpl implements ServerSocketFacade
 
         socket = serverSocket.accept();
 
-        return new SocketConnectionFacadeImpl(socket);
+        return new SocketConnectionFacadeImpl(socket, socketReadTimeout);
     }
 
     public void close() throws IOException
     {
         serverSocket.close();
+    }
+
+    public void setSocketReadTimeout(int socketReadTimeout)
+    {
+        this.socketReadTimeout = socketReadTimeout;
     }
 }

--- a/src/main/java/org/asteriskjava/util/internal/SocketConnectionFacadeImpl.java
+++ b/src/main/java/org/asteriskjava/util/internal/SocketConnectionFacadeImpl.java
@@ -155,12 +155,30 @@ public class SocketConnectionFacadeImpl implements SocketConnectionFacade
      */
     SocketConnectionFacadeImpl(Socket socket) throws IOException
     {
-        socket.setSoTimeout(MAX_SOCKET_READ_TIMEOUT_MILLIS);
+        this(socket, MAX_SOCKET_READ_TIMEOUT_MILLIS);
+    }
+
+    /**
+     * Creates a new instance for use with FastAGI that uses NL ("\n") as line delimiter.
+     *
+     * @param socket the underlying socket.
+     * @param timeout 0 indicates default, -1 indicates infinite timeout (not recommended)
+     * @throws IOException if the connection cannot be initialized.
+     */
+    SocketConnectionFacadeImpl(Socket socket, int timeout) throws IOException
+    {
+        if (timeout == -1)
+        {
+            timeout = 0;
+        } else if (timeout == 0) {
+            timeout = MAX_SOCKET_READ_TIMEOUT_MILLIS;
+        }
+        socket.setSoTimeout(timeout);
         initialize(socket, StandardCharsets.UTF_8, NL_PATTERN);
     }
 
-    /** 70 mi = 70 * 60 * 1000 */
-    private static final int MAX_SOCKET_READ_TIMEOUT_MILLIS = 4200000;
+    /** 3 hrs = 3 * 3660 * 1000 */
+    public static final int MAX_SOCKET_READ_TIMEOUT_MILLIS = 10800000;
 
     private void initialize(Socket socket, Charset encoding, Pattern pattern) throws IOException
     {

--- a/src/test/java/org/asteriskjava/fastagi/DefaultAgiServerTest.java
+++ b/src/test/java/org/asteriskjava/fastagi/DefaultAgiServerTest.java
@@ -123,6 +123,10 @@ public class DefaultAgiServerTest
         {
             closeCalls++;
         }
+
+        public void setSocketReadTimeout(int socketReadTimeout)
+        {
+        }
     }
 
     @Test


### PR DESCRIPTION
DefaultAgiServer use indirectly SocketConnectionFacade which has a default timeout of 4200s.
This timeout is triggered on long AGI calls like Dial.

This follows #274.

At the moment I did not modify the default value, using _null_ values.
These _null_ values are not necessary if DefaultAgiServer has a default timeout value.
Or if MAX_SOCKET_READ_TIMEOUT_MILLIS is only used by ServerSocketFacade/DefaultAgiServer (with SocketConnectionFacadeImpl(Socket)) maybe it could be moved there.