### PR TITLE
Add support for Asterisk16 as well as Call Manager 4.0.3 & 5.0.0

### DIFF
--- a/src/main/java/org/asteriskjava/AsteriskVersion.java
+++ b/src/main/java/org/asteriskjava/AsteriskVersion.java
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
  */
 public class AsteriskVersion implements Comparable<AsteriskVersion>, Serializable
 {
+    private static final String VERSION_PATTERN_16 = "^\\s*Asterisk (GIT-)?16[-. ].*";
     private static final String VERSION_PATTERN_15 = "^\\s*Asterisk (GIT-)?15[-. ].*";
     private static final String VERSION_PATTERN_14 = "^\\s*Asterisk (GIT-)?14[-. ].*";
     private static final String VERSION_PATTERN_13 = "^\\s*Asterisk ((SVN-branch|GIT)-)?13[-. ].*";
@@ -111,14 +112,21 @@ public class AsteriskVersion implements Comparable<AsteriskVersion>, Serializabl
      */
     public static final AsteriskVersion ASTERISK_14 = new AsteriskVersion(1400, "Asterisk 14", VERSION_PATTERN_14);
 
-    /**
-     * Represents the Asterisk 15 series.
-     *
-     * @since 2.1.0
-     */
-    public static final AsteriskVersion ASTERISK_15 = new AsteriskVersion(1500, "Asterisk 15", VERSION_PATTERN_15);
+	/**
+	 * Represents the Asterisk 15 series.
+	 *
+	 * @since 2.1.0
+	 */
+	public static final AsteriskVersion ASTERISK_15 = new AsteriskVersion(1500, "Asterisk 15", VERSION_PATTERN_15);
 
-    private static final AsteriskVersion knownVersions[] = new AsteriskVersion[]{ASTERISK_15, ASTERISK_14, ASTERISK_13,
+	/**
+	 * Represents the Asterisk 16 series.
+	 *
+	 * @since 2.1.0
+	 */
+	public static final AsteriskVersion ASTERISK_16 = new AsteriskVersion(1600, "Asterisk 16", VERSION_PATTERN_16);
+
+	private static final AsteriskVersion knownVersions[] = new AsteriskVersion[]{ASTERISK_16, ASTERISK_15, ASTERISK_14, ASTERISK_13,
             ASTERISK_12, ASTERISK_11, ASTERISK_10, ASTERISK_1_8, ASTERISK_1_6};
 
     /**

--- a/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
@@ -1381,6 +1381,12 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
                 && !"Asterisk Call Manager/3.1.0".equals(identifier) // Asterisk
                                                                      // =14.3.0
 
+			    && !"Asterisk Call Manager/4.0.3".equals(identifier) // Asterisk
+			                                                         // 15
+
+			    && !"Asterisk Call Manager/5.0.0".equals(identifier) // Asterisk
+			                                                         // 16
+
                 && !"OpenPBX Call Manager/1.0".equals(identifier) && !"CallWeaver Call Manager/1.0".equals(identifier)
                 && !(identifier != null && identifier.startsWith("Asterisk Call Manager Proxy/")))
         {


### PR DESCRIPTION
Sorry for previous PR has conflict.  I created this branch based on 2.0.4
1. add support for Asterisk16
2. add supports for Call Manager 4.0.3 and 5.0.0

I'm not sure this should merge into master or not? If so, I will solve conflict and merge again, thanks!