### PR TITLE
Add asynchronous method sendEventGeneratingAction

### DIFF
--- a/src/main/java/org/asteriskjava/manager/DefaultManagerConnection.java
+++ b/src/main/java/org/asteriskjava/manager/DefaultManagerConnection.java
@@ -350,6 +350,14 @@ public class DefaultManagerConnection implements ManagerConnection
         return impl.sendEventGeneratingAction(action, timeout);
     }
 
+    @Override
+    public void sendEventGeneratingAction(EventGeneratingAction action,
+            SendEventGeneratingActionCallback callback)
+            throws IOException, IllegalArgumentException, IllegalStateException
+    {
+        impl.sendEventGeneratingAction(action, callback);
+    }
+
     public void addEventListener(final ManagerEventListener listener)
     {
         impl.addEventListener(listener);

--- a/src/main/java/org/asteriskjava/manager/ManagerConnection.java
+++ b/src/main/java/org/asteriskjava/manager/ManagerConnection.java
@@ -404,6 +404,20 @@ public interface ManagerConnection
             throws IOException, EventTimeoutException, IllegalArgumentException, IllegalStateException;
 
     /**
+     * Asynchronously sends an {@link EventGeneratingAction} to the Asterisk
+     * server. This is similar to
+     * {@link #sendEventGeneratingAction(EventGeneratingAction, long)} except it
+     * does NOT block to wait for the completion. Instead after the action
+     * completes or fails the result is provided to the optional callback via
+     * {@link SendEventGeneratingActionCallback#onResponse(ResponseEvents)}.
+     *
+     * @see #sendEventGeneratingAction(EventGeneratingAction, long)
+     */
+    void sendEventGeneratingAction(
+            EventGeneratingAction action,
+            SendEventGeneratingActionCallback callback)
+                    throws IOException, IllegalArgumentException, IllegalStateException;
+    /**
      * Registers an event listener that is called whenever an
      * {@link org.asteriskjava.manager.event.ManagerEvent} is receiced from the
      * Asterisk server.

--- a/src/main/java/org/asteriskjava/manager/SendEventGeneratingActionCallback.java
+++ b/src/main/java/org/asteriskjava/manager/SendEventGeneratingActionCallback.java
@@ -1,0 +1,31 @@
+package org.asteriskjava.manager;
+
+import org.asteriskjava.manager.response.ManagerError;
+import org.asteriskjava.manager.response.ManagerResponse;
+
+/**
+ * Callback interface to send
+ * {@link org.asteriskjava.manager.action.EventGeneratingAction} asynchronously.
+ *
+ * @see org.asteriskjava.manager.ManagerConnection#sendEventGeneratingAction(org.asteriskjava.manager.action.EventGeneratingAction, SendEventGeneratingActionCallback)
+ *
+ * Initial response is passed to one of {@link #onResponse(ManagerResponse)} or
+ * {@link #onErrorResponse(ManagerResponse)}. but not both.
+ */
+public interface SendEventGeneratingActionCallback
+{
+    /**
+     * Called to notify that
+     * {@link ManagerConnection#sendEventGeneratingAction(org.asteriskjava.manager.action.EventGeneratingAction, SendEventGeneratingActionCallback)}
+     * is done.
+     * <p>
+     * If connection is lost before action is completed then
+     * {@link ResponseEvents#getResponse()} can be null or list of events might
+     * be lacking some events including end event. The
+     * {@link ResponseEvents#getResponse()} can also be {@link ManagerError}
+     *
+     * @param responseEvents
+     *            the response at whatever state it was when action ended.
+     */
+    public void onResponse(ResponseEvents responseEvents);
+}

--- a/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
@@ -51,6 +51,7 @@ import org.asteriskjava.manager.ManagerConnectionState;
 import org.asteriskjava.manager.ManagerEventListener;
 import org.asteriskjava.manager.ResponseEvents;
 import org.asteriskjava.manager.SendActionCallback;
+import org.asteriskjava.manager.SendEventGeneratingActionCallback;
 import org.asteriskjava.manager.TimeoutException;
 import org.asteriskjava.manager.action.ChallengeAction;
 import org.asteriskjava.manager.action.CommandAction;
@@ -1117,6 +1118,56 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
         return responseEvents;
     }
 
