### PR TITLE
AsteriskServer.java: Remove traces of previous merge conflict.

### DIFF
--- a/src/main/java/org/asteriskjava/live/AsteriskServer.java
+++ b/src/main/java/org/asteriskjava/live/AsteriskServer.java
@@ -333,12 +333,10 @@ public interface AsteriskServer {
     String getVersion() throws ManagerCommunicationException;
 
     /**
-     * <<<<<<< HEAD Returns the CVS revision of a given source file of this
+     * Returns the CVS revision of a given source file of this
      * Asterisk server. <br>
-     * ======= Returns the CVS revision of a given source file of this Asterisk
-     * server. <br>
-     * >>>>>>> refs/heads/release-1.1 For example getVersion("app_meetme.c") may
-     * return {1, 102} for CVS revision "1.102". <br>
+     * For example getVersion("app_meetme.c") may return {1, 102} for
+     * CVS revision "1.102". <br>
      * Note that this feature is not available with Asterisk 1.0.x. <br>
      * You can use this feature if you need to write applications that behave
      * different depending on specific modules being available in a specific

--- a/src/main/java/org/asteriskjava/util/internal/SocketConnectionFacadeImpl.java
+++ b/src/main/java/org/asteriskjava/util/internal/SocketConnectionFacadeImpl.java
@@ -46,10 +46,8 @@ public class SocketConnectionFacadeImpl implements SocketConnectionFacade {
     private Trace trace;
 
     /**
-     * <<<<<<< HEAD Creates a new instance for use with the Manager API that
-     * uses UTF-8 as encoding and CRNL ("\r\n") as line delimiter. =======
-     * Creates a new instance for use with the Manager API that uses CRNL
-     * ("\r\n") as line delimiter. >>>>>>> refs/heads/release-1.1
+     * Creates a new instance for use with the Manager API that uses UTF-8
+     * as the encoding and CRLF ("\r\n") as line delimiter.
      *
      * @param host        the foreign host to connect to.
      * @param port        the foreign port to connect to.
@@ -64,7 +62,7 @@ public class SocketConnectionFacadeImpl implements SocketConnectionFacade {
 
     /**
      * Creates a new instance for use with the Manager API that uses the given
-     * encoding and CRNL ("\r\n") as line delimiter.
+     * encoding and CRLF ("\r\n") as line delimiter.
      *
      * @param host        the foreign host to connect to.
      * @param port        the foreign port to connect to.


### PR DESCRIPTION
In passing, changed "CRNL" to "CRLF" in javadoc because that is the more common phrasing.