### PR TITLE
timeout may happen in addNewChannel()

### DIFF
--- a/src/main/java/org/asteriskjava/live/internal/ChannelManager.java
+++ b/src/main/java/org/asteriskjava/live/internal/ChannelManager.java
@@ -222,7 +222,7 @@ class ChannelManager
                 {
                     channel.getVariable(Constants.VARIABLE_TRACE_ID);
                 }
-                catch (NoSuchChannelException e)
+                catch (NoSuchChannelException | ManagerCommunicationException e)
                 {
                     try
                     {


### PR DESCRIPTION
if a simple GetVarAction has timeout, it will try it again, and don't skip the rest of the addNewChannel(), because of an exception. Or if it has no more time (SLEEP_TIME_BEFORE_GET_VAR interval was not enough) to complete GetVar, it will skip it simple.

more details: https://github.com/asterisk-java/asterisk-java/issues/302