### PR TITLE
Allow extending AMI classes to use custom SSL factory

### DIFF
--- a/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/ManagerConnectionImpl.java
@@ -766,7 +766,17 @@ public class ManagerConnectionImpl implements ManagerConnection, Dispatcher
         writer.setSocket(socket);
     }
 
+    // This method signature is preserved for backwards compatibility
+    // e.g. in case there exist any classes overriding this signature
     protected SocketConnectionFacade createSocket() throws IOException
+    {
+        // Forward to method that is convenient to override
+        return createSocket(hostname, port, ssl, socketTimeout, socketReadTimeout, encoding);
+    }
+
+    protected SocketConnectionFacade createSocket(
+            String hostname, int port, boolean ssl, int socketTimeout, int socketReadTimeout, Charset encoding)
+                    throws IOException
     {
         return new SocketConnectionFacadeImpl(hostname, port, ssl, socketTimeout, socketReadTimeout, encoding);
     }

--- a/src/main/java/org/asteriskjava/util/internal/SocketConnectionFacadeImpl.java
+++ b/src/main/java/org/asteriskjava/util/internal/SocketConnectionFacadeImpl.java
@@ -130,7 +130,7 @@ public class SocketConnectionFacadeImpl implements SocketConnectionFacade
 
         if (ssl)
         {
-            socket = SSLSocketFactory.getDefault().createSocket();
+            socket = createSSLSocket();
         }
         else
         {
@@ -144,6 +144,12 @@ public class SocketConnectionFacadeImpl implements SocketConnectionFacade
         {
             trace = new FileTrace(socket);
         }
+    }
+
+    protected Socket createSSLSocket()
+            throws IOException
+    {
+        return SSLSocketFactory.getDefault().createSocket();
     }
 
     /**


### PR DESCRIPTION
Please consider these changes to enable using custom SSLSocketFactory thus allowing custom certificate authority, certificates, validation etc be controlled per connection without affecting runtime defaults.

An example to make use of these changes:

```
public class CustomAmiConnection extends ManagerConnectionImpl
{
	@Override
	protected SocketConnectionFacade createSocket(
			String hostname, int port,
			boolean ssl,
			int socketTimeout,
			int socketReadTimeout,
			Charset encoding)
					throws IOException
	{
		return new CustomSocketConnectionFacadeImpl(hostname, port, ssl, socketTimeout, socketReadTimeout, encoding);
	}

	static class CustomSocketConnectionFacadeImpl extends SocketConnectionFacadeImpl
	{
		public CustomSocketConnectionFacadeImpl(
				String host, int port,
				boolean ssl,
				int timeout,
				int readTimeout,
				Charset encoding)
						throws IOException
		{
			super(host, port, ssl, timeout, readTimeout, encoding);
		}

		@Override
		protected Socket createSSLSocket() throws IOException {
			SSLContext sslContext = getCustomSSLContext();
			return sslContext.getSocketFactory().createSocket();
		}
	}
}
```