### PR TITLE
Add asterisk 22 certified a supported version

### DIFF
--- a/src/main/java/org/asteriskjava/AsteriskVersion.java
+++ b/src/main/java/org/asteriskjava/AsteriskVersion.java
@@ -44,6 +44,7 @@ public class AsteriskVersion implements Comparable<AsteriskVersion>, Serializabl
     private final String versionString;
     private final Pattern patterns[];
 
+    private static final String VERSION_PATTERN_CERTIFIED_22 = "^\\s*Asterisk certified-(GIT-)?22[-. ].*";
     private static final String VERSION_PATTERN_CERTIFIED_20 = "^\\s*Asterisk certified-(GIT-)?20[-. ].*";
     private static final String VERSION_PATTERN_CERTIFIED_18 = "^\\s*Asterisk certified[-/](GIT-)?18[-. ].*";
     private static final String VERSION_PATTERN_CERTIFIED_16 = "^\\s*Asterisk certified/(GIT-)?16[-. ].*";
@@ -171,7 +172,7 @@ public class AsteriskVersion implements Comparable<AsteriskVersion>, Serializabl
      *
      * @since 3.40.0
      */
-    public static final AsteriskVersion ASTERISK_22 = new AsteriskVersion(2200, "Asterisk 22", VERSION_PATTERN_22);
+    public static final AsteriskVersion ASTERISK_22 = new AsteriskVersion(2200, "Asterisk 22", VERSION_PATTERN_22, VERSION_PATTERN_CERTIFIED_22);
 
     /**
      * Represents the Asterisk 23 series.

--- a/src/test/java/org/asteriskjava/AsteriskVersionTest.java
+++ b/src/test/java/org/asteriskjava/AsteriskVersionTest.java
@@ -31,8 +31,14 @@ class AsteriskVersionTest {
     void test18() {
         assertTrue(AsteriskVersion.getDetermineVersionFromString("Asterisk 18.1.0").equals(AsteriskVersion.ASTERISK_18));
     }
+
     @Test
     void testCertified18() {
         assertTrue(AsteriskVersion.getDetermineVersionFromString("Asterisk certified/18.9-cert2").equals(AsteriskVersion.ASTERISK_18));
+    }
+
+    @Test
+    void testCertified22() {
+        assertTrue(AsteriskVersion.getDetermineVersionFromString("Asterisk certified-22.8-cert2").equals(AsteriskVersion.ASTERISK_22));
     }
 }


### PR DESCRIPTION
Make current certified-asterisk 22 a known version as this seems out since 24-Feb-2026.
Avoids error:
 [o.a.m.internal.ManagerConnectionImpl    ] : Unable to determine asterisk version, assuming Asterisk 16... you should expect problems to follow.