### PR TITLE
Remove duplicate fields in CelEvent which already defined in ManagerEvent

### DIFF
--- a/src/main/java/org/asteriskjava/manager/event/CelEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/CelEvent.java
@@ -29,8 +29,6 @@ public class CelEvent extends ManagerEvent
     private String callerIDani;
     private String callerIDrdnis;
     private String callerIDdnid;
-    private String exten;
-    private String context;
     private String application;
     private String appData;
     private String eventTime;
@@ -96,26 +94,6 @@ public class CelEvent extends ManagerEvent
     public void setCallerIDdnid(String callerIDdnid)
     {
         this.callerIDdnid = callerIDdnid;
-    }
-
-    public String getExten()
-    {
-        return exten;
-    }
-
-    public void setExten(String exten)
-    {
-        this.exten = exten;
-    }
-
-    public String getContext()
-    {
-        return context;
-    }
-
-    public void setContext(String context)
-    {
-        this.context = context;
     }
 
     public String getApplication()


### PR DESCRIPTION
These 2 fields: `exten` and `context`  already defined in super class and decorated with protected keyword, as well as it's getter / setter.

That is fine for compilation and building event object, but if some library uses reflection to lookup fields and do stuff, for instance, google's json lib `Gson`, it will throw an error: `java.lang.IllegalArgumentException: class 'org.asteriskjava.manager.event.CelEvent' declares multiple JSON fields named 'exten'`.

I tested by using Gson and it works if I remove these 2 fields.

Following are fields I gathered from `ManagerEvent` and `CelEvent`, copied it to a plain text file, then counted by command `sed s/' '/\\n/g | sort | uniq -c | sort -nr`

```
 2 exten;
   2 context;
   1 userField;
   1 uniqueID;
   1 timestamp;
   1 systemName;
   1 server;
   1 sequenceNumber;
   1 privilege;
   1 priority;
   1 peerAccount;
   1 peer;
   1 linkedID;
   1 line;
   1 func;
   1 file;
   1 extra;
   1 eventTime;
   1 eventName;
   1 dateReceived;
   1 connectedLineNum;
   1 connectedLineName;
   1 channelStateDesc;
   1 channelState;
   1 channel;
   1 callerIdNum;
   1 callerIdName;
   1 callerIDrdnis;
   1 callerIDdnid;
   1 callerIDani;
   1 application;
   1 appData;
   1 amaFlags;
   1 accountCode;
```