### PR TITLE
Could org.asteriskjava:asterisk-java:3.28.0 drop off redundant dependencies?

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,24 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>32.1.3-jre</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>listenablefuture</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -109,6 +127,12 @@
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>0.10.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Hi! I found the pom file of project **_org.asteriskjava:asterisk-java:3.28.0_** introduced **_18_** dependencies. However, among them, **_4_** libraries (**_22%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
com.google.code.findbugs:jsr305:jar:3.0.2:compile
com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
com.google.errorprone:error_prone_annotations:jar:2.3.4:compile
com.google.j2objc:j2objc-annotations:jar:1.3:compile
## Outdated dependencies
com.google.j2objc:j2objc-annotations:1.3 (**_2383_** days without maintenance)

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_com.google.code.findbugs:jsr305:jar:3.0.2:compile_** induced dependency conflict in the dependency graph. As such, I suggest a refactoring operation for **_org.asteriskjava:asterisk-java:3.28.0_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_org.asteriskjava:asterisk-java:3.28.0_**’s maven tests.

Best regards
![image](https://user-images.githubusercontent.com/78527112/160522341-d0fb78c5-53f5-4d8d-9185-f2f7bbd65b86.png)
