### PR TITLE
Compatibility set to 1.8 because streams are used in the code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ version = '2.0.0.CI-SNAPSHOT'
 
 description = """Asterisk-Java"""
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 repositories {
         


### PR DESCRIPTION
Eg. in AsteriskPBX:
```return response.getResult().stream().anyMatch(line -> line.contains(dialPlan));```