### PR TITLE
regression: org.slf4j used instead of internal logging abstraction

### DIFF
--- a/src/main/java/org/asteriskjava/manager/internal/ResponseBuilderImpl.java
+++ b/src/main/java/org/asteriskjava/manager/internal/ResponseBuilderImpl.java
@@ -19,11 +19,10 @@ import org.asteriskjava.manager.response.CommandResponse;
 import org.asteriskjava.manager.response.ManagerError;
 import org.asteriskjava.manager.response.ManagerResponse;
 import org.asteriskjava.manager.util.EventAttributesHelper;
-import org.slf4j.Logger;
+import org.asteriskjava.util.Log;
+import org.asteriskjava.util.LogFactory;
 
 import java.util.*;
-
-import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Default implementation of the ResponseBuilder interface.
@@ -33,7 +32,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  * @see org.asteriskjava.manager.response.ManagerResponse
  */
 class ResponseBuilderImpl implements ResponseBuilder {
-    private static final Logger logger = getLogger(ResponseBuilderImpl.class);
+    private static final Log logger = LogFactory.getLog(ResponseBuilderImpl.class);
 
     private static final Set<String> ignoredAttributes = new HashSet<>(Arrays.asList(
         "attributes", "proxyresponse", ManagerReader.COMMAND_RESULT_RESPONSE_KEY));

--- a/src/main/java/org/asteriskjava/manager/util/EventAttributesHelper.java
+++ b/src/main/java/org/asteriskjava/manager/util/EventAttributesHelper.java
@@ -19,8 +19,9 @@ import org.asteriskjava.manager.event.CdrEvent;
 import org.asteriskjava.manager.event.UserEvent;
 import org.asteriskjava.manager.response.ManagerResponse;
 import org.asteriskjava.util.AstUtil;
+import org.asteriskjava.util.Log;
+import org.asteriskjava.util.LogFactory;
 import org.asteriskjava.util.ReflectionUtil;
-import org.slf4j.Logger;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -29,13 +30,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.slf4j.LoggerFactory.getLogger;
-
 /**
  * @author Piotr Olaszewski <piotrooo>
  */
 public class EventAttributesHelper {
-    private static final Logger logger = getLogger(EventAttributesHelper.class);
+    private static final Log logger = LogFactory.getLog(EventAttributesHelper.class);
 
     private EventAttributesHelper() {
     }


### PR DESCRIPTION
In 3.36.0 we created a runtime dependency on org.slf4j that was not there before. We now use our own logging abstraction instead.

We intend to switch wholesale to slf4j in 4.x but we shouldn't be adding new dependencies without bumping the major version number.