### PR TITLE
HangupAction.java: Support Hangup taking a regular expression for channel name.

### DIFF
--- a/src/main/java/org/asteriskjava/manager/action/HangupAction.java
+++ b/src/main/java/org/asteriskjava/manager/action/HangupAction.java
@@ -16,18 +16,31 @@
  */
 package org.asteriskjava.manager.action;
 
+import org.asteriskjava.manager.event.ChannelsHungupListComplete;
+import org.asteriskjava.manager.event.ResponseEvent;
+
 /**
- * The HangupAction causes Asterisk to hang up a given channel.<p>
+ * The HangupAction causes Asterisk to hang up a given channel.
+ * <p>
  * Hangup with a cause code is only supported by Asterisk versions later than 1.6.2.
+ * <p>
+ * If the provided channel is surrounded by {@code /forward slashes/}, Asterisk
+ * will interpret the value as a
+ * <a href="https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap09.html#tag_09_04">POSIX Extended Regular Expression (ERE)</a>,
+ * allowing multiple channels to be hung up at once.
+ * <p>
+ * If you are passing a regular expression to this action, ensure that you also
+ * use one of the {@link org.asteriskjava.manager.ManagerConnection#sendEventGeneratingAction(EventGeneratingAction)}
+ * overloads to capture the response correctly.
  *
  * @author srt
  * @version $Id$
  */
-public class HangupAction extends AbstractManagerAction {
+public class HangupAction extends AbstractManagerAction implements EventGeneratingAction {
     /**
      * Serializable version identifier
      */
-    static final long serialVersionUID = 0L;
+    private static final long serialVersionUID = -7534073930283445113L;
 
     private String channel;
     private Integer cause;
@@ -42,22 +55,22 @@ public class HangupAction extends AbstractManagerAction {
     /**
      * Creates a new HangupAction that hangs up the given channel.
      *
-     * @param channel the name of the channel to hangup.
+     * @param channelOrRegex the name of the channel to hangup.
      * @since 0.2
      */
-    public HangupAction(String channel) {
-        this.channel = channel;
+    public HangupAction(String channelOrRegex) {
+        this.channel = channelOrRegex;
     }
 
     /**
      * Creates a new HangupAction that hangs up the given channel with the given cause code.
      *
-     * @param channel the name of the channel to hangup.
-     * @param cause   the cause code. The cause code must be &gt;= 0 and &lt;= 127.
+     * @param channelOrRegex the name of the channel to hangup.
+     * @param cause          the cause code. The cause code must be &gt;= 0 and &lt;= 127.
      * @since 1.0.0
      */
-    public HangupAction(String channel, int cause) {
-        this.channel = channel;
+    public HangupAction(String channelOrRegex, int cause) {
+        this.channel = channelOrRegex;
         this.cause = cause;
     }
 
@@ -107,5 +120,10 @@ public class HangupAction extends AbstractManagerAction {
      */
     public void setCause(Integer cause) {
         this.cause = cause;
+    }
+
+    @Override
+    public Class<? extends ResponseEvent> getActionCompleteEventClass() {
+        return ChannelsHungupListComplete.class;
     }
 }

--- a/src/main/java/org/asteriskjava/manager/event/ChannelHungupEvent.java
+++ b/src/main/java/org/asteriskjava/manager/event/ChannelHungupEvent.java
@@ -1,0 +1,38 @@
+package org.asteriskjava.manager.event;
+
+public class ChannelHungupEvent extends ResponseEvent {
+    /**
+     * Serial version identifier.
+     */
+    private static final long serialVersionUID = -3439496042163782400L;
+
+    private String channel;
+
+    /**
+     * Constructs a ChannelHungupEvent
+     *
+     * @param source The object on which the Event initially occurred.
+     * @throws IllegalArgumentException if source is null.
+     */
+    public ChannelHungupEvent(Object source) {
+        super(source);
+    }
+
+    /**
+     * Get the name of the channel that was hung up.
+     *
+     * @return the name of the channel
+     */
+    public String getChannel() {
+        return channel;
+    }
+
+    /**
+     * Set the name of the channel that was hung up.
+     *
+     * @param channel the name of the channel
+     */
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+}

--- a/src/main/java/org/asteriskjava/manager/event/ChannelsHungupListComplete.java
+++ b/src/main/java/org/asteriskjava/manager/event/ChannelsHungupListComplete.java
@@ -1,0 +1,41 @@
+package org.asteriskjava.manager.event;
+
+public class ChannelsHungupListComplete extends ResponseEvent {
+    /**
+     * Serial version identifier.
+     */
+    private static final long serialVersionUID = 2531650218749540207L;
+    private Integer listItems;
+
+    /**
+     * Constructs a ChannelsHungupListComplete
+     *
+     * @param source The object on which the Event initially occurred.
+     * @throws IllegalArgumentException if source is null.
+     */
+    public ChannelsHungupListComplete(Object source) {
+        super(source);
+    }
+
+    /**
+     * Returns the number of ChannelHungup that have been reported.
+     *
+     * @return the number of ChannelHungup that have been reported.
+     */
+    public Integer getListItems() {
+        return listItems;
+    }
+
+    /**
+     * Sets the number of ChannelHungup that have been reported.
+     *
+     * @param listItems the number of ChannelHungup that have been reported.
+     */
+    public void setListItems(Integer listItems) {
+        this.listItems = listItems;
+    }
+
+    public void setEventList(String eventList) {
+        // This exists just to silence a warning, the value is always 'Complete'
+    }
+}


### PR DESCRIPTION
If you supply a single literal channel name, you should use `ManagerConnection.sendAction(...)`.

If you send a regular expression instead (a `String` starting and ending with a slash), you need to use `ManagerConnection.sendEventGeneratingAction(...)` to handle the response correctly.

See https://docs.asterisk.org/Latest_API/API_Documentation/AMI_Actions/Hangup/ for usage information.

Fixes: https://github.com/asterisk-java/asterisk-java/issues/340