### PR TITLE
Add the AMI function PJSipShowEndpoint, and cleans up some documentation.

### DIFF
--- a/src/main/java/org/asteriskjava/manager/AbstractManagerEventListener.java
+++ b/src/main/java/org/asteriskjava/manager/AbstractManagerEventListener.java
@@ -764,7 +764,23 @@ public abstract class AbstractManagerEventListener implements ManagerEventListen
     public void handleEvent(VarSetEvent event)
     {
     }
+    
+    public void handleEvent(EndpointDetail event) 
+    {	
+    }
+    
+    public void handleEvent(AorDetail event) 
+    {	
+    }
 
+    public void handleEvent(ContactStatusDetail event) 
+    {	
+    }
+    
+    public void handleEvent(EndpointDetailComplete event) 
+    {	
+    }
+    
     /**
      * Dispatches to the appropriate handleEvent(...) method.
      *

--- a/src/main/java/org/asteriskjava/manager/action/PJSipShowContactsAction.java
+++ b/src/main/java/org/asteriskjava/manager/action/PJSipShowContactsAction.java
@@ -20,18 +20,18 @@ import org.asteriskjava.manager.event.ContactListComplete;
 import org.asteriskjava.manager.event.ResponseEvent;
 
 /**
- * Retrieves a list of all defined SIP peers.
+ * Retrieves a list of all defined PJSIP contacts.
  * <p>
- * For each peer that is found a PeerEntryEvent is sent by Asterisk containing
- * the details. When all peers have been reported a PeerlistCompleteEvent is
+ * For each contact that is found a ContactList is sent by Asterisk containing
+ * the details. When all contact have been reported a ContactListComplete is
  * sent.
  * <p>
- * Available since Asterisk 1.2 Permission required: write=system
+ * Available since Asterisk 16 Permission required: write=system
  *
  * @author srt
  * @version $Id$
- * @see org.asteriskjava.manager.event.PeerEntryEvent
- * @see org.asteriskjava.manager.event.PeerlistCompleteEvent
+ * @see org.asteriskjava.manager.event.ContactList
+ * @see org.asteriskjava.manager.event.ContactListComplete
  * @since 0.2
  */
 public class PJSipShowContactsAction extends AbstractManagerAction implements EventGeneratingAction

--- a/src/main/java/org/asteriskjava/manager/action/PJSipShowEndpointAction.java
+++ b/src/main/java/org/asteriskjava/manager/action/PJSipShowEndpointAction.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright 2004-2006 Stefan Reuter
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.asteriskjava.manager.action;
+
+import org.asteriskjava.manager.event.EndpointDetailComplete;
+import org.asteriskjava.manager.event.ResponseEvent;
+
+/**
+ * Retrieves details about a given endpoint.
+ * <p>
+ * For the given endpoint, the call will return several events, including
+ * EndpointDetail, AorDetail, AuthDetail, TransportDetail, ContactStatusDetail,and IdentifyDetail.
+ * 
+ * Some events may appear multiple times.
+ * 
+ * When all events have been reported an EndpointDetailComplete is
+ * sent.
+ * <p>
+ * Available since Asterisk 12 Permission required: write=system
+ *
+ * @author Steve Sether
+ * @version $Id$
+ * @see org.asteriskjava.manager.event.ContactStatusDetail
+ * @see org.asteriskjava.manager.event.AorDetail
+ * @see org.asteriskjava.manager.event.EndpointDetail
+ * @see org.asteriskjava.manager.event.TransportDetail
+ * @see org.asteriskjava.manager.event.AuthDetail
+ * @see org.asteriskjava.manager.event.EndpointDetailComplete
+ * @since 12
+ */
+public class PJSipShowEndpointAction extends AbstractManagerAction implements EventGeneratingAction
+{
+	/**
+     * Serial version identifier.
+     */
+	private static final long serialVersionUID = -5508189961610900058L;
+	private String endpoint;
+    
+
+	public String getEndpoint() {
+		return endpoint;
+	}
+
+	public void setEndpoint(String endpoint) {
+		this.endpoint = endpoint;
+	}
+
+	/**
+     * Creates a new SipPeersAction.
+     */
+    public PJSipShowEndpointAction()
+    {
+
+    }
+
+    @Override
+    public String getAction()
+    {
+        return "PJSIPShowEndpoint";
+    }
+
+    public Class< ? extends ResponseEvent> getActionCompleteEventClass()
+    {
+        return EndpointDetailComplete.class;
+    }
+}

--- a/src/main/java/org/asteriskjava/manager/action/PJSipShowEndpointsAction.java
+++ b/src/main/java/org/asteriskjava/manager/action/PJSipShowEndpointsAction.java
@@ -26,13 +26,13 @@ import org.asteriskjava.manager.event.ResponseEvent;
  * the details. When all peers have been reported a PeerlistCompleteEvent is
  * sent.
  * <p>
- * Available since Asterisk 1.2 Permission required: write=system
+ * Available since Asterisk 12 Permission required: write=system
  *
  * @author srt
  * @version $Id$
  * @see org.asteriskjava.manager.event.PeerEntryEvent
  * @see org.asteriskjava.manager.event.PeerlistCompleteEvent
