### PR TITLE
From Asterisk 11 to 12 most QueueEvents now uses Interface instead of Location

### DIFF
--- a/src/main/java/org/asteriskjava/manager/event/AbstractQueueMemberEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/AbstractQueueMemberEvent.java
@@ -30,8 +30,10 @@ public abstract class AbstractQueueMemberEvent extends ManagerEvent
      */
     private static final long serialVersionUID = -7437833328723536814L;
     private String queue;
-    private String location;
+    private String _interface;
     private String memberName;
+    private String pausedReason;
+    private String inCall;
 
     /**
      * @param source
@@ -67,9 +69,9 @@ public abstract class AbstractQueueMemberEvent extends ManagerEvent
      * 
      * @return the name of the member's interface.
      */
-    public String getLocation()
+    final public String getInterface()
     {
-        return location;
+        return _interface;
     }
 
     /**
@@ -77,9 +79,39 @@ public abstract class AbstractQueueMemberEvent extends ManagerEvent
      * 
      * @param member the name of the member's interface.
      */
-    public void setLocation(String member)
+    final public void setInterface(String _interface)
     {
-        this.location = member;
+        this._interface = _interface;
+    }
+
+    /**
+     * Returns the name of the member's interface.<p>
+     * E.g. the channel name or agent group.
+     *
+     * @deprecated since Asterisk 12
+     *
+     * @return the name of the member's interface.
+     */
+    @Deprecated
+    final public String getLocation()
+    {
+        return _interface;
+    }
+
+    /**
+     * Sets the name of the member's interface.
+     *
+     * @deprecated since Asterisk 12
+     *
+     * @param member the name of the member's interface.
+     */
+    @Deprecated
+    final public void setLocation(String _interface)
+    {
+        if ((_interface != null) && (!"null".equals(_interface)))
+        {  // Location is not in use since asterisk 12
+            this._interface = _interface;
+        }
     }
 
     /**
@@ -106,5 +138,25 @@ public abstract class AbstractQueueMemberEvent extends ManagerEvent
     public void setMemberName(String memberName)
     {
         this.memberName = memberName;
+    }
+
+    public String getPausedReason()
+    {
+        return pausedReason;
+    }
+
+    public void setPausedReason(String pausedReason)
+    {
+        this.pausedReason = pausedReason;
+    }
+
+    public String getInCall()
+    {
+        return inCall;
+    }
+
+    public void setInCall(String inCall)
+    {
+        this.inCall = inCall;
     }
 }

--- a/src/main/java/org/asteriskjava/manager/event/QueueMemberAddedEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/QueueMemberAddedEvent.java
@@ -40,7 +40,6 @@ public class QueueMemberAddedEvent extends AbstractQueueMemberEvent
     private Boolean paused;
     
     private String stateinterface;
-    private String _interface;
     private Boolean ringinuse;
 
     public QueueMemberAddedEvent(Object source)
@@ -200,17 +199,7 @@ public class QueueMemberAddedEvent extends AbstractQueueMemberEvent
 	public void setStateinterface(String stateinterface)
 	{
 		this.stateinterface = stateinterface;
-	}
-
-	public String getInterface()
-	{
-		return _interface;
-	}
-
-	public void setInterface(String _interface)
-	{
-		this._interface = _interface;
-	}
+    }
 
 	public Boolean getRinginuse()
 	{

--- a/src/main/java/org/asteriskjava/manager/event/QueueMemberEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/QueueMemberEvent.java
@@ -61,6 +61,7 @@ public class QueueMemberEvent extends ResponseEvent
     private String stateinterface;
     private Integer incall;
     private String pausedreason;
+    private String _interface;
 
 
 
@@ -93,25 +94,54 @@ public class QueueMemberEvent extends ResponseEvent
     }
 
     /**
-     * Returns the name of the member's interface.
-     * <p>
-     * E.g. the channel name or agent group (for example "Agent/@1").
-     * 
+     * Returns the name of the member's interface.<p>
+     * E.g. the channel name or agent group.
+     *
      * @return the name of the member's interface.
      */
