### PR TITLE
bnd.bnd: Correct generated Import-Package OSGi header.

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -9,8 +9,7 @@ Bundle-License: http://www.apache.org/licenses/LICENSE-2.0.txt
 -exportcontents: !*.internal.*, *
 
 Import-Package: \
-	javax.net,\
-	javax.net.ssl,\
-	javax.script,\
-	org.apache.log4j;resolution:=optional,\
-	org.slf4j;resolution:=optional
+	!org.asteriskjava.*,\
+	org.apache.logging.log4j.*;resolution:=optional,\
+	org.slf4j.*;resolution:=optional,\
+	*

--- a/src/main/java/META-INF/MANIFEST.MF
+++ b/src/main/java/META-INF/MANIFEST.MF
@@ -1,3 +1,0 @@
-Manifest-Version: 1.0
-Class-Path: 
-


### PR DESCRIPTION
In 3.16.0, we switched from log4j 1.x to 2.x but neglected to update the `Import-Package` header with that change.

We now use bnd's default `Import-Package` functionality and override where necessary.