- * @since 0.2
+ * @since 12
  */
 public class PJSipShowEndpointsAction extends AbstractManagerAction implements EventGeneratingAction
 {

--- a/src/main/java/org/asteriskjava/manager/event/AorDetail.java
+++ b/src/main/java/org/asteriskjava/manager/event/AorDetail.java
@@ -1,0 +1,157 @@
+package org.asteriskjava.manager.event;
+
+import org.asteriskjava.util.AstUtil;
+
+/**
+ * A ContactStatusDetail event is triggered in response to a
+ * {@link org.asteriskjava.manager.action.PJSipShowEndpoint},
+ * and contains information about a PJSIP Contact
+ * <p>
+ *
+ * @author Steve Sether
+ * @version $Id$
+ * @since 12
+ */
+
+public class AorDetail extends ResponseEvent {
+
+    /**
+     * Serial version identifier.
+     */
+	private static final long serialVersionUID = 2634171854313358591L;
+	public AorDetail(Object source) {
+		super(source);
+	}
+
+
+	private String objectType;
+	private String objectName;
+	private int minimumExpiration;
+	private int defaultExpiration;
+	private Float qualifyTimeout;
+	private String mailboxes; 
+	private Boolean supportPath;
+	private String voicemailExtension; 
+	private int maxContacts;
+	private Boolean authenticateQualify;
+	private String contacts;
+	private int maximumExpiration;
+	private int qualifyFrequency;
+	private Boolean removeExisting;
+	private String outboundProxy; 
+	private int totalContacts;
+	private int contactsRegistered;
+	private String endpointName;
+	public String getObjectType() {
+		return objectType;
+	}
+	public void setObjectType(String objectType) {
+		this.objectType = objectType;
+	}
+	public String getObjectName() {
+		return objectName;
+	}
+	public void setObjectName(String objectName) {
+		this.objectName = objectName;
+	}
+	public int getMinimumExpiration() {
+		return minimumExpiration;
+	}
+	public void setMinimumExpiration(int minimumExpiration) {
+		this.minimumExpiration = minimumExpiration;
+	}
+	public int getDefaultExpiration() {
+		return defaultExpiration;
+	}
+	public void setDefaultExpiration(int defaultExpiration) {
+		this.defaultExpiration = defaultExpiration;
+	}
+	public Float getQualifyTimeout() {
+		return qualifyTimeout;
+	}
+	public void setQualifyTimeout(Float qualifyTimeout) {
+		this.qualifyTimeout = qualifyTimeout;
+	}
+	public String getMailboxes() {
+		return mailboxes;
+	}
+	public void setMailboxes(String mailboxes) {
+		this.mailboxes = mailboxes;
+	}
+	public Boolean isSupportPath() {
+		return supportPath;
+	}
+	public void setSupportPath(Boolean supportPath) {
+		this.supportPath = supportPath;
+	}
+	public String getVoicemailExtension() {
+		return voicemailExtension;
+	}
+	public void setVoicemailExtension(String voicemailExtension) {
+		this.voicemailExtension = voicemailExtension;
+	}
+	public int getMaxContacts() {
+		return maxContacts;
+	}
+	public void setMaxContacts(int maxContacts) {
+		this.maxContacts = maxContacts;
+	}
+	public Boolean isAuthenticateQualify() {
+		return authenticateQualify;
+	}
+	public void setAuthenticateQualify(Boolean authenticateQualify) {
+		this.authenticateQualify = authenticateQualify;
+	}
+	public String getContacts() {
+		return contacts;
+	}
+	public void setContacts(String contacts) {
+		this.contacts = contacts;
+	}
+	public int getMaximumExpiration() {
+		return maximumExpiration;
+	}
+	public void setMaximumExpiration(int maximumExpiration) {
+		this.maximumExpiration = maximumExpiration;
+	}
+	public int getQualifyFrequency() {
+		return qualifyFrequency;
+	}
+	public void setQualifyFrequency(int qualifyFrequency) {
+		this.qualifyFrequency = qualifyFrequency;
+	}
+	public Boolean isRemoveExisting() {
+		return removeExisting;
+	}
+	public void setRemoveExisting(Boolean removeExisting) {
+		this.removeExisting = removeExisting;
+	}
+	public String getOutboundProxy() {
+		return outboundProxy;
+	}
+	public void setOutboundProxy(String outboundProxy) {
+		this.outboundProxy = outboundProxy;
+	}
+	public int getTotalContacts() {
+		return totalContacts;
+	}
+	public void setTotalContacts(int totalContacts) {
+		this.totalContacts = totalContacts;
+	}
+	public int getContactsRegistered() {
+		return contactsRegistered;
+	}
+	public void setContactsRegistered(int contactsRegistered) {
+		this.contactsRegistered = contactsRegistered;
+	}
+	public String getEndpointName() {
+		return endpointName;
+	}
+	public void setEndpointName(String endpointName) {
+		this.endpointName = endpointName;
+	}
+	
+
+	
+	
+}

--- a/src/main/java/org/asteriskjava/manager/event/AuthDetail.java
+++ b/src/main/java/org/asteriskjava/manager/event/AuthDetail.java
@@ -1,0 +1,121 @@
+package org.asteriskjava.manager.event;
+
+
+/**
+ * An AuthDetail event is triggered in response to a
+ * {@link org.asteriskjava.manager.action.PJSipShowEndpoint},
+ * and contains information about a PJSIP Contact
+ * <p>
+ *
+ * @author Steve Sether
+ * @version $Id$
+ * @since 12
+ */
+
+public class AuthDetail extends ResponseEvent {
+
+	/**
+     * Serial version identifier.
+     */
+	private static final long serialVersionUID = -4998727723768836212L;
+
+	private String event;
+	private String objectType;
+	private String objectName;
+	private String username;
+	private String password;
+	private String md5Cred;
+	private String realm;
+	private int nonceLifetime;
+	private String authType;
+	private String EndpointName;
+
+	public AuthDetail(Object source) {
+		super(source);
+	}
+
+	public String getEvent() {
+		return event;
+	}
+
+	public void setEvent(String event) {
+		this.event = event;
+	}
+
+	public String getObjectType() {
+		return objectType;
+	}
+
+	public void setObjectType(String objectType) {
+		this.objectType = objectType;
+	}
+
+	public String getObjectName() {
+		return objectName;
+	}
+
+	public void setObjectName(String objectName) {
+		this.objectName = objectName;
+	}
+
+	public String getUsername() {
+		return username;
+	}
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	public String getMd5Cred() {
+		return md5Cred;
+	}
+
+	public void setMd5Cred(String md5Cred) {
+		this.md5Cred = md5Cred;
+	}
+
+	public String getRealm() {
+		return realm;
+	}
+
+	public void setRealm(String realm) {
+		this.realm = realm;
+	}
+
+	public int getNonceLifetime() {
+		return nonceLifetime;
+	}
+
+	public void setNonceLifetime(int nonceLifetime) {
+		this.nonceLifetime = nonceLifetime;
+	}
+
+	public String getAuthType() {
+		return authType;
+	}
+
+	public void setAuthType(String authType) {
+		this.authType = authType;
+	}
+
+	public String getEndpointName() {
+		return EndpointName;
+	}
+
+	public void setEndpointName(String endpointName) {
+		EndpointName = endpointName;
+	}
+
+
+
+	
+	
+}

--- a/src/main/java/org/asteriskjava/manager/event/ContactStatusDetail.java
+++ b/src/main/java/org/asteriskjava/manager/event/ContactStatusDetail.java
@@ -1,0 +1,171 @@
+package org.asteriskjava.manager.event;
+
+import org.asteriskjava.util.AstUtil;
+
+/**
+ * A ContactStatusDetail event is triggered in response to a
+ * {@link org.asteriskjava.manager.action.PJSipShowEndpoint},
+ * and contains information about a PJSIP Contact 
+ * <p>
+ *
+ * @author Steve Sether
+ * @version $Id$
+ * @since 12
+ */
+
+public class ContactStatusDetail extends ResponseEvent {
+
+    /**
+     * Serial version identifier.
+     */
+	private static final long serialVersionUID = 987290433601178780L;
+	private String aor;
+	private String uri;
+	private String userAgent;
+	private long regExpire;
+	private String viaAddress;
+	private String callID;
+	private String status;
+	// roundtripusec when it contains a value is a long, but when it doesn't
+	// asterisk reports "N/A"
+	private String roundtripUsec;
+	private String endpointName;
+	private String id;
+	private Boolean authenticateQualify;
+	private String outboundProxy; 
+	private String path; 
+	private int qualifyFrequency;
+	private Float qualifyTimeout;
+	
+	public String getAor() {
+		return aor;
+	}
+	
+	public void setAor(String aor) {
+		this.aor = aor;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	public String getUri() {
+		return uri;
+	}
+
+	public void setUri(String uri) {
+		this.uri = uri;
+	}
+
+	public String getUserAgent() {
+		return userAgent;
+	}
+
+	public void setUserAgent(String userAgent) {
+		this.userAgent = userAgent;
+	}
+
+	public long getRegExpire() {
+		return regExpire;
+	}
+
+	public void setRegExpire(long regExpire) {
+		this.regExpire = regExpire;
+	}
+
+	public String getViaAddress() {
+		return viaAddress;
+	}
+
+	public void setViaAddress(String viaAddress) {
+		this.viaAddress = viaAddress;
+	}
+
+	public String getCallID() {
+		return callID;
+	}
+
+	public void setCallID(String callID) {
+		this.callID = callID;
+	}
+
+	public String getEndpointName() {
+		return endpointName;
+	}
+
+	public void setEndpointName(String endpointName) {
+		this.endpointName = endpointName;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public Boolean isAuthenticateQualify() {
+		return authenticateQualify;
+	}
+
+	public void setAuthenticateQualify(Boolean authenticateQualify) {
+		this.authenticateQualify = authenticateQualify;
+	}
+	
+	public String getOutboundProxy() {
+		return outboundProxy;
+	}
+
+	public void setOutboundProxy(String outboundProxy) {
+		this.outboundProxy = outboundProxy;
+	}
+
+	public String getPath() {
+		return path;
+	}
+
+	public void setPath(String path) {
+		this.path = path;
+	}
+
+	public int getQualifyFrequency() {
+		return qualifyFrequency;
+	}
+
+	public void setQualifyFrequency(int qualifyFrequency) {
+		this.qualifyFrequency = qualifyFrequency;
+	}
+
+	public Float getQualifyTimeout() {
+		return qualifyTimeout;
+	}
+
+	public void setQualifyTimeout(Float qualifyTimeout) {
+		this.qualifyTimeout = qualifyTimeout;
+	}
+	
+	public void setQualifyTimeout(String qualifyTimeout) {
+		this.qualifyTimeout = Float.parseFloat(qualifyTimeout);
+	}
+
+	public ContactStatusDetail(Object source) {
+		super(source);
+	}
+
+	public String getRoundtripUsec() {
+		return roundtripUsec;
+	}
+
+	public void setRoundtripUsec(String roundtripUsec) {
+		this.roundtripUsec = roundtripUsec;
+	}
+
+
+	
+	
+}

--- a/src/main/java/org/asteriskjava/manager/event/EndpointDetail.java
+++ b/src/main/java/org/asteriskjava/manager/event/EndpointDetail.java
@@ -1,0 +1,1148 @@
+package org.asteriskjava.manager.event;
+
+import org.asteriskjava.util.AstUtil;
+
+/**
+ * A EndpointDetail event is triggered in response to a
+ * {@link org.asteriskjava.manager.action.PJSipShowEndpoint},
+ * and contains information about a PJSIP endpoint
+ * <p>
+ *
+ * @author Steve Sether
+ * @version $Id$
+ * @since 12
+ */
+
+public class EndpointDetail extends ResponseEvent {
+
+    /**
+     * Serial version identifier.
+     */
+	private static final long serialVersionUID = 77481930059189731L;
+    private Integer listItems;
+    private String eventList;
+	
+	public Integer getListItems() {
+		return listItems;
+	}
+
+	public void setListItems(Integer listItems) {
+		this.listItems = listItems;
+	}
+
+	public String getEventList() {
+		return eventList;
+	}
+
+	public void setEventList(String eventList) {
+		this.eventList = eventList;
+	}
+
+	private String objectName;
+	private String objectType;
+	private Boolean rpidImmediate;
+	private Boolean webrtc;
+	private Boolean ignorel83WithoutSdp;
+	private int deviceStateBusyAt;
+	private int t38UdptlMaxdatagram;
+	private int dtlsRekey;
+	private String namedPickupGroup; 
+	private String directMediaMethod;
+	private Boolean sendRpid;
+	private String pickupGroup; 
+	private String sdpSession;
+	private String dtlsVerify;
+	private String messageContext;
+	private String mailboxes;
+	private String recordOnFeature;
+	private String dtlsPrivateKey; 
+	private String dtlsFingerprint;
+	private String fromDomain; 
+	private int timersSessExpires;
+	private String namedCallGroup; 
+	private String dtlsCipher; 
+	private Boolean mediaEncryptionOptimistic;
+	private Boolean suppressQ850ReasonHeaders;
+	private String aors;
+	private String identifyBy;
+	private String calleridPrivacy;
+	private String mwiSubscribeReplacesUnsolicited;
+	private String cosAudio;
+	private Boolean followEarlyMediaFork;
+	private String context;
+	private Boolean rtpSymmetric;
+	private String transport; 
+	private String mohSuggest;
+	private Boolean t38Udptl;
+	private Boolean faxDetect;
+	private String tosVideo;
+	private Boolean srtpTag32;
+	private Boolean referBlindProgress;
+	private int maxAudioStreams;
+	private Boolean bundle;
+	private Boolean useAvpf;
+	private String callGroup; 
+	private Boolean sendConnectedLine;
+	private int faxDetectTimeout;
+	private String sdpOwner;
+	private Boolean forceRport;
+	private String calleridTag; 
+	private int rtpTimeoutHold;
+	private Boolean usePtime;
+	private String mediaAddress; 
+	private String voicemailExtension; 
+	private int rtpTimeout;
+	private String setVar;
+	private String contactAcl; 
+	private Boolean preferredCodecOnly;
+	private Boolean forceAvp;
+	private String recordOffFeature;
+	private String fromUser; 
+	private Boolean sendDiversion;
+	private Boolean t38UdptlIpv6;
+	private String toneZone; 
+	private String language; 
+	private Boolean allowSubscribe;
+	private Boolean rtpIpv6;
+	private String callerid;
+	private Boolean mohPassthrough;
+	private String cosVideo;
+	private String dtlsAutoGenerateCert;
+	private Boolean asymmetricRtpCodec;
+	private Boolean iceSupport;
+	private Boolean aggregateMwi;
+	private Boolean oneTouchRecording;
+	private String mwiFromUser; 
+	private String accountcode;
+	private String allow;
+	private Boolean rewriteContact;
+	private Boolean userEqPhone;
+	private String rtpEngine;
+	private String subscribeContext;
+	private Boolean notifyEarlyInuseRinging;
+	private String incomingMwiMailbox; 
+	private String auth; 
+	private String directMediaGlareMitigation;
+	private Boolean trustIdInbound;
+	private Boolean bindRtpToMediaAddress;
+	private Boolean disableDirectMediaOnNat;
+	private Boolean mediaEncryption;
+	private Boolean mediaUseReceivedTransport;
+	private Boolean allowOverlap;
+	private String dtmfMode;
+	private String outboundAuth; 
+	private String tosAudio;
+	private String dtlsCertFile; 
+	private String dtlsCaPath; 
+	private String dtlsSetup;
+	private String connectedLineMethod;
+	private Boolean g726NonStandard;
+	private String _100rel;
+	private String timers;
+	private Boolean directMedia;
+	private String acl;
+	private int timersMinSe;
+	private Boolean trustIdOutbound;
+	private int subMinExpiry;
+	private Boolean rtcpMux;
+	private int maxVideoStreams;
+	private Boolean acceptMultipleSdpAnswers;
+	private Boolean trustConnectedLine;
+	private Boolean sendPai;
+	private int rtpKeepalive;
+	private String t38UdptlEc;
+	private Boolean t38UdptlNat;
+	private Boolean allowTransfer;
+	private String dtlsCaFile; 
+	private String outboundProxy;
+	private Boolean inbandProgress;
+	private String deviceState;
+	private String activeChannels;
+	private Boolean ignore183withoutsdp;
+	
+	public int getMaxVideoStreams() {
+		return maxVideoStreams;
+	}
+
+	public void setMaxVideoStreams(int maxVideoStreams) {
+		this.maxVideoStreams = maxVideoStreams;
+	}
+	
+	public String getObjectName() {
+		return objectName;
+	}
+
+	public void setObjectName(String objectName) {
+		this.objectName = objectName;
+	}
+
+	public String getObjectType() {
+		return objectType;
+	}
+
+	public void setObjectType(String objectType) {
+		this.objectType = objectType;
+	}
+
+	public Boolean isRpidImmediate() {
+		return rpidImmediate;
+	}
+
+	public void setRpidImmediate(Boolean rpidImmediate) {
+		this.rpidImmediate = rpidImmediate;
+	}
+	
+	public Boolean isWebrtc() {
+		return webrtc;
+	}
+
+	public void setWebrtc(Boolean webrtc) {
+		this.webrtc = webrtc;
+	}
+
+	public Boolean isIgnorel83WithoutSdp() {
+		return ignorel83WithoutSdp;
+	}
+
+	public void setIgnorel83WithoutSdp(Boolean ignorel83WithoutSdp) {
+		this.ignorel83WithoutSdp = ignorel83WithoutSdp;
+	}
+
+	public int getDeviceStateBusyAt() {
+		return deviceStateBusyAt;
+	}
+
+	public void setDeviceStateBusyAt(int deviceStateBusyAt) {
+		this.deviceStateBusyAt = deviceStateBusyAt;
+	}
+
+	public int getT38UdptlMaxdatagram() {
+		return t38UdptlMaxdatagram;
+	}
+
+	public void setT38UdptlMaxdatagram(int t38UdptlMaxdatagram) {
+		this.t38UdptlMaxdatagram = t38UdptlMaxdatagram;
+	}
+
+	public int getDtlsRekey() {
+		return dtlsRekey;
+	}
+
+	public void setDtlsRekey(int dtlsRekey) {
+		this.dtlsRekey = dtlsRekey;
+	}
+
+	public String getNamedPickupGroup() {
+		return namedPickupGroup;
+	}
+
+	public void setNamedPickupGroup(String namedPickupGroup) {
+		this.namedPickupGroup = namedPickupGroup;
+	}
+
+	public String getDirectMediaMethod() {
+		return directMediaMethod;
+	}
+
+	public void setDirectMediaMethod(String directMediaMethod) {
+		this.directMediaMethod = directMediaMethod;
+	}
+
+	public Boolean isSendRpid() {
+		return sendRpid;
+	}
+
+	public void setSendRpid(Boolean sendRpid) {
+		this.sendRpid = sendRpid;
+	}
+
+	public String getPickupGroup() {
+		return pickupGroup;
+	}
+
+	public void setPickupGroup(String pickupGroup) {
+		this.pickupGroup = pickupGroup;
+	}
+
+	public String getSdpSession() {
+		return sdpSession;
+	}
+
+	public void setSdpSession(String sdpSession) {
+		this.sdpSession = sdpSession;
+	}
+
+	public String getDtlsVerify() {
+		return dtlsVerify;
+	}
+
+	public void setDtlsVerify(String dtlsVerify) {
+		this.dtlsVerify = dtlsVerify;
+	}
+
+	public String getMessageContext() {
+		return messageContext;
+	}
+
+	public void setMessageContext(String messageContext) {
+		this.messageContext = messageContext;
+	}
+
+	public String getMailboxes() {
+		return mailboxes;
+	}
+
+	public void setMailboxes(String mailboxes) {
+		this.mailboxes = mailboxes;
+	}
+
+	public String getRecordOnFeature() {
+		return recordOnFeature;
+	}
+
+	public void setRecordOnFeature(String recordOnFeature) {
+		this.recordOnFeature = recordOnFeature;
+	}
+
+	public String getDtlsPrivateKey() {
+		return dtlsPrivateKey;
+	}
+
+	public void setDtlsPrivateKey(String dtlsPrivateKey) {
+		this.dtlsPrivateKey = dtlsPrivateKey;
+	}
+
+	public String getDtlsFingerprint() {
+		return dtlsFingerprint;
+	}
+
+	public void setDtlsFingerprint(String dtlsFingerprint) {
+		this.dtlsFingerprint = dtlsFingerprint;
+	}
+
+	public String getFromDomain() {
+		return fromDomain;
+	}
+
+	public void setFromDomain(String fromDomain) {
+		this.fromDomain = fromDomain;
+	}
+
+	public int getTimersSessExpires() {
+		return timersSessExpires;
+	}
+
+	public void setTimersSessExpires(int timersSessExpires) {
+		this.timersSessExpires = timersSessExpires;
+	}
+
+	public String getNamedCallGroup() {
+		return namedCallGroup;
+	}
+
+	public void setNamedCallGroup(String namedCallGroup) {
+		this.namedCallGroup = namedCallGroup;
+	}
+
+	public String getDtlsCipher() {
+		return dtlsCipher;
+	}
+
+	public void setDtlsCipher(String dtlsCipher) {
+		this.dtlsCipher = dtlsCipher;
+	}
+
+	public Boolean isMediaEncryptionOptimistic() {
+		return mediaEncryptionOptimistic;
+	}
+
+	public void setMediaEncryptionOptimistic(Boolean mediaEncryptionOptimistic) {
+		this.mediaEncryptionOptimistic = mediaEncryptionOptimistic;
+	}
+
+	public Boolean isSuppressQ850ReasonHeaders() {
+		return suppressQ850ReasonHeaders;
+	}
+
+	public void setSuppressQ850ReasonHeaders(Boolean suppressQ850ReasonHeaders) {
+		this.suppressQ850ReasonHeaders = suppressQ850ReasonHeaders;
+	}
+
+	public String getAors() {
+		return aors;
+	}
+
+	public void setAors(String aors) {
+		this.aors = aors;
+	}
+
+	public String getIdentifyBy() {
+		return identifyBy;
+	}
+
+	public void setIdentifyBy(String identifyBy) {
+		this.identifyBy = identifyBy;
+	}
+
+	public String getCalleridPrivacy() {
+		return calleridPrivacy;
+	}
+
+	public void setCalleridPrivacy(String calleridPrivacy) {
+		this.calleridPrivacy = calleridPrivacy;
+	}
+
+	public String getMwiSubscribeReplacesUnsolicited() {
+		return mwiSubscribeReplacesUnsolicited;
+	}
+
+	public void setMwiSubscribeReplacesUnsolicited(String mwiSubscribeReplacesUnsolicited) {
+		this.mwiSubscribeReplacesUnsolicited = mwiSubscribeReplacesUnsolicited;
+	}
+
+	public Boolean isFollowEarlyMediaFork() {
+		return followEarlyMediaFork;
+	}
+
+	public void setFollowEarlyMediaFork(Boolean followEarlyMediaFork) {
+		this.followEarlyMediaFork = followEarlyMediaFork;
+	}
+
+	public String getContext() {
+		return context;
+	}
+
+	public void setContext(String context) {
+		this.context = context;
+	}
+
+	public Boolean isRtpSymmetric() {
+		return rtpSymmetric;
+	}
+
+	public void setRtpSymmetric(Boolean rtpSymmetric) {
+		this.rtpSymmetric = rtpSymmetric;
+	}
+
+	public String getTransport() {
+		return transport;
+	}
+
+	public void setTransport(String transport) {
+		this.transport = transport;
+	}
+
+	public String getMohSuggest() {
+		return mohSuggest;
+	}
+
+	public void setMohSuggest(String mohSuggest) {
+		this.mohSuggest = mohSuggest;
+	}
+
+	public Boolean isT38Udptl() {
+		return t38Udptl;
+	}
+
+	public void setT38Udptl(Boolean t38Udptl) {
+		this.t38Udptl = t38Udptl;
+	}
+
+	public Boolean isFaxDetect() {
+		return faxDetect;
+	}
+
+	public void setFaxDetect(Boolean faxDetect) {
+		this.faxDetect = faxDetect;
+	}
+
+	public Boolean getSrtpTag32() {
+		return srtpTag32;
+	}
+
+	public void setSrtpTag32(Boolean srtpTag32) {
+		this.srtpTag32 = srtpTag32;
+	}
+
+	public Boolean isReferBlindProgress() {
+		return referBlindProgress;
+	}
+
+	public void setReferBlindProgress(Boolean referBlindProgress) {
+		this.referBlindProgress = referBlindProgress;
+	}
+	
+	public int getMaxAudioStreams() {
+		return maxAudioStreams;
+	}
+
+	public void setMaxAudioStreams(int maxAudioStreams) {
+		this.maxAudioStreams = maxAudioStreams;
+	}
+
+	public Boolean isBundle() {
+		return bundle;
+	}
+
+	public void setBundle(Boolean bundle) {
+		this.bundle = bundle;
+	}
+	
+
+	public Boolean isUseAvpf() {
+		return useAvpf;
+	}
+
+	public void setUseAvpf(Boolean useAvpf) {
+		this.useAvpf = useAvpf;
+	}
+	
+
+	public String getCallGroup() {
+		return callGroup;
+	}
+
+	public void setCallGroup(String callGroup) {
+		this.callGroup = callGroup;
+	}
+
+	public Boolean isSendConnectedLine() {
+		return sendConnectedLine;
+	}
+
+	public void setSendConnectedLine(Boolean sendConnectedLine) {
+		this.sendConnectedLine = sendConnectedLine;
+	}
+	
+
+	public int getFaxDetectTimeout() {
+		return faxDetectTimeout;
+	}
+
+	public void setFaxDetectTimeout(int faxDetectTimeout) {
+		this.faxDetectTimeout = faxDetectTimeout;
+	}
+
+	public String getSdpOwner() {
+		return sdpOwner;
+	}
+
+	public void setSdpOwner(String sdpOwner) {
+		this.sdpOwner = sdpOwner;
+	}
+
+	public Boolean isForceRport() {
+		return forceRport;
+	}
+
+	public void setForceRport(Boolean forceRport) {
+		this.forceRport = forceRport;
+	}
+	
+
+	public String getCalleridTag() {
+		return calleridTag;
+	}
+
+	public void setCalleridTag(String calleridTag) {
+		this.calleridTag = calleridTag;
+	}
+
+	public int getRtpTimeoutHold() {
+		return rtpTimeoutHold;
+	}
+
+	public void setRtpTimeoutHold(int rtpTimeoutHold) {
+		this.rtpTimeoutHold = rtpTimeoutHold;
+	}
+
+	public Boolean isUsePtime() {
+		return usePtime;
+	}
+
+	public void setUsePtime(Boolean usePtime) {
+		this.usePtime = usePtime;
+	}
+	
+
+	public String getMediaAddress() {
+		return mediaAddress;
+	}
+
+	public void setMediaAddress(String mediaAddress) {
+		this.mediaAddress = mediaAddress;
+	}
+
+	public String getVoicemailExtension() {
+		return voicemailExtension;
+	}
+
+	public void setVoicemailExtension(String voicemailExtension) {
+		this.voicemailExtension = voicemailExtension;
+	}
+
+	public int getRtpTimeout() {
+		return rtpTimeout;
+	}
+
+	public void setRtpTimeout(int rtpTimeout) {
+		this.rtpTimeout = rtpTimeout;
+	}
+
+	public String getSetVar() {
+		return setVar;
+	}
+
+	public void setSetVar(String setVar) {
+		this.setVar = setVar;
+	}
+
+	public String getContactAcl() {
+		return contactAcl;
+	}
+
+	public void setContactAcl(String contactAcl) {
+		this.contactAcl = contactAcl;
+	}
+
+	public Boolean isPreferredCodecOnly() {
+		return preferredCodecOnly;
+	}
+
+	public void setPreferredCodecOnly(Boolean preferredCodecOnly) {
+		this.preferredCodecOnly = preferredCodecOnly;
+	}
+	
+	public Boolean isForceAvp() {
+		return forceAvp;
+	}
+
+	public void setForceAvp(Boolean forceAvp) {
+		this.forceAvp = forceAvp;
+	}
+	
+
+	public String getRecordOffFeature() {
+		return recordOffFeature;
+	}
+
+	public void setRecordOffFeature(String recordOffFeature) {
+		this.recordOffFeature = recordOffFeature;
+	}
+
+	public String getFromUser() {
+		return fromUser;
+	}
+
+	public void setFromUser(String fromUser) {
+		this.fromUser = fromUser;
+	}
+
+	public Boolean isSendDiversion() {
+		return sendDiversion;
+	}
+
+	public void setSendDiversion(Boolean sendDiversion) {
+		this.sendDiversion = sendDiversion;
+	}
+	
+
+	public Boolean isT38UdptlIpv6() {
+		return t38UdptlIpv6;
+	}
+
+	public void setT38UdptlIpv6(Boolean t38UdptlIpv6) {
+		this.t38UdptlIpv6 = t38UdptlIpv6;
+	}
+	
+
+	public String getToneZone() {
+		return toneZone;
+	}
+
+	public void setToneZone(String toneZone) {
+		this.toneZone = toneZone;
+	}
+
+	public String getLanguage() {
+		return language;
+	}
+
+	public void setLanguage(String language) {
+		this.language = language;
+	}
+
+	public Boolean isAllowSubscribe() {
+		return allowSubscribe;
+	}
+
+	public void setAllowSubscribe(Boolean allowSubscribe) {
+		this.allowSubscribe = allowSubscribe;
+	}
+	
+	public Boolean isRtpIpv6() {
+		return rtpIpv6;
+	}
+
+	public void setRtpIpv6(Boolean rtpIpv6) {
+		this.rtpIpv6 = rtpIpv6;
+	}
+	
+
+	public String getCallerid() {
+		return callerid;
+	}
+
+	public void setCallerid(String callerid) {
+		this.callerid = callerid;
+	}
+
+	public Boolean isMohPassthrough() {
+		return mohPassthrough;
+	}
+
+	public void setMohPassthrough(Boolean mohPassthrough) {
+		this.mohPassthrough = mohPassthrough;
+	}
+	
+	public String getCosAudio() {
+		return cosAudio;
+	}
+
+	public void setCosAudio(String cosAudio) {
+		this.cosAudio = cosAudio;
+	}
+
+	public String getCosVideo() {
+		return cosVideo;
+	}
+
+	public void setCosVideo(String cosVideo) {
+		this.cosVideo = cosVideo;
+	}
+
+	public String getDtlsAutoGenerateCert() {
+		return dtlsAutoGenerateCert;
+	}
+
+	public void setDtlsAutoGenerateCert(String dtlsAutoGenerateCert) {
+		this.dtlsAutoGenerateCert = dtlsAutoGenerateCert;
+	}
+
+	public Boolean isAsymmetricRtpCodec() {
+		return asymmetricRtpCodec;
+	}
+
+	public void setAsymmetricRtpCodec(Boolean asymmetricRtpCodec) {
+		this.asymmetricRtpCodec = asymmetricRtpCodec;
+	}
+	
+
+	public Boolean isIceSupport() {
+		return iceSupport;
+	}
+
+	public void setIceSupport(Boolean iceSupport) {
+		this.iceSupport = iceSupport;
+	}
+
+	
+	public Boolean isAggregateMwi() {
+		return aggregateMwi;
+	}
+
+	public void setAggregateMwi(Boolean aggregateMwi) {
+		this.aggregateMwi = aggregateMwi;
+	}
+	
+
+	public Boolean isOneTouchRecording() {
+		return oneTouchRecording;
+	}
+
+	public void setOneTouchRecording(Boolean oneTouchRecording) {
+		this.oneTouchRecording = oneTouchRecording;
+	}
+	
+
+	public String getMwiFromUser() {
+		return mwiFromUser;
+	}
+
+	public void setMwiFromUser(String mwiFromUser) {
+		this.mwiFromUser = mwiFromUser;
+	}
+
+	public String getAccountcode() {
+		return accountcode;
+	}
+
+	public void setAccountcode(String accountcode) {
+		this.accountcode = accountcode;
+	}
+
+	public String getAllow() {
+		return allow;
+	}
+
+	public void setAllow(String allow) {
+		this.allow = allow;
+	}
+
+	public Boolean isRewriteContact() {
+		return rewriteContact;
+	}
+
+	public void setRewriteContact(Boolean rewriteContact) {
+		this.rewriteContact = rewriteContact;
+	}
+	
+	public Boolean isUserEqPhone() {
+		return userEqPhone;
+	}
+
+	public void setUserEqPhone(Boolean userEqPhone) {
+		this.userEqPhone = userEqPhone;
+	}
+	
+	public String getRtpEngine() {
+		return rtpEngine;
+	}
+
+	public void setRtpEngine(String rtpEngine) {
+		this.rtpEngine = rtpEngine;
+	}
+
+	public String getSubscribeContext() {
+		return subscribeContext;
+	}
+
+	public void setSubscribeContext(String subscribeContext) {
+		this.subscribeContext = subscribeContext;
+	}
+
+	public Boolean isNotifyEarlyInuseRinging() {
+		return notifyEarlyInuseRinging;
+	}
+
+	public void setNotifyEarlyInuseRinging(Boolean notifyEarlyInuseRinging) {
+		this.notifyEarlyInuseRinging = notifyEarlyInuseRinging;
+	}
+	
+	public String getIncomingMwiMailbox() {
+		return incomingMwiMailbox;
+	}
+
+	public void setIncomingMwiMailbox(String incomingMwiMailbox) {
+		this.incomingMwiMailbox = incomingMwiMailbox;
+	}
+
+	public String getAuth() {
+		return auth;
+	}
+
+	public void setAuth(String auth) {
+		this.auth = auth;
+	}
+
+	public String getDirectMediaGlareMitigation() {
+		return directMediaGlareMitigation;
+	}
+
+	public void setDirectMediaGlareMitigation(String directMediaGlareMitigation) {
+		this.directMediaGlareMitigation = directMediaGlareMitigation;
+	}
+
+	public Boolean isTrustIdInbound() {
+		return trustIdInbound;
+	}
+
+	public void setTrustIdInbound(Boolean trustIdInbound) {
+		this.trustIdInbound = trustIdInbound;
+	}
+	
+	public Boolean isBindRtpToMediaAddress() {
+		return bindRtpToMediaAddress;
+	}
+
+	public void setBindRtpToMediaAddress(Boolean bindRtpToMediaAddress) {
+		this.bindRtpToMediaAddress = bindRtpToMediaAddress;
+	}
+	
+	public Boolean isDisableDirectMediaOnNat() {
+		return disableDirectMediaOnNat;
+	}
+
+	public void setDisableDirectMediaOnNat(Boolean disableDirectMediaOnNat) {
+		this.disableDirectMediaOnNat = disableDirectMediaOnNat;
+	}
+	
+	public Boolean isMediaEncryption() {
+		return mediaEncryption;
+	}
+
+	public void setMediaEncryption(Boolean mediaEncryption) {
+		this.mediaEncryption = mediaEncryption;
+	}
+	
+	public Boolean isMediaUseReceivedTransport() {
+		return mediaUseReceivedTransport;
+	}
+
+	public void setMediaUseReceivedTransport(Boolean mediaUseReceivedTransport) {
+		this.mediaUseReceivedTransport = mediaUseReceivedTransport;
+	}
+	
+	public Boolean isAllowOverlap() {
+		return allowOverlap;
+	}
+
+	public void setAllowOverlap(Boolean allowOverlap) {
+		this.allowOverlap = allowOverlap;
+	}
+	
+	public String getDtmfMode() {
+		return dtmfMode;
+	}
+
+	public void setDtmfMode(String dtmfMode) {
+		this.dtmfMode = dtmfMode;
+	}
+
+	public String getOutboundAuth() {
+		return outboundAuth;
+	}
+
+	public void setOutboundAuth(String outboundAuth) {
+		this.outboundAuth = outboundAuth;
+	}
+	
+	public String getTosVideo() {
+		return tosVideo;
+	}
+
+	public void setTosVideo(String tosVideo) {
+		this.tosVideo = tosVideo;
+	}
+
+	public String getTosAudio() {
+		return tosAudio;
+	}
+
+	public void setTosAudio(String tosAudio) {
+		this.tosAudio = tosAudio;
+	}
+
+	public String getDtlsCertFile() {
+		return dtlsCertFile;
+	}
+
+	public void setDtlsCertFile(String dtlsCertFile) {
+		this.dtlsCertFile = dtlsCertFile;
+	}
+
+	public String getDtlsCaPath() {
+		return dtlsCaPath;
+	}
+
+	public void setDtlsCaPath(String dtlsCaPath) {
+		this.dtlsCaPath = dtlsCaPath;
+	}
+
+	public String getDtlsSetup() {
+		return dtlsSetup;
+	}
+
+	public void setDtlsSetup(String dtlsSetup) {
+		this.dtlsSetup = dtlsSetup;
+	}
+
+	public String getConnectedLineMethod() {
+		return connectedLineMethod;
+	}
+
+	public void setConnectedLineMethod(String connectedLineMethod) {
+		this.connectedLineMethod = connectedLineMethod;
+	}
+
+	public Boolean isG726NonStandard() {
+		return g726NonStandard;
+	}
+
+	public void setG726NonStandard(Boolean g726NonStandard) {
+		this.g726NonStandard = g726NonStandard;
+	}
+
+	public String get100rel() {
+		return _100rel;
+	}
+
+	public void set100rel(String _100rel) {
+		this._100rel = _100rel;
+	}
+
+	public String getTimers() {
+		return timers;
+	}
+
+	public void setTimers(String timers) {
+		this.timers = timers;
+	}
+
+	public Boolean isDirectMedia() {
+		return directMedia;
+	}
+
+	public void setDirectMedia(Boolean directMedia) {
+		this.directMedia = directMedia;
+	}
+
+	public String getAcl() {
+		return acl;
+	}
+
+	public void setAcl(String acl) {
+		this.acl = acl;
+	}
+
+	public int getTimersMinSe() {
+		return timersMinSe;
+	}
+
+	public void setTimersMinSe(int timersMinSe) {
+		this.timersMinSe = timersMinSe;
+	}
+
+	public Boolean isTrustIdOutbound() {
+		return trustIdOutbound;
+	}
+
+	public void setTrustIdOutbound(Boolean trustIdOutbound) {
+		this.trustIdOutbound = trustIdOutbound;
+	}
+
+	public int getSubMinExpiry() {
+		return subMinExpiry;
+	}
+
+	public void setSubMinExpiry(int subMinExpiry) {
+		this.subMinExpiry = subMinExpiry;
+	}
+
+	public Boolean isRtcpMux() {
+		return rtcpMux;
+	}
+
+	public void setRtcpMux(Boolean rtcpMux) {
+		this.rtcpMux = rtcpMux;
+	}
+
+	public Boolean isAcceptMultipleSdpAnswers() {
+		return acceptMultipleSdpAnswers;
+	}
+
+	public void setAcceptMultipleSdpAnswers(Boolean acceptMultipleSdpAnswers) {
+		this.acceptMultipleSdpAnswers = acceptMultipleSdpAnswers;
+	}
+
+	public Boolean isTrustConnectedLine() {
+		return trustConnectedLine;
+	}
+
+	public void setTrustConnectedLine(Boolean trustConnectedLine) {
+		this.trustConnectedLine = trustConnectedLine;
+	}
+
+	public Boolean isSendPai() {
+		return sendPai;
+	}
+
+	public void setSendPai(Boolean sendPai) {
+		this.sendPai = sendPai;
+	}
+
+	public int getRtpKeepalive() {
+		return rtpKeepalive;
+	}
+
+	public void setRtpKeepalive(int rtpKeepalive) {
+		this.rtpKeepalive = rtpKeepalive;
+	}
+
+	public String getT38UdptlEc() {
+		return t38UdptlEc;
+	}
+
+	public void setT38UdptlEc(String t38UdptlEc) {
+		this.t38UdptlEc = t38UdptlEc;
+	}
+
+	public Boolean isT38UdptlNat() {
+		return t38UdptlNat;
+	}
+
+	public void setT38UdptlNat(Boolean t38UdptlNat) {
+		this.t38UdptlNat = t38UdptlNat;
+	}
+
+	public Boolean isAllowTransfer() {
+		return allowTransfer;
+	}
+
+	public void setAllowTransfer(Boolean allowTransfer) {
+		this.allowTransfer = allowTransfer;
+	}
+
+	public String getDtlsCaFile() {
+		return dtlsCaFile;
+	}
+
+	public void setDtlsCaFile(String dtlsCaFile) {
+		this.dtlsCaFile = dtlsCaFile;
+	}
+
+	public String getOutboundProxy() {
+		return outboundProxy;
+	}
+
+	public void setOutboundProxy(String outboundProxy) {
+		this.outboundProxy = outboundProxy;
+	}
+
+	public Boolean isInbandProgress() {
+		return inbandProgress;
+	}
+
+	public void setInbandProgress(Boolean inbandProgress) {
+		this.inbandProgress = inbandProgress;
+	}
+
+	public String getDeviceState() {
+		return deviceState;
+	}
+
+	public void setDeviceState(String deviceState) {
+		this.deviceState = deviceState;
+	}
+
+	public String getActiveChannels() {
+		return activeChannels;
+	}
+
+	public void setActiveChannels(String activeChannels) {
+		this.activeChannels = activeChannels;
+	}
+
+	public EndpointDetail(Object source) {
+		super(source);
+	}
+
+	public Boolean getIgnore183withoutsdp() {
+		return ignore183withoutsdp;
+	}
+
+	public void setIgnore183withoutsdp(Boolean ignore183withoutsdp) {
+		this.ignore183withoutsdp = ignore183withoutsdp;
+	}
+
+}

--- a/src/main/java/org/asteriskjava/manager/event/EndpointDetailComplete.java
+++ b/src/main/java/org/asteriskjava/manager/event/EndpointDetailComplete.java
@@ -17,17 +17,17 @@
 package org.asteriskjava.manager.event;
 
 /**
- * An EndpointListComplete event is triggered after the details of all end points have been
- * reported in response to a PJSIPShowEndpoints event.
+ * An EndpointDetailComplete event is triggered after the details of an endpoint has been
+ * reported in response to a PJSIPShowEndpoint
  * <p>
  * Available since Asterisk 12
  * 
- * @see org.asteriskjava.manager.event.PJSipShowEndpoints
- * @author srt
+ * @see org.asteriskjava.manager.event.PJSIpShowEndpoint
+ * @author Steve Sether
  * @version $Id$
  * @since 12
  */
-public class EndpointListComplete extends ResponseEvent
+public class EndpointDetailComplete extends ResponseEvent
 {
     /**
      * Serial version identifier.
@@ -41,15 +41,15 @@ public class EndpointListComplete extends ResponseEvent
      * 
      * @param source
      */
-    public EndpointListComplete(Object source)
+    public EndpointDetailComplete(Object source)
     {
         super(source);
     }
 
     /**
-     * Returns the number of Endpoints that have been reported.
+     * Returns the number of EndpointDetail events that have been reported.
      * 
-     * @return the number of Endpoints that have been reported.
+     * @return the number of EndpointDetail events that have been reported.
      */
     public Integer getListItems()
     {
@@ -57,9 +57,9 @@ public class EndpointListComplete extends ResponseEvent
     }
 
     /**
-     * Sets the number of Endpoints that have been reported.
+     * Sets the number of EndpointDetail events that have been reported.
      * 
-     * @param listItems the number of PeerEvents that have been reported.
+     * @param listItems the number of EndpointDetail events that have been reported.
      */
     public void setListItems(Integer listItems)
     {
@@ -69,11 +69,11 @@ public class EndpointListComplete extends ResponseEvent
     /**
      * Returns always "Complete".
      * <p>
-     * Available since Asterisk 1.6.
+     * Available since Asterisk 12.
      *
-     * @return always returns "Complete" confirming that all PeerEntry events have
+     * @return always returns "Complete" confirming that all EndpointDetail events have
      *         been sent.
-     * @since 1.0.0
+     * @since 12
      */
     public String getEventList()
     {

--- a/src/main/java/org/asteriskjava/manager/event/TransportDetail.java
+++ b/src/main/java/org/asteriskjava/manager/event/TransportDetail.java
@@ -1,0 +1,257 @@
+package org.asteriskjava.manager.event;
+
+
+/**
+ * A TransportDetail event is triggered in response to a
+ * {@link org.asteriskjava.manager.action.PJSipShowEndpoint}
+ * <p>
+ *
+ * @author Steve Sether
+ * @version $Id$
+ * @since 12
+ */
+
+public class TransportDetail extends ResponseEvent {
+
+    /**
+     * Serial version identifier.
+     */
+	private static final long serialVersionUID = 8558130768089350575L;
+	private String Event;
+	private String objectType;
+	private String pbjectName;
+	private String protocol;
+	private String bind;
+	private int asycOperations;
+	private String caListFile;
+	private String caListPath;
+	private String certFile;     
+	private String privKeyFile;
+	private String password;
+	private String externalSignalingAddress;
+	private int	externalSignalingPort;
+	private String externalMediaAddress;
+	private String domain;
+	private String verifyServer;
+	private String verifyClient;
+	private Boolean requireClientCert;
+	private String method;
+	private String cipher;
+	private String localNet;
+	private String tos;
+	private int cos;
+	private int websocketWriteTimeout;
+	private String endpointName;
+
+	
+	/**
+     * Serial version identifier.
+     */
+	public TransportDetail(Object source) {
+		super(source);
+	}
+
+	public String getEvent() {
+		return Event;
+	}
+
+	public void setEvent(String event) {
+		Event = event;
+	}
+
+	public String getObjectType() {
+		return objectType;
+	}
+
+	public void setObjectType(String objectType) {
+		this.objectType = objectType;
+	}
+
+	public String getPbjectName() {
+		return pbjectName;
+	}
+
+	public void setPbjectName(String pbjectName) {
+		this.pbjectName = pbjectName;
+	}
+
+	public String getProtocol() {
+		return protocol;
+	}
+
+	public void setProtocol(String protocol) {
+		this.protocol = protocol;
+	}
+
+	public String getBind() {
+		return bind;
+	}
+
+	public void setBind(String bind) {
+		this.bind = bind;
+	}
+
+	public int getAsycOperations() {
+		return asycOperations;
+	}
+
+	public void setAsycOperations(int asycOperations) {
+		this.asycOperations = asycOperations;
+	}
+
+	public String getCaListFile() {
+		return caListFile;
+	}
+
+	public void setCaListFile(String caListFile) {
+		this.caListFile = caListFile;
+	}
+
+	public String getCaListPath() {
+		return caListPath;
+	}
+
+	public void setCaListPath(String caListPath) {
+		this.caListPath = caListPath;
+	}
+
+	public String getCertFile() {
+		return certFile;
+	}
+
+	public void setCertFile(String certFile) {
+		this.certFile = certFile;
+	}
+
+	public String getPrivKeyFile() {
+		return privKeyFile;
+	}
+
+	public void setPrivKeyFile(String privKeyFile) {
+		this.privKeyFile = privKeyFile;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	public String getExternalSignalingAddress() {
+		return externalSignalingAddress;
+	}
+
+	public void setExternalSignalingAddress(String externalSignalingAddress) {
+		this.externalSignalingAddress = externalSignalingAddress;
+	}
+
+	public int getExternalSignalingPort() {
+		return externalSignalingPort;
+	}
+
+	public void setExternalSignalingPort(int externalSignalingPort) {
+		this.externalSignalingPort = externalSignalingPort;
+	}
+
+	public String getExternalMediaAddress() {
+		return externalMediaAddress;
+	}
+
+	public void setExternalMediaAddress(String externalMediaAddress) {
+		this.externalMediaAddress = externalMediaAddress;
+	}
+
+	public String getDomain() {
+		return domain;
+	}
+
+	public void setDomain(String domain) {
+		this.domain = domain;
+	}
+
+	public String getVerifyServer() {
+		return verifyServer;
+	}
+
+	public void setVerifyServer(String verifyServer) {
+		this.verifyServer = verifyServer;
+	}
+
+	public String getVerifyClient() {
+		return verifyClient;
+	}
+
+	public void setVerifyClient(String verifyClient) {
+		this.verifyClient = verifyClient;
+	}
+
+	public Boolean getRequireClientCert() {
+		return requireClientCert;
+	}
+
+	public void setRequireClientCert(Boolean requireClientCert) {
+		this.requireClientCert = requireClientCert;
+	}
+
+	public String getMethod() {
+		return method;
+	}
+
+	public void setMethod(String method) {
+		this.method = method;
+	}
+
+	public String getCipher() {
+		return cipher;
+	}
+
+	public void setCipher(String cipher) {
+		this.cipher = cipher;
+	}
+
+	public String getLocalNet() {
+		return localNet;
+	}
+
+	public void setLocalNet(String localNet) {
+		this.localNet = localNet;
+	}
+
+	public String getTos() {
+		return tos;
+	}
+
+	public void setTos(String tos) {
+		this.tos = tos;
+	}
+
+	public int getCos() {
+		return cos;
+	}
+
+	public void setCos(int cos) {
+		this.cos = cos;
+	}
+
+	public int getWebsocketWriteTimeout() {
+		return websocketWriteTimeout;
+	}
+
+	public void setWebsocketWriteTimeout(int websocketWriteTimeout) {
+		this.websocketWriteTimeout = websocketWriteTimeout;
+	}
+
+	public String getEndpointName() {
+		return endpointName;
+	}
+
+	public void setEndpointName(String endpointName) {
+		this.endpointName = endpointName;
+	}
+
+	public static long getSerialversionuid() {
+		return serialVersionUID;
+	}
+}

--- a/src/main/java/org/asteriskjava/manager/internal/AbstractBuilder.java
+++ b/src/main/java/org/asteriskjava/manager/internal/AbstractBuilder.java
@@ -120,7 +120,11 @@ abstract class AbstractBuilder
                     try
                     {
                         Constructor< ? > constructor = dataType.getConstructor(String.class);
-                        value = constructor.newInstance(entry.getValue());
+                        // Asterisk sometimes uses yes/no instead of True/False for boolean.  java.lang.Boolean(String) doesn't handle this.
+                        if (dataType.isAssignableFrom(Boolean.class)) {
+                        	value = constructor.newInstance(AstUtil.convertAsteriskBooleanStringToStandardBooleanString((String)entry.getValue()));
+                        }
+                        else value = constructor.newInstance(entry.getValue());
                     }
                     catch (Exception e)
                     {

--- a/src/main/java/org/asteriskjava/manager/internal/ResponseEventsImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/ResponseEventsImpl.java
@@ -91,7 +91,7 @@ public class ResponseEventsImpl implements ResponseEvents
     }
 
     /**
-     * Indicats if all events have been received.
+     * Indicates if all events have been received.
      * 
      * @param complete <code>true</code> if all events have been received,
      *            <code>false</code> otherwise.

--- a/src/main/java/org/asteriskjava/util/AstUtil.java
+++ b/src/main/java/org/asteriskjava/util/AstUtil.java
@@ -199,4 +199,33 @@ public class AstUtil
 
         return NULL_LITERALS.contains(((String) s).toLowerCase(Locale.US));
     }
+    /**
+     * Converts a non-standard Asterisk boolean String value into something the Boolean class
+     * String constructor recognizes.
+     * 
+     * Asterisk can return various strings that represent truth values.  
+     * This method converts them into standard True/False, or null if null.
+     * 
+     * @param value
+     * @return <code>true</code> if the String is "true" or "yes" (case insensitive).
+     * 		  <code>false</code> if the String is "false" or "no" (case insensitive).
+     * 		  <code>null</code> if the String is null.
+     * @throws <code>IllegalArgumentException</code> if any other value not listed above.
+     */
+    
+	public static String convertAsteriskBooleanStringToStandardBooleanString(String value) {
+		if (value == null)  return null;
+		switch (value.toLowerCase())
+		{
+			case "true":
+			case "yes":
+				return "True";
+			case "false":
+			case "no":
+				return "False";
+			default:
+				throw new IllegalArgumentException("value of:" + value + " was not recognized as a boolean");
+		}
+		
+	}
 }


### PR DESCRIPTION
I've added support for the AMI function PJSipShowEndpoint, and all its documented (and oddly one undocumented) return events.  

I did need to make one change to the codebase.  It seems Asterisk sometimes returns a yes/no value for a boolean, instead of always using True/False.  java.lang.Boolean doesn't understand yes/no, and always returns false.  To account for this, I modified AbstractBuilder.java, and added a special case for when the returned attribute was a Boolean.  

In that case, I pass the attrbute value String through a helper function AstUtil.convertAsteriskBooleanStringToStandardBooleanString(String), which converts the non-standard Asterisk yes/no into True/False, which the standard Boolean constructor understands.