### PR TITLE
Implement semantic version checking for AMI version

### DIFF
--- a/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
@@ -1333,12 +1333,15 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
         }
     }
 
-    private boolean isSupportedProtocolIdentifier(final String identifier) {
+    private boolean isSupportedProtocolIdentifier(final String identifier)
+    {
 
         // Normal version checks
-        for (String supportedVersion : SUPPORTED_AMI_VERSIONS) {
+        for (String supportedVersion : SUPPORTED_AMI_VERSIONS)
+        {
             String prefix = "Asterisk Call Manager/" + supportedVersion + ".";
-            if (identifier.startsWith(prefix)) {
+            if (identifier.startsWith(prefix))
+            {
                 return true;
             }
         }
@@ -1365,7 +1368,8 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
     {
         logger.info("Connected via " + identifier);
 
-        if (identifier == null || !isSupportedProtocolIdentifier(identifier)) {
+        if (identifier == null || !isSupportedProtocolIdentifier(identifier))
+        {
             logger.warn("Unsupported protocol version '" + identifier + "'. Use at your own risk.");
         }
 

--- a/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
@@ -92,6 +92,19 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
     private static final int MAX_VERSION_ATTEMPTS = 4;
     private static final String CMD_SHOW_VERSION = "core show version";
 
+    // NOTE: identifier is AMI_VERSION, defined in include/asterisk/manager.h
+    // AMI version consists of MAJOR.BREAKING.NON-BREAKING.
+    private static final String[] SUPPORTED_AMI_VERSIONS = {
+        "2.6", // Asterisk 13
+        "2.7", // Asterisk 13.2
+        "2.8", // Asterisk >13.5
+        "2.9", // Asterisk >13.3
+        "3.1", // Asterisk =14.3
+        "3.2", // Asterisk 14.4.0
+        "4.0", // Asterisk 15
+        "5.0", // Asterisk 16
+    };
+
     private static final AtomicLong idCounter = new AtomicLong(0);
 
     /**
@@ -811,7 +824,7 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
 
     /**
      * Implements synchronous sending of "simple" actions.
-     * 
+     *
      * @param timeout - in milliseconds
      */
     public ManagerResponse sendAction(ManagerAction action, long timeout)
@@ -1320,6 +1333,27 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
         }
     }
 
+    private boolean isSupportedProtocolIdentifier(final String identifier) {
+
+        // Normal version checks
+        for (String supportedVersion : SUPPORTED_AMI_VERSIONS) {
+            String prefix = "Asterisk Call Manager/" + supportedVersion + ".";
+            if (identifier.startsWith(prefix)) {
+                return true;
+            }
+        }
+    
+        // Other cases
+        if ("OpenPBX Call Manager/1.0".equals(identifier))
+            return true;
+        if ("CallWeaver Call Manager/1.0".equals(identifier))
+            return true;
+        if (identifier.startsWith("Asterisk Call Manager Proxy/"))
+            return true;
+    
+        return false;
+    }
+
     /**
      * This method is called when a {@link ProtocolIdentifierReceivedEvent} is
      * received from the reader. Having received a correct protocol identifier
@@ -1331,45 +1365,7 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
     {
         logger.info("Connected via " + identifier);
 
-        // NOTE: value is AMI_VERSION, defined in include/asterisk/manager.h
-
-        if (
-        // Asterisk 13
-        !"Asterisk Call Manager/2.6.0".equals(identifier)
-
-                // Asterisk 13.2
-                && !"Asterisk Call Manager/2.7.0".equals(identifier)
-
-                // Asterisk > 13.5
-                && !"Asterisk Call Manager/2.8.0".equals(identifier)
-
-                // Asterisk > 13.13
-                && !"Asterisk Call Manager/2.9.0".equals(identifier)
-
-                // Asterisk =14.3.0
-                && !"Asterisk Call Manager/3.1.0".equals(identifier)
-
-                // since Asterisk 14.4.0
-                && !"Asterisk Call Manager/3.2.0".equals(identifier)
-
-                // since Asterisk 15
-                && !"Asterisk Call Manager/4.0.0".equals(identifier)
-
-                // since Asterisk 15.1
-                && !"Asterisk Call Manager/4.0.1".equals(identifier)
-
-                // since Asterisk 15.2
-                && !"Asterisk Call Manager/4.0.2".equals(identifier)
-
-                // since Asterisk 15.3
-                && !"Asterisk Call Manager/4.0.3".equals(identifier)
-
-                // Asterisk 16
-                && !"Asterisk Call Manager/5.0.0".equals(identifier)
-
-                && !"OpenPBX Call Manager/1.0".equals(identifier) && !"CallWeaver Call Manager/1.0".equals(identifier)
-                && !(identifier != null && identifier.startsWith("Asterisk Call Manager Proxy/")))
-        {
+        if (identifier == null || !isSupportedProtocolIdentifier(identifier)) {
             logger.warn("Unsupported protocol version '" + identifier + "'. Use at your own risk.");
         }
 


### PR DESCRIPTION
As AMI versions keep updating for every minor Asterisk release, it's unfeasible to keep updating the library.

This patch uses semantic versioning, so if the MAJOR.BREAKING part of the version matches, AsteriskJava won't complain if the NON-BREAKING part of AMI_VERSION increases.