### PR TITLE
AsteriskMapping.java: Allow `@AsteriskMapping` use on types.

### DIFF
--- a/src/main/java/org/asteriskjava/manager/AsteriskMapping.java
+++ b/src/main/java/org/asteriskjava/manager/AsteriskMapping.java
@@ -3,19 +3,23 @@ package org.asteriskjava.manager;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Customized the mapping to Asterisk. In general the mapping is done implicitly based
- * on reflection but there are certain action that are using headers with specical
- * characters that can not be represented in Java. In those cases you can annotate
- * the property (getter, setter or field) and provide the header name that Asterisk expects.
+ * Customize the mapping to Asterisk. In general the mapping is done implicitly
+ * based on reflection but there are certain actions that use headers with
+ * characters that are not valid in Java identifiers. In those cases you can
+ * annotate the property (getter, setter or field) and provide the header name
+ * that Asterisk sends or expects.
+ * <p>
+ * Similarly, if an AMI event name contains characters that are not valid Java
+ * identifiers, the class itself can be decorated with this annotation to
+ * affect the mapping.
  *
  * @since 1.0.0
  */
-@Target({METHOD, FIELD})
+@Target({TYPE, METHOD, FIELD})
 @Retention(RUNTIME)
 public @interface AsteriskMapping {
     String value();

--- a/src/main/java/org/asteriskjava/manager/internal/EventBuilderImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/EventBuilderImpl.java
@@ -15,6 +15,7 @@
  */
 package org.asteriskjava.manager.internal;
 
+import org.asteriskjava.manager.AsteriskMapping;
 import org.asteriskjava.manager.event.*;
 import org.asteriskjava.manager.util.EventAttributesHelper;
 import org.asteriskjava.util.Log;
@@ -60,14 +61,18 @@ class EventBuilderImpl implements EventBuilder {
     }
 
     public final void registerEventClass(Class<? extends ManagerEvent> clazz) throws IllegalArgumentException {
-        String className;
         String eventType;
 
-        className = clazz.getName();
-        eventType = className.substring(className.lastIndexOf('.') + 1).toLowerCase(Locale.ENGLISH);
+        AsteriskMapping annotation = clazz.getAnnotation(AsteriskMapping.class);
+        if (annotation == null) {
+            String className = clazz.getName();
+            eventType = className.substring(className.lastIndexOf('.') + 1).toLowerCase(Locale.ENGLISH);
 
-        if (eventType.endsWith("event")) {
-            eventType = eventType.substring(0, eventType.length() - "event".length());
+            if (eventType.endsWith("event")) {
+                eventType = eventType.substring(0, eventType.length() - "event".length());
+            }
+        } else {
+            eventType = annotation.value().toLowerCase(Locale.ENGLISH);
         }
 
         if (UserEvent.class.isAssignableFrom(clazz) && !eventType.startsWith("userevent")) {


### PR DESCRIPTION
Allows manager events and `UserEvent`s that contain characters that are otherwise illegal in Java identifiers to be mapped to handler classes.