+    public void sendEventGeneratingAction(
+            EventGeneratingAction action,
+            SendEventGeneratingActionCallback callback)
+                    throws IOException, IllegalArgumentException, IllegalStateException
+    {
+        if (action == null)
+        {
+            throw new IllegalArgumentException("Unable to send action: action is null.");
+        }
+        else if (action.getActionCompleteEventClass() == null)
+        {
+            throw new IllegalArgumentException(
+                    "Unable to send action: actionCompleteEventClass for " + action.getClass().getName() + " is null.");
+        }
+        else if (!ResponseEvent.class.isAssignableFrom(action.getActionCompleteEventClass()))
+        {
+            throw new IllegalArgumentException(
+                    "Unable to send action: actionCompleteEventClass (" + action.getActionCompleteEventClass().getName()
+                            + ") for " + action.getClass().getName() + " is not a ResponseEvent.");
+        }
+
+        if (state != CONNECTED)
+        {
+            throw new IllegalStateException(
+                    "Actions may only be sent when in state " + "CONNECTED but connection is in state " + state);
+        }
+
+        final String internalActionId = createInternalActionId();
+
+        if (callback != null)
+        {
+            AsyncEventGeneratingResponseHandler responseEventHandler = new AsyncEventGeneratingResponseHandler(
+                    action.getActionCompleteEventClass(), callback);
+
+            // register response handler...
+            synchronized (this.responseListeners)
+            {
+                this.responseListeners.put(internalActionId, responseEventHandler);
+            }
+
+            // ...and event handler.
+            synchronized (this.responseEventListeners)
+            {
+                this.responseEventListeners.put(internalActionId, responseEventHandler);
+            }
+        }
+
+        writer.sendAction(action, internalActionId);
+    }
+
     /**
      * Creates a new unique internal action id based on the hash code of this
      * connection and a sequence.
@@ -1687,6 +1738,79 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
             if (events.isComplete())
             {
                 events.countDown();
+            }
+        }
+    }
+
+    private class AsyncEventGeneratingResponseHandler
+            implements SendActionCallback, ManagerEventListener
+    {
+        private final Class<? extends ResponseEvent> actionCompleteEventClass;
+        private final SendEventGeneratingActionCallback callback;
+
+        private final ResponseEventsImpl events;
+
+        public AsyncEventGeneratingResponseHandler(
+                Class<? extends ResponseEvent> actionCompleteEventClass,
+                SendEventGeneratingActionCallback callback)
+        {
+            this.actionCompleteEventClass = actionCompleteEventClass;
+            this.callback = callback;
+
+            this.events = new ResponseEventsImpl();
+        }
+
+        @Override
+        public void onManagerEvent(ManagerEvent event)
+        {
+            if (event instanceof DisconnectEvent)
+            {
+                callback.onResponse(events);
+                return;
+            }
+
+            // should always be a ResponseEvent, anyway...
+            if (false == (event instanceof ResponseEvent))
+            {
+                return;
+            }
+
+            ResponseEvent responseEvent = (ResponseEvent)event;
+            events.addEvent(responseEvent);
+
+            if (actionCompleteEventClass.isAssignableFrom(event.getClass()))
+            {
+                events.setComplete(true);
+                String internalActionId = responseEvent.getInternalActionId();
+                synchronized (responseEventListeners)
+                {
+                    responseEventListeners.remove(internalActionId);
+                }
+                callback.onResponse(events);
+            }
+        }
+
+        @Override
+        public void onResponse(ManagerResponse response)
+        {
+            // If disconnected
+            if (response == null)
+            {
+                callback.onResponse(events);
+                return;
+            }
+
+            events.setRepsonse(response);
+            if (response instanceof ManagerError)
+            {
+                events.setComplete(true);
+            }
+
+            // finished?
+            if (events.isComplete())
+            {
+                // invoke callback
+                callback.onResponse(events);
             }
         }
     }


### PR DESCRIPTION
In ManagerConnectionImpl adds an asynchronous version of method sendEventGeneratingAction, using a callback.
Ideally this would merge after branch fix-synchronous-calls-block-past-disconnect