### PR TITLE
setKeepAliveAfterAuthenticationFailure is not accessible from applica…

### DIFF
--- a/src/main/java/org/asteriskjava/manager/ManagerConnection.java
+++ b/src/main/java/org/asteriskjava/manager/ManagerConnection.java
@@ -19,7 +19,6 @@ package org.asteriskjava.manager;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.charset.Charset;
-
 import org.asteriskjava.AsteriskVersion;
 import org.asteriskjava.manager.action.EventGeneratingAction;
 import org.asteriskjava.manager.action.ManagerAction;
@@ -207,6 +206,16 @@ public interface ManagerConnection
      * @since 0.3
      */
     void setSocketReadTimeout(int socketReadTimeout);
+    /**
+     * Set to <code>true</code> to try reconnecting to ther asterisk serve even
+     * if the reconnection attempt threw an AuthenticationFailedException. <br>
+     * Default is <code>true</code>.
+     *
+     * @param keepAliveAfterAuthenticationFailure <code>true</code> to try
+     * reconnecting to ther asterisk serve even if the reconnection attempt
+     * threw an AuthenticationFailedException, <code>false</code> otherwise.
+     */
+    public void setKeepAliveAfterAuthenticationFailure(boolean keepAliveAfterAuthenticationFailure);
 
     /**
      * Logs in to the Asterisk server with the username and password specified


### PR DESCRIPTION
When during a running session the manaer password changes we have no possibility to detect this because the keeptAliveAfterAuthenticationFailure stll tries to reconnect silently.
The application has no possibility to modify this behavour because the setter is hidden.

This patch makes the setter visible to application layer