### PR TITLE
MeetMeJoinEvent.java: Add missing `Duration` field.

### DIFF
--- a/src/main/java/org/asteriskjava/manager/event/MeetMeJoinEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/MeetMeJoinEvent.java
@@ -33,10 +33,25 @@ public class MeetMeJoinEvent extends AbstractMeetMeEvent {
      */
     private static final long serialVersionUID = 0L;
 
+    private Integer duration;
+
     /**
      * @param source
      */
     public MeetMeJoinEvent(Object source) {
         super(source);
+    }
+
+    /**
+     * Returns how long the user has been in the conference.
+     *
+     * @return the duration, in seconds, the user has been in the conference
+     */
+    public Integer getDuration() {
+        return duration;
+    }
+
+    public void setDuration(Integer duration) {
+        this.duration = duration;
     }
 }


### PR DESCRIPTION
The way that the `MeetMe` AMI event code is written, if a user is present a duration is present assuming it is non-zero.

Fixes: #719