### PR TITLE
MeetMeTalkRequestEvent.java: Make constructor `public`.

### DIFF
--- a/src/main/java/org/asteriskjava/manager/event/MeetMeTalkRequestEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/MeetMeTalkRequestEvent.java
@@ -16,7 +16,7 @@ public class MeetMeTalkRequestEvent extends AbstractMeetMeEvent {
      * @param source The object on which the Event initially occurred.
      * @throws IllegalArgumentException if source is null.
      */
-    protected MeetMeTalkRequestEvent(Object source) {
+    public MeetMeTalkRequestEvent(Object source) {
         super(source);
     }
 


### PR DESCRIPTION
This is why you let the tests finish before blindly merging a PR.