### PR TITLE
AsteriskVersion.java: Correct certified Asterisk version matching.

### DIFF
--- a/src/main/java/org/asteriskjava/AsteriskVersion.java
+++ b/src/main/java/org/asteriskjava/AsteriskVersion.java
@@ -40,8 +40,8 @@ public class AsteriskVersion implements Comparable<AsteriskVersion>, Serializabl
     private final String versionString;
     private final Pattern patterns[];
 
-    private static final String VERSION_PATTERN_CERTIFIED_20 = "^\\s*Asterisk certified/(GIT-)?20[-. ].*";
-    private static final String VERSION_PATTERN_CERTIFIED_18 = "^\\s*Asterisk certified/(GIT-)?18[-. ].*";
+    private static final String VERSION_PATTERN_CERTIFIED_20 = "^\\s*Asterisk certified-(GIT-)?20[-. ].*";
+    private static final String VERSION_PATTERN_CERTIFIED_18 = "^\\s*Asterisk certified[-/](GIT-)?18[-. ].*";
     private static final String VERSION_PATTERN_CERTIFIED_16 = "^\\s*Asterisk certified/(GIT-)?16[-. ].*";
     private static final String VERSION_PATTERN_CERTIFIED_13 = "^\\s*Asterisk certified/((SVN-branch|GIT)-)?13[-. ].*";
 


### PR DESCRIPTION
Between the 18.9-cert4 and 18.9-cert5 versions of certified Asterisk, the version string format was switched from using a `/` separator to using a `-`, so we need to take that in to account.

Certified Asterisk 20+ has always used the hyphen separator.

Fixes #597