### PR TITLE
Fix maven javadoc plugin configuration property after update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,8 +234,7 @@
                             </execution>
                         </executions>
                         <configuration>
-
-                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <doclint>none</doclint>
                             <additionalOptions>-Xdoclint:none</additionalOptions>
                             <additionalJOptions>
                                 <additionalparam>-Xdoclint:none</additionalparam>


### PR DESCRIPTION
After bump dependencies by dependabot, configuration in new version was changed.