### PR TITLE
Make builds be platform independent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,9 @@
 			<url>${snapshot.distribution.url}</url>
 		</snapshotRepository>
 	</distributionManagement>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
    Prevent maven messages like:
    [WARNING] File encoding has not been set, using platform encoding XXXX, i.e. build is platform dependent!