-    public String getLocation()
+    final public String getInterface()
     {
-        return location;
+        return _interface;
     }
 
     /**
      * Sets the name of the member's interface.
      * 
-     * @param location the name of the member's interface.
+     * @param member the name of the member's interface.
      */
-    public void setLocation(String location)
+    final public void setInterface(String _interface)
     {
-        this.location = location;
+        this._interface = _interface;
+    }
+
+    /**
+     * Returns the name of the member's interface.<p>
+     * E.g. the channel name or agent group.
+     *
+     * @deprecated since Asterisk 12
+     *
+     * @return the name of the member's interface.
+     */
+    @Deprecated
+    final public String getLocation()
+    {
+        return _interface;
+    }
+
+    /**
+     * Sets the name of the member's interface.
+     *
+     * @deprecated since Asterisk 12
+     *
+     * @param member the name of the member's interface.
+     */
+    @Deprecated
+    final public void setLocation(String _interface)
+    {
+        if ((_interface != null) && (!"null".equals(_interface)))
+        {  // Location is not in use since asterisk 12
+            this._interface = _interface;
+        }
     }
 
     /**

--- a/src/main/java/org/asteriskjava/manager/event/QueueMemberPauseEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/QueueMemberPauseEvent.java
@@ -11,7 +11,6 @@ public class QueueMemberPauseEvent extends QueueMemberPausedEvent
     Integer penalty;
     Integer status;
     Boolean ringinuse;
-    String iface;
     String stateInterface;
     Integer incall;
     String pausedreason;
@@ -118,21 +117,6 @@ public class QueueMemberPauseEvent extends QueueMemberPausedEvent
         this.ringinuse = ringinuse;
     }
 
-    /**
-     * @return the iface
-     */
-    public String getInterface()
-    {
-        return iface;
-    }
-
-    /**
-     * @param iface the iface to set
-     */
-    public void setInterface(String iface)
-    {
-        this.iface = iface;
-    }
 
     /**
      * @return the stateInterface

--- a/src/main/java/org/asteriskjava/manager/event/QueueMemberRemovedEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/QueueMemberRemovedEvent.java
@@ -37,7 +37,6 @@ public class QueueMemberRemovedEvent extends AbstractQueueMemberEvent
     Integer penalty;
     String stateinterface;
     String membership;
-    String _interface;
     Long callstaken;
     Boolean ringinuse;
     Long lastcall;
@@ -95,20 +94,7 @@ public class QueueMemberRemovedEvent extends AbstractQueueMemberEvent
 	public void setMembership(String membership)
 	{
 		this.membership = membership;
-	}
-
-
-	public String getInterface()
-	{
-		return _interface;
-	}
-
-
-	public void setInterface(String _interface)
-	{
-		this._interface = _interface;
-	}
-
+    }
 
 	public Long getCallstaken()
 	{

--- a/src/main/java/org/asteriskjava/manager/event/QueueMemberStatusEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/QueueMemberStatusEvent.java
@@ -30,7 +30,6 @@ public class QueueMemberStatusEvent extends QueueMemberEvent
     private static final long serialVersionUID = -2293926744791895763L;
 
     private String ringinuse;
-    private String iface;
     private Integer incall;
 
     /**
@@ -39,16 +38,6 @@ public class QueueMemberStatusEvent extends QueueMemberEvent
     public QueueMemberStatusEvent(Object source)
     {
         super(source);
-    }
-
-    public String getInterface()
-    {
-        return iface;
-    }
-
-    public void setInterface(String iface)
-    {
-        this.iface = iface;
     }
 
     /**


### PR DESCRIPTION
This patch will accept location parameter only if it is not null so it is not possible to overwrite a correct parameter already set via Interface.

This patch works in our Production environment without any problems.
Older application who uses getLocation are still functional and it works with all asterisk versions