### PR TITLE
Base64.java: Deprecate our Base64 implementation in favor of Java's.

### DIFF
--- a/src/main/java/org/asteriskjava/manager/event/SkypeChatMessageEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/SkypeChatMessageEvent.java
@@ -16,9 +16,8 @@
  */
 package org.asteriskjava.manager.event;
 
-import org.asteriskjava.util.Base64;
-
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 /**
  * A SkypeChatMessageEvent is triggered when a Skype Chat message is sent or
@@ -107,6 +106,6 @@ public class SkypeChatMessageEvent extends ManagerEvent {
         if (message == null) {
             return null;
         }
-        return new String(Base64.base64ToByteArray(message), StandardCharsets.UTF_8);
+        return new String(Base64.getDecoder().decode(message), StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/org/asteriskjava/util/Base64.java
+++ b/src/main/java/org/asteriskjava/util/Base64.java
@@ -12,8 +12,11 @@ package org.asteriskjava.util;
  * and vice-versa.<p>
  * From java.util.prefs.
  *
+ * @deprecated Use {@link java.util.Base64} instead.
+ *
  * @author Josh Bloch
  */
+@Deprecated
 public class Base64 {
 
     private Base64() {


### PR DESCRIPTION
The only code in the library that uses it is Skype-for-Asterisk which I am pretty sure has been dead a long time anyway.