### PR TITLE
Channels entering holding bridges should not generate BridgeEvent

### DIFF
--- a/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeState.java
+++ b/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeState.java
@@ -26,6 +26,7 @@ class BridgeState
     private final Log logger = LogFactory.getLog(getClass());
 
     private static final BridgeEnterEventComparator BRIDGE_ENTER_EVENT_COMPARATOR = new BridgeEnterEventComparator();
+    private static final String HOLDING_BRIDGE_TECH = "holding_bridge";
 
     private final Map<String, BridgeEnterEvent> members = new HashMap<>();
 
@@ -48,7 +49,7 @@ class BridgeState
     {
         List<BridgeEnterEvent> remaining = null;
 
-        if (event.getBridgeTechnology().equals("holding_bridge")) {
+        if (HOLDING_BRIDGE_TECH.equals(event.getBridgeTechnology())) {
             /* channels in a holding bridge aren't bridged to one another */
             return null;
         }
@@ -86,7 +87,7 @@ class BridgeState
     {
         List<BridgeEnterEvent> remaining = new LinkedList<>();
 
-        if (event.getBridgeTechnology().equals("holding_bridge")) {
+        if (HOLDING_BRIDGE_TECH.equals(event.getBridgeTechnology())) {
             /* channels in a holding bridge aren't bridged to one another */
             return null;
         }

--- a/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeState.java
+++ b/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeState.java
@@ -48,6 +48,11 @@ class BridgeState
     {
         List<BridgeEnterEvent> remaining = null;
 
+        if (event.getBridgeTechnology().equals("holding_bridge")) {
+	    /* channels in a holding bridge aren't bridged to one another */
+            return null;
+        }
+
         synchronized (members)
         {
             if (members.put(event.getChannel(), event) == null && members.size() == 2)

--- a/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeState.java
+++ b/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeState.java
@@ -49,7 +49,7 @@ class BridgeState
         List<BridgeEnterEvent> remaining = null;
 
         if (event.getBridgeTechnology().equals("holding_bridge")) {
-	    /* channels in a holding bridge aren't bridged to one another */
+            /* channels in a holding bridge aren't bridged to one another */
             return null;
         }
 

--- a/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeState.java
+++ b/src/main/java/org/asteriskjava/manager/internal/backwardsCompatibility/bridge/BridgeState.java
@@ -86,6 +86,11 @@ class BridgeState
     {
         List<BridgeEnterEvent> remaining = new LinkedList<>();
 
+        if (event.getBridgeTechnology().equals("holding_bridge")) {
+            /* channels in a holding bridge aren't bridged to one another */
+            return null;
+        }
+
         synchronized (members)
         {
             remaining.addAll(members.values());


### PR DESCRIPTION
Backwards compatibility in asterisk-java will generate an Asterisk <= 11 style BridgeEvent whenever two channels enter the same bridge. Channels entering bridges where BridgeTechnology = "holding_bridge" should not be considered joined together in these circumstances (a single bridge of this technology is used for parking for instance, and a stasis application could similarly use a holding bridge to keep a set of channels in a bridge without them really being explicitly joined together).

Issue: https://github.com/asterisk-java/asterisk-java/issues/330