### PR TITLE
main: Update some deprecated Java API.

### DIFF
--- a/src/main/java/org/asteriskjava/Cli.java
+++ b/src/main/java/org/asteriskjava/Cli.java
@@ -52,7 +52,7 @@ public class Cli
                 Integer port = null;
                 try
                 {
-                    port = new Integer(args[1]);
+                    port = Integer.parseInt(args[1], 10);
                 }
                 catch (NumberFormatException e)
                 {

--- a/src/main/java/org/asteriskjava/pbx/DefaultAsteriskSettings.java
+++ b/src/main/java/org/asteriskjava/pbx/DefaultAsteriskSettings.java
@@ -28,7 +28,7 @@ public abstract class DefaultAsteriskSettings implements AsteriskSettings {
         // doesn't overlap any conference rooms you are currently running on your pbx.
         // You should probably allow 200 conference rooms here e.g. (3000-3200)
         // Actions like transfers (and conference calls) use a conference room.
-        return new Integer(3000);
+        return 3000;
     }
 
     @Override

--- a/src/test/java/org/asteriskjava/fastagi/internal/AgiRequestImplTest.java
+++ b/src/test/java/org/asteriskjava/fastagi/internal/AgiRequestImplTest.java
@@ -66,7 +66,7 @@ class AgiRequestImplTest {
         assertEquals("9876", request.getRdnis(), "incorrect rdnis");
         assertEquals("local", request.getContext(), "incorrect context");
         assertEquals("8870", request.getExtension(), "incorrect extension");
-        assertEquals(new Integer(1), request.getPriority(), "incorrect priority");
+        assertEquals(Integer.valueOf(1), request.getPriority(), "incorrect priority");
         assertEquals(Boolean.FALSE, request.getEnhanced(), "incorrect enhanced");
         assertNull(request.getAccountCode(), "incorrect accountCode must not be set");
         assertEquals(AsteriskVersion.ASTERISK_13, request.getAsteriskVersion(), "incorret Asterisk Version Number");

--- a/src/test/java/org/asteriskjava/manager/event/NewStateEventTest.java
+++ b/src/test/java/org/asteriskjava/manager/event/NewStateEventTest.java
@@ -16,13 +16,13 @@ class NewStateEventTest {
     @Test
     void testWithState() {
         newStateEvent.setState("Ring");
-        assertEquals(new Integer(4), newStateEvent.getChannelState());
+        assertEquals(Integer.valueOf(4), newStateEvent.getChannelState());
         assertEquals("Ring", newStateEvent.getChannelStateDesc());
     }
 
     @Test
     void testWithUnknownState() {
         newStateEvent.setState("Unknown (4)");
-        assertEquals(new Integer(4), newStateEvent.getChannelState());
+        assertEquals(Integer.valueOf(4), newStateEvent.getChannelState());
     }
 }

--- a/src/test/java/org/asteriskjava/manager/event/RtcpReceivedEventTest.java
+++ b/src/test/java/org/asteriskjava/manager/event/RtcpReceivedEventTest.java
@@ -17,14 +17,14 @@ class RtcpReceivedEventTest {
     void testFrom() {
         rtcpReceivedEvent.setFrom("192.168.0.1:1234");
         assertEquals(rtcpReceivedEvent.getFromAddress().getHostAddress(), "192.168.0.1");
-        assertEquals(new Integer(1234), rtcpReceivedEvent.getFromPort());
+        assertEquals(Integer.valueOf(1234), rtcpReceivedEvent.getFromPort());
     }
 
     @Test
     void testPt() {
         rtcpReceivedEvent.setPt("200(Sender Report)");
-        assertEquals(new Long(200), rtcpReceivedEvent.getPt());
-        assertEquals(new Long(RtcpReceivedEvent.PT_SENDER_REPORT), rtcpReceivedEvent.getPt());
+        assertEquals(Long.valueOf(200), rtcpReceivedEvent.getPt());
+        assertEquals(Long.valueOf(RtcpReceivedEvent.PT_SENDER_REPORT), rtcpReceivedEvent.getPt());
     }
 
     @Test
@@ -42,6 +42,6 @@ class RtcpReceivedEventTest {
     @Test
     void testRtt() {
         rtcpReceivedEvent.setRtt("12345(sec)");
-        assertEquals(new Double(12345), rtcpReceivedEvent.getRtt());
+        assertEquals(Double.valueOf(12345), rtcpReceivedEvent.getRtt());
     }
 }

--- a/src/test/java/org/asteriskjava/manager/internal/EventBuilderImplTest.java
+++ b/src/test/java/org/asteriskjava/manager/internal/EventBuilderImplTest.java
@@ -357,7 +357,7 @@ class EventBuilderImplTest {
         event = eventBuilder.buildEvent(this, properties);
 
         assertNotNull(event);
-        assertEquals(new Long(569108), ((MeetMeLeaveEvent) event).getDuration(), "Duration property not set correctly");
+        assertEquals(Long.valueOf(569108), ((MeetMeLeaveEvent) event).getDuration(), "Duration property not set correctly");
     }
 
     @Test

--- a/src/test/java/org/asteriskjava/manager/internal/ManagerReaderImplTest.java
+++ b/src/test/java/org/asteriskjava/manager/internal/ManagerReaderImplTest.java
@@ -168,8 +168,8 @@ class ManagerReaderImplTest {
 
         RtcpReceivedEvent rtcpReceivedEvent = (RtcpReceivedEvent) dispatcher.dispatchedEvents.get(0);
         assertEquals("192.168.0.1", rtcpReceivedEvent.getFromAddress().getHostAddress(), "Invalid from address on RtcpReceivedEvent");
-        assertEquals(new Integer(1234), rtcpReceivedEvent.getFromPort(), "Invalid from port on RtcpReceivedEvent");
-        assertEquals(new Long(999), rtcpReceivedEvent.getHighestSequence(), "Invalid highest sequence on RtcpReceivedEvent");
+        assertEquals(Integer.valueOf(1234), rtcpReceivedEvent.getFromPort(), "Invalid from port on RtcpReceivedEvent");
+        assertEquals(Long.valueOf(999), rtcpReceivedEvent.getHighestSequence(), "Invalid highest sequence on RtcpReceivedEvent");
 
         assertEquals(DisconnectEvent.class, dispatcher.dispatchedEvents.get(1).getClass(), "second event must be a DisconnectEvent");
     }


### PR DESCRIPTION
We still have some implementations and calls to `Object.finalize()` but changing that is breaking so it should wait until 4.0.