### PR TITLE
- Removed the incall attribute in specialized class, because alread exist in super class.

### DIFF
--- a/src/main/java/org/asteriskjava/manager/event/QueueMemberStatusEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/QueueMemberStatusEvent.java
@@ -31,7 +31,6 @@ public class QueueMemberStatusEvent extends QueueMemberEvent
 
     private String ringinuse;
     private String iface;
-    private Integer incall;
 
     /**
      * @param source
@@ -66,16 +65,4 @@ public class QueueMemberStatusEvent extends QueueMemberEvent
     {
         this.ringinuse = ringinuse;
     }
-
-    public Integer getIncall()
-    {
-        return incall;
-    }
-
-    public void setIncall(Integer incall)
-    {
-        this.incall = incall;
-    }
-    
-    
 }


### PR DESCRIPTION
In some cases that require analyzing QueueMemberStatusEvent for json using gson lib, a lib returns an exception that shows that it has duplicate attributes.