### PR TITLE
MeetMeTalkRequestEvent: Add missing event handler class.

### DIFF
--- a/src/main/java/org/asteriskjava/manager/AbstractManagerEventListener.java
+++ b/src/main/java/org/asteriskjava/manager/AbstractManagerEventListener.java
@@ -171,6 +171,9 @@ public abstract class AbstractManagerEventListener implements ManagerEventListen
     public void handleEvent(MeetMeTalkingRequestEvent event) {
     }
 
+    public void handleEvent(MeetMeTalkRequestEvent event) {
+    }
+
     public void handleEvent(MonitorStartEvent event) {
     }
 

--- a/src/main/java/org/asteriskjava/manager/event/MeetMeTalkRequestEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/MeetMeTalkRequestEvent.java
@@ -1,0 +1,50 @@
+package org.asteriskjava.manager.event;
+
+/**
+ * A MeetMeTalkRequestEvent is triggered when a muted user requests talking in
+ * a MeetMe conference.
+ */
+public class MeetMeTalkRequestEvent extends AbstractMeetMeEvent {
+    private static final long serialVersionUID = 0L;
+
+    private Boolean status;
+    private Integer duration;
+
+    /**
+     * Constructs a MeetMeTalkRequestEvent.
+     *
+     * @param source The object on which the Event initially occurred.
+     * @throws IllegalArgumentException if source is null.
+     */
+    protected MeetMeTalkRequestEvent(Object source) {
+        super(source);
+    }
+
+    /**
+     * The length of time (in seconds) that the MeetMe user has been in the
+     * conference at the time of this event.
+     *
+     * @return the number of seconds this user has been in the conference.
+     */
+    public Integer getDuration() {
+        return duration;
+    }
+
+    public void setDuration(Integer duration) {
+        this.duration = duration;
+    }
+
+    /**
+     * Returns whether the user has started or stopped requesting talking.
+     *
+     * @return {@code true} if the user has started requesting talking,
+     * {@code false} if the user has stopped requesting talking.
+     */
+    public Boolean getStatus() {
+        return status;
+    }
+
+    public void setStatus(Boolean status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/org/asteriskjava/manager/event/MeetMeTalkingRequestEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/MeetMeTalkingRequestEvent.java
@@ -23,6 +23,8 @@ package org.asteriskjava.manager.event;
  * It is implemented in <code>apps/app_meetme.c</code><p>
  * Available since Asterisk 1.6
  *
+ * @deprecated You want {@link MeetMeTalkRequestEvent} instead.
+ *
  * @author srt
  * @version $Id$
  * @since 1.0.0


### PR DESCRIPTION
It has been `MeetmeTalkRequest` (not `TalkING`) since it was introduced:

https://github.com/asterisk/asterisk/commit/adc9003fc5119a4265dc85f64f32c66c358f